### PR TITLE
Add filter for clang-tidy; fix edge_case_test

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 Checks:          '-*,clang-analyzer-*,clang-diagnostic-*,readability-*,modernize-*,boost-*,bugprone-*,cppcoreguidelines-*,google-*,hicpp-*,performance-*,readability-*,-google-readability-namespace-comments,-readability-inconsistent-declaration-parameter-name,-readability-braces-around-statements,-hicpp-signed-bitwise,-google-runtime-references,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers'
 WarningsAsErrors: 'modernize-*,cppcoreguidelines-*,boost-*,performance-*,google-build-using-namespace,readability-else-after-return,google-readability-todo'
-HeaderFilterRegex: ''
+HeaderFilterRegex: '.*\.hpp$'
 AnalyzeTemporaryDtors: false
 FormatStyle:     .clang-format
 User:            bogdan

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,8 +119,6 @@ install:
       elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
         pip3 install --user pyyaml
       fi
-    # make py3 as default python
-    sudo ln -s /usr/local/bin/python3 /usr/local/bin/python
     pip3 install --user requests gitpython cmake
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,12 @@ matrix:
           packages:
             - git
             - llvm
-      after_script:
+      script:
+        - export CC=${_CC}
+        - export CXX=${_CXX}
+        - cmake . -Bbuild -DCOVERAGE=${COVERAGE:OFF}
+        - cmake --build build -- -j2
+        - cmake --build build --target test
         - housekeeping/clang-tidy.sh build
 
     - os: linux
@@ -114,6 +119,8 @@ install:
       elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
         pip3 install --user pyyaml
       fi
+    # make py3 as default python
+    sudo ln -s /usr/local/bin/python3 /usr/local/bin/python
     pip3 install --user requests gitpython cmake
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,14 +52,8 @@ matrix:
           packages:
             - git
             - llvm
-      script:
-        # run clang-tidy
-        - export CLANG_TIDY=$(find /usr/local/Cellar/llvm -type f -name clang-tidy | head -n 1)
-        - export CC=$_CC
-        - export CXX=$_CXX
-        - cmake . -Bbuild -DCLANG_TIDY=ON -DCLANG_TIDY_BIN=${CLANG_TIDY}
-        - cmake --build build -- -j2
-        - cmake --build build --target test
+      after_script:
+        - housekeeping/clang-tidy.sh build
 
     - os: linux
       name: "Linux gcc8 Coverage"

--- a/core/libp2p/transport/impl/transport_listener_impl.cpp
+++ b/core/libp2p/transport/impl/transport_listener_impl.cpp
@@ -63,8 +63,7 @@ namespace libp2p::transport {
             boost::asio::post(context_, [this, c]() { handler_(c); });
             signal_new_connection_(c);
           } else {
-            boost::asio::post(
-                context_, [this, e = r.error()]() { this->signal_error_(e); });
+            signal_error_(r.error());
           }
         });
   }

--- a/housekeeping/clang-tidy.sh
+++ b/housekeeping/clang-tidy.sh
@@ -7,8 +7,6 @@ BUILD_DIR=$(echo "$(cd "$(dirname "$1")"; pwd -P)/$(basename "$1")")
 BN=$(dirname $0)
 cd ${BN}
 
-
-
 # list of cpp files changed in this branch (in comparison to master); tests are ignored
 FILES=$(git diff --name-only HEAD..origin/master | grep "cpp" | grep -v "test")
 CLANG_TIDY=$(find /usr/local/Cellar/llvm -type f -name clang-tidy | head -n 1)

--- a/housekeeping/clang-tidy.sh
+++ b/housekeeping/clang-tidy.sh
@@ -8,12 +8,8 @@ BN=$(dirname $0)
 cd ${BN}
 
 
