### PR TITLE
Add SHA2-256

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -34,3 +34,7 @@ find_package(binaryen CONFIG REQUIRED)
 # https://github.com/hyperledger/iroha-ed25519
 hunter_add_package(iroha-ed25519)
 find_package(ed25519 CONFIG REQUIRED)
+
+# https://www.openssl.org/
+hunter_add_package(OpenSSL)
+find_package(OpenSSL REQUIRED)

--- a/core/crypto/sha/CMakeLists.txt
+++ b/core/crypto/sha/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# Copyright Soramitsu Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+add_library(sha
+    sha256.hpp
+    sha256.cpp
+    )
+target_link_libraries(sha
+    PUBLIC OpenSSL::SSL
+    OpenSSL::Crypto
+    buffer
+    blob
+    )

--- a/core/crypto/sha/sha256.cpp
+++ b/core/crypto/sha/sha256.cpp
@@ -1,0 +1,25 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "crypto/sha/sha256.hpp"
+
+#include <openssl/sha.h>
+
+namespace kagome::crypto {
+  common::Hash256 sha256(std::string_view input) {
+    const auto *bytes_ptr =
+        reinterpret_cast<const uint8_t *>(input.data());  // NOLINT
+    return sha256(gsl::make_span(bytes_ptr, input.length()));
+  }
+
+  common::Hash256 sha256(gsl::span<const uint8_t> input) {
+    common::Hash256 out;
+    SHA256_CTX ctx;
+    SHA256_Init(&ctx);
+    SHA256_Update(&ctx, input.data(), input.size());
+    SHA256_Final(out.data(), &ctx);
+    return out;
+  }
+}  // namespace kagome::crypto

--- a/core/crypto/sha/sha256.hpp
+++ b/core/crypto/sha/sha256.hpp
@@ -1,0 +1,30 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_SHA256_HPP
+#define KAGOME_SHA256_HPP
+
+#include <string_view>
+
+#include <gsl/span>
+#include "common/blob.hpp"
+
+namespace kagome::crypto {
+  /**
+   * Take a SHA-256 hash from string
+   * @param input to be hashed
+   * @return hashed bytes
+   */
+  common::Hash256 sha256(std::string_view input);
+
+  /**
+   * Take a SHA-256 hash from bytes
+   * @param input to be hashed
+   * @return hashed bytes
+   */
+  common::Hash256 sha256(gsl::span<const uint8_t> input);
+}  // namespace kagome::crypto
+
+#endif  // KAGOME_SHA256_HPP

--- a/test/core/crypto/CMakeLists.txt
+++ b/test/core/crypto/CMakeLists.txt
@@ -1,2 +1,8 @@
+#
+# Copyright Soramitsu Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
 add_subdirectory(blake2)
 add_subdirectory(twox)
+add_subdirectory(sha)

--- a/test/core/crypto/sha/CMakeLists.txt
+++ b/test/core/crypto/sha/CMakeLists.txt
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-add_subdirectory(blake2)
-add_subdirectory(twox)
-add_subdirectory(sha)
+addtest(sha256_test
+    sha256_test.cpp
+    )
+target_link_libraries(sha256_test
+    sha
+    )

--- a/test/core/crypto/sha/sha256_test.cpp
+++ b/test/core/crypto/sha/sha256_test.cpp
@@ -1,0 +1,36 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "common/buffer.hpp"
+#include "crypto/sha/sha256.hpp"
+
+using namespace kagome::common;
+using namespace kagome::crypto;
+
+class Sha256Test : public ::testing::Test {
+ public:
+  /// NIST test vectors https://www.di-mgt.com.au/sha_testvectors.html
+  const std::vector<std::pair<std::string, std::string>> test_vectors{
+      {"", "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855"},
+      {"abc",
+       "BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD"},
+      {"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
+       "248D6A61D20638B8E5C026930C3E6039A33CE45964FF2167F6ECEDD419DB06C1"},
+      {"abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmno"
+       "pjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu",
+       "CF5B16A778AF8380036CE59E7B0492370B249B11E8F07A51AFAC45037AFEE9D1"},
+      {std::string(1000000, 'a'),
+       "CDC76E5C9914FB9281A1C7E284D73E67F1809A48A497200E046D39CCC7112CD0"}};
+};
+
+TEST_F(Sha256Test, Valid) {
+  for (const auto &[initial, digest] : test_vectors) {
+    ASSERT_EQ(sha256(initial).toHex(), digest);
+  }
+}


### PR DESCRIPTION

### Description of the Change

Add a SHA2-256 hashing, which is already needed in some of the pull requests.

### Benefits

New hashing technique.

### Possible Drawbacks 

None.

### Usage Examples or Tests *[optional]*

`/test/core/crypto/sha/sha256_test.cpp`