-BRANCH=HEAD
-if [[ -z "$TRAVIS_BRANCH" ]]; then
-    BRANCH=${TRAVIS_BRANCH}
-fi
-BRANCH=$( git rev-parse --abbrev-ref ${BRANCH})
-
+BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+BRANCH=$(git rev-parse --abbrev-ref ${BRANCH})
 
 # list of cpp files changed in this branch (in comparison to master); tests are ignored
 FILES=$(git diff --name-only $BRANCH..origin/master | grep "cpp" | grep -v "test")

--- a/housekeeping/clang-tidy.sh
+++ b/housekeeping/clang-tidy.sh
@@ -7,8 +7,8 @@ BUILD_DIR=$(echo "$(cd "$(dirname "$1")"; pwd -P)/$(basename "$1")")
 BN=$(dirname $0)
 cd ${BN}
 
-# list of cpp files changed in last commit; tests are ignored
-FILES=$(git show --name-only --format=oneline | tail -n+2 | grep "cpp" | grep -v "test")
+# list of cpp files changed in this branch (in comparison to master); tests are ignored
+FILES=$(git show --name-only --format=oneline master | tail -n+2 | grep "cpp" | grep -v "test")
 CLANG_TIDY=$(find /usr/local/Cellar/llvm -type f -name clang-tidy | head -n 1)
 RUN_CLANG_TIDY=$(find /usr/local/Cellar/llvm -type f -name run-clang-tidy.py | head -n 1)
 

--- a/housekeeping/clang-tidy.sh
+++ b/housekeeping/clang-tidy.sh
@@ -8,12 +8,7 @@ BN=$(dirname $0)
 cd ${BN}
 
 
-BRANCH=
-if [[ -z "$TRAVIS_BRANCH" ]]; then
-    BRANCH=${TRAVIS_BRANCH}
-else
-    BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
-fi
+BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
 
 # list of cpp files changed in this branch (in comparison to master); tests are ignored
 FILES=$(git diff --name-only $BRANCH..origin/master | grep "cpp" | grep -v "test")

--- a/housekeeping/clang-tidy.sh
+++ b/housekeeping/clang-tidy.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash -xe
+
+# this script filters build/compile_commands.json and runs clang-tidy on files changed in the last commit
+
+BUILD_DIR=$(echo "$(cd "$(dirname "$1")"; pwd -P)/$(basename "$1")")
+
+BN=$(dirname $0)
+cd ${BN}
+
+# list of cpp files changed in last commit; tests are ignored
+FILES=$(git show --name-only --format=oneline | tail -n+2 | grep "cpp" | grep -v "test")
+CLANG_TIDY=$(find /usr/local/Cellar/llvm -type f -name clang-tidy | head -n 1)
+RUN_CLANG_TIDY=$(find /usr/local/Cellar/llvm -type f -name run-clang-tidy.py | head -n 1)
+
+# filter compile_commands.json
+echo ${FILES} | ./filter_compile_commands.py -p ${BUILD_DIR}
+
+${RUN_CLANG_TIDY} -clang-tidy-binary=${CLANG_TIDY} -p ${BUILD_DIR}

--- a/housekeeping/clang-tidy.sh
+++ b/housekeeping/clang-tidy.sh
@@ -7,8 +7,16 @@ BUILD_DIR=$(echo "$(cd "$(dirname "$1")"; pwd -P)/$(basename "$1")")
 BN=$(dirname $0)
 cd ${BN}
 
+
+BRANCH=
+if [[ -z "$TRAVIS_BRANCH" ]]; then
+    BRANCH=${TRAVIS_BRANCH}
+else
+    BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+fi
+
 # list of cpp files changed in this branch (in comparison to master); tests are ignored
-FILES=$(git show --name-only --format=oneline master | tail -n+2 | grep "cpp" | grep -v "test")
+FILES=$(git diff --name-only $BRANCH..origin/master | grep "cpp" | grep -v "test")
 CLANG_TIDY=$(find /usr/local/Cellar/llvm -type f -name clang-tidy | head -n 1)
 RUN_CLANG_TIDY=$(find /usr/local/Cellar/llvm -type f -name run-clang-tidy.py | head -n 1)
 

--- a/housekeeping/clang-tidy.sh
+++ b/housekeeping/clang-tidy.sh
@@ -8,7 +8,12 @@ BN=$(dirname $0)
 cd ${BN}
 
 
-BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+BRANCH=HEAD
+if [[ -z "$TRAVIS_BRANCH" ]]; then
+    BRANCH=${TRAVIS_BRANCH}
+fi
+BRANCH=$( git rev-parse --abbrev-ref ${BRANCH})
+
 
 # list of cpp files changed in this branch (in comparison to master); tests are ignored
 FILES=$(git diff --name-only $BRANCH..origin/master | grep "cpp" | grep -v "test")

--- a/housekeeping/clang-tidy.sh
+++ b/housekeeping/clang-tidy.sh
@@ -13,6 +13,6 @@ CLANG_TIDY=$(find /usr/local/Cellar/llvm -type f -name clang-tidy | head -n 1)
 RUN_CLANG_TIDY=$(find /usr/local/Cellar/llvm -type f -name run-clang-tidy.py | head -n 1)
 
 # filter compile_commands.json
-echo ${FILES} | ./filter_compile_commands.py -p ${BUILD_DIR}
+echo ${FILES} | python3 ./filter_compile_commands.py -p ${BUILD_DIR}
 
-${RUN_CLANG_TIDY} -clang-tidy-binary=${CLANG_TIDY} -p ${BUILD_DIR}
+python3 ${RUN_CLANG_TIDY} -clang-tidy-binary=${CLANG_TIDY} -p ${BUILD_DIR}

--- a/housekeeping/clang-tidy.sh
+++ b/housekeeping/clang-tidy.sh
@@ -8,11 +8,9 @@ BN=$(dirname $0)
 cd ${BN}
 
 
-BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
-BRANCH=$(git rev-parse --abbrev-ref ${BRANCH})
 
 # list of cpp files changed in this branch (in comparison to master); tests are ignored
-FILES=$(git diff --name-only $BRANCH..origin/master | grep "cpp" | grep -v "test")
+FILES=$(git diff --name-only HEAD..origin/master | grep "cpp" | grep -v "test")
 CLANG_TIDY=$(find /usr/local/Cellar/llvm -type f -name clang-tidy | head -n 1)
 RUN_CLANG_TIDY=$(find /usr/local/Cellar/llvm -type f -name run-clang-tidy.py | head -n 1)
 

--- a/housekeeping/filter_compile_commands.py
+++ b/housekeeping/filter_compile_commands.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+import argparse
+from pathlib import Path
+import re
+
+
+def remove_non_whitelist(wl):
+    def f(x):
+        for w in wl:
+            if w in x['file']:
+                print("selected for analysis: {}".format(w))
+                return True
+        return False
+
+    return f
+
+
+def make_backup(src: Path):
+    dest = Path(src.absolute().__str__() + ".backup")
+    if dest.exists():
+        return  # backup is already there
+
+    dest.touch()
+    dest.write_text(src.read_text())  # for text files
+    assert dest.exists()
+
+
+def do(args) -> None:
+    builddir: Path = args.p
+
+    if not builddir.exists():
+        raise Exception("build dir {} does not exist".format(builddir))
+
+    if not builddir.is_dir():
+        raise Exception("build dir {} is not dir".format(builddir))
+
+    p = Path(builddir, "compile_commands.json")
+    if not p.exists():
+        raise Exception("build dir {} does not contain compile_commands.json".format(builddir))
+
+    make_backup(p)
+
+    with p.open("r") as f:
+        data = f.read()
+        j = json.loads(data)
+
+        wl = read_whitelist()
+        j = filter(remove_non_whitelist(wl), j)
+        j = list(j)
+        s = json.dumps(j, indent=4)
+
+    with open(p, "w") as w:
+        w.write(s)
+        print("success")
+
+
+def read_whitelist():
+    whitelist = []
+    print("provide whitelisted files, one path on a single line")
+
+    for line in sys.stdin:
+        lines = re.split("[\s\n]+", line)
+        for l in lines:
+            if len(l) > 0:
+                whitelist.append(l)
+
+    return whitelist
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        prog="filter "
+    )
+    parser.add_argument("-p", help="path to build dir",
+                        type=Path)
+
+    args = parser.parse_args()
+    do(args)

--- a/test/core/libp2p/transport/tcp_edge_cases.cpp
+++ b/test/core/libp2p/transport/tcp_edge_cases.cpp
@@ -79,7 +79,7 @@ TEST(TCP, SingleListenerCanAcceptManyClients) {
         return;
       }
 
-      EXPECT_FALSE(ec);
+      EXPECT_ERRCODE_SUCCESS(ec);
       EXPECT_EQ(read, size);
 
       do_write();
@@ -100,7 +100,7 @@ TEST(TCP, SingleListenerCanAcceptManyClients) {
         return;
       }
 
-      EXPECT_FALSE(ec);
+      EXPECT_ERRCODE_SUCCESS(ec);
 
       counter++;
 
@@ -153,13 +153,13 @@ TEST(TCP, SingleListenerCanAcceptManyClients) {
         conn->asyncWrite(
             boost::asio::buffer(buf->toVector(), kSize),
             [buf, kSize, conn, rdbuf](auto &&ec, size_t write) {
-              ASSERT_FALSE(ec);
+              EXPECT_ERRCODE_SUCCESS(ec);
               ASSERT_EQ(kSize, write);
 
               conn->asyncRead(
                   boost::asio::buffer(rdbuf->toVector(), kSize), kSize,
                   [buf, kSize, write, rdbuf](auto &&ec, size_t read) {
-                    ASSERT_FALSE(ec);
+                    EXPECT_ERRCODE_SUCCESS(ec);
                     ASSERT_EQ(read, write);
                     ASSERT_EQ(read, kSize);
                     ASSERT_EQ(*rdbuf, *buf);

--- a/test/core/libp2p/transport/tcp_edge_cases.cpp
+++ b/test/core/libp2p/transport/tcp_edge_cases.cpp
@@ -53,9 +53,8 @@ TEST(TCP, TwoListenersCantBindOnSamePort) {
  * @then each client is expected to receive sent message
  */
 TEST(TCP, SingleListenerCanAcceptManyClients) {
-  const int kClients = 2;
+  const int kClients = 4;
   const int kSize = 1500;
-  const int kRetries = 10;
   size_t counter = 0;  // number of answers
 
   /**
@@ -139,33 +138,29 @@ TEST(TCP, SingleListenerCanAcceptManyClients) {
       boost::asio::io_context context;
 
       auto transport = std::make_unique<TransportImpl>(context);
-      for (int i = 0; i < kRetries; i++) {
-        srand(i);
+      EXPECT_OUTCOME_TRUE(conn, transport->dial(ma));
 
-        EXPECT_OUTCOME_TRUE(conn, transport->dial(ma));
+      auto buf = std::make_shared<Buffer>(kSize, 0);
+      std::generate(buf->begin(), buf->end(), []() {
+        return rand();  // NOLINT
+      });
 
-        auto buf = std::make_shared<Buffer>(kSize, 0);
-        std::generate(buf->begin(), buf->end(), []() {
-          return rand();  // NOLINT
-        });
+      auto rdbuf = std::make_shared<Buffer>(kSize, 1);
+      conn->asyncWrite(
+          boost::asio::buffer(buf->toVector(), kSize),
+          [buf, kSize, conn, rdbuf](auto &&ec, size_t write) {
+            EXPECT_ERRCODE_SUCCESS(ec);
+            ASSERT_EQ(kSize, write);
 
-        auto rdbuf = std::make_shared<Buffer>(kSize, 1);
-        conn->asyncWrite(
-            boost::asio::buffer(buf->toVector(), kSize),
-            [buf, kSize, conn, rdbuf](auto &&ec, size_t write) {
-              EXPECT_ERRCODE_SUCCESS(ec);
-              ASSERT_EQ(kSize, write);
-
-              conn->asyncRead(
-                  boost::asio::buffer(rdbuf->toVector(), kSize), kSize,
-                  [buf, kSize, write, rdbuf](auto &&ec, size_t read) {
-                    EXPECT_ERRCODE_SUCCESS(ec);
-                    ASSERT_EQ(read, write);
-                    ASSERT_EQ(read, kSize);
-                    ASSERT_EQ(*rdbuf, *buf);
-                  });
-            });
-      }
+            conn->asyncRead(boost::asio::buffer(rdbuf->toVector(), kSize),
+                            kSize,
+                            [buf, kSize, write, rdbuf](auto &&ec, size_t read) {
+                              EXPECT_ERRCODE_SUCCESS(ec);
+                              ASSERT_EQ(read, write);
+                              ASSERT_EQ(read, kSize);
+                              ASSERT_EQ(*rdbuf, *buf);
+                            });
+          });
       context.run_for(500ms);
     });
   });
@@ -174,7 +169,7 @@ TEST(TCP, SingleListenerCanAcceptManyClients) {
   std::for_each(clients.begin(), clients.end(),
                 [](std::thread &t) { t.join(); });
 
-  ASSERT_EQ(counter, kRetries * kClients)
+  ASSERT_EQ(counter, kClients)
       << "not all clients' requests were handled";
 }
 

--- a/test/core/libp2p/transport/tcp_transport_integration_test.cpp
+++ b/test/core/libp2p/transport/tcp_transport_integration_test.cpp
@@ -29,7 +29,7 @@ struct Reverse : public std::enable_shared_from_this<Reverse> {
 
   void do_read_completed(const std::error_code &ec, size_t read) {
     ASSERT_FALSE(conn->isClosed());
-    EXPECT_FALSE(ec);
+    EXPECT_ERRCODE_SUCCESS(ec);
     EXPECT_EQ(read, size);
 
     do_reverse();
@@ -56,7 +56,7 @@ struct Reverse : public std::enable_shared_from_this<Reverse> {
 
   void do_write_completed(const std::error_code &ec, size_t write) {
     ASSERT_FALSE(conn->isClosed());
-    EXPECT_FALSE(ec);
+    EXPECT_ERRCODE_SUCCESS(ec);
     EXPECT_TRUE(conn->close());
   }
 
@@ -145,14 +145,14 @@ TEST(TCP, Integration) {
       [&asyncReadExecuted, &asyncWriteExecuted, rcvbuf, &msg, conn](
           auto &&ec, size_t write) {
         asyncWriteExecuted = true;
-        EXPECT_FALSE(ec);
+        EXPECT_ERRCODE_SUCCESS(ec);
         EXPECT_EQ(msg.size(), write);
 
         conn->asyncRead(
             boost::asio::buffer(rcvbuf->toVector()), msg.size(),
             [&asyncReadExecuted, msg, rcvbuf, write](auto &&ec, size_t read) {
               asyncReadExecuted = true;
-              EXPECT_FALSE(ec);
+              EXPECT_ERRCODE_SUCCESS(ec);
               EXPECT_EQ(read, write);
               std::string reversed{rcvbuf->begin(), rcvbuf->end()};
               std::cout << "client> received  : " << reversed << "\n";

--- a/test/testutil/outcome.hpp
+++ b/test/testutil/outcome.hpp
@@ -28,4 +28,6 @@
 #define EXPECT_OUTCOME_TRUE(val, expr) \
   __EXPECT_OUTCOME_TRUE_3(UNIQUE_NAME(_r), val, expr)
 
+#define EXPECT_ERRCODE_SUCCESS(ec) EXPECT_FALSE(ec) << ec.message();
+
 #endif  // KAGOME_GTEST_OUTCOME_UTIL_HPP


### PR DESCRIPTION
- force clang-tidy analyze headers
- make clang-tidy analyze only hpp/cpps changed in the **current branch** (by filtering out unnecessary files from compile_commands.json)
- fix libp2p_tcp_edge_cases test
