### PR TITLE
Updated ScaleCodec for working with new primitives

### DIFF
--- a/core/primitives/block_id.hpp
+++ b/core/primitives/block_id.hpp
@@ -6,14 +6,13 @@
 #ifndef KAGOME_CORE_PRIMITIVES_BLOCK_ID_HPP
 #define KAGOME_CORE_PRIMITIVES_BLOCK_ID_HPP
 
-#include <variant>
-
+#include <boost/variant.hpp>
 #include "common/blob.hpp"
 #include "primitives/common.hpp"
 
 namespace kagome::primitives {
   /// Block id is the variant over BlockHash and BlockNumber
-  using BlockId = std::variant<common::Hash256, BlockNumber>;
+  using BlockId = boost::variant<common::Hash256, BlockNumber>;
 }  // namespace kagome::primitives
 
 #endif  // KAGOME_CORE_PRIMITIVES_BLOCK_ID_HPP

--- a/core/primitives/impl/scale_codec_impl.cpp
+++ b/core/primitives/impl/scale_codec_impl.cpp
@@ -6,15 +6,32 @@
 #include "primitives/impl/scale_codec_impl.hpp"
 
 #include "primitives/block.hpp"
+#include "primitives/block_id.hpp"
+#include "primitives/transaction_validity.hpp"
+#include "primitives/version.hpp"
 #include "scale/collection.hpp"
 #include "scale/compact.hpp"
 #include "scale/fixedwidth.hpp"
 #include "scale/scale_error.hpp"
-
-using kagome::common::Buffer;
-using namespace kagome::scale;  // NOLINT
+#include "scale/variant.hpp"
 
 namespace kagome::primitives {
+  using kagome::common::Buffer;
+  using ArrayChar8Encoder = scale::TypeEncoder<std::array<uint8_t, 8>>;
+  using ApiEncoder = scale::TypeEncoder<std::pair<ArrayChar8Encoder, uint32_t>>;
+  using kagome::scale::collection::decodeCollection;
+  using kagome::scale::collection::decodeString;
+  using kagome::scale::collection::encodeBuffer;
+  using kagome::scale::collection::encodeCollection;
+  using kagome::scale::collection::encodeString;
+  using kagome::scale::compact::decodeInteger;
+  using kagome::scale::compact::encodeInteger;
+  using kagome::scale::fixedwidth::decodeUint32;
+  using kagome::scale::fixedwidth::decodeUint64;
+  using kagome::scale::fixedwidth::encodeUint32;
+  using kagome::scale::fixedwidth::encodeUint64;
+  using kagome::scale::variant::decodeVariant;
+  using kagome::scale::variant::encodeVariant;
 
   outcome::result<Buffer> ScaleCodecImpl::encodeBlock(
       const Block &block) const {
@@ -23,7 +40,7 @@ namespace kagome::primitives {
     out.putBuffer(encoded_header);
 
     // put number of extrinsics
-    OUTCOME_TRY(compact::encodeInteger(block.extrinsics().size(), out));
+    OUTCOME_TRY(encodeInteger(block.extrinsics().size(), out));
 
     for (auto &&extrinsic : block.extrinsics()) {
       OUTCOME_TRY(encoded_extrinsic, encodeExtrinsic(extrinsic));
@@ -36,7 +53,7 @@ namespace kagome::primitives {
   outcome::result<Block> ScaleCodecImpl::decodeBlock(Stream &stream) const {
     OUTCOME_TRY(header, decodeBlockHeader(stream));
     // first decode number of items
-    OUTCOME_TRY(integer, compact::decodeInteger(stream));
+    OUTCOME_TRY(integer, decodeInteger(stream));
     auto items_count = integer.convert_to<uint64_t>();
 
     std::vector<Extrinsic> collection;
@@ -55,22 +72,22 @@ namespace kagome::primitives {
       const BlockHeader &block_header) const {
     Buffer out;
 
-    OUTCOME_TRY(collection::encodeBuffer(block_header.parentHash(), out));
-    fixedwidth::encodeUint64(block_header.number(), out);
-    OUTCOME_TRY(collection::encodeBuffer(block_header.stateRoot(), out));
-    OUTCOME_TRY(collection::encodeBuffer(block_header.extrinsicsRoot(), out));
-    OUTCOME_TRY(collection::encodeBuffer(block_header.digest(), out));
+    OUTCOME_TRY(encodeBuffer(block_header.parentHash(), out));
+    encodeUint64(block_header.number(), out);
+    OUTCOME_TRY(encodeBuffer(block_header.stateRoot(), out));
+    OUTCOME_TRY(encodeBuffer(block_header.extrinsicsRoot(), out));
+    OUTCOME_TRY(encodeBuffer(block_header.digest(), out));
 
     return out;
   }
 
   outcome::result<BlockHeader> ScaleCodecImpl::decodeBlockHeader(
       Stream &stream) const {
-    OUTCOME_TRY(parent_hash, collection::decodeCollection<uint8_t>(stream));
-    OUTCOME_TRY(number, fixedwidth::decodeUint64(stream));
-    OUTCOME_TRY(state_root, collection::decodeCollection<uint8_t>(stream));
-    OUTCOME_TRY(extrinsics_root, collection::decodeCollection<uint8_t>(stream));
-    OUTCOME_TRY(digest, collection::decodeCollection<uint8_t>(stream));
+    OUTCOME_TRY(parent_hash, decodeCollection<uint8_t>(stream));
+    OUTCOME_TRY(number, decodeUint64(stream));
+    OUTCOME_TRY(state_root, decodeCollection<uint8_t>(stream));
+    OUTCOME_TRY(extrinsics_root, decodeCollection<uint8_t>(stream));
+    OUTCOME_TRY(digest, decodeCollection<uint8_t>(stream));
 
     return BlockHeader(Buffer{parent_hash}, number, Buffer{state_root},
                        Buffer{extrinsics_root}, Buffer{digest});
@@ -80,19 +97,202 @@ namespace kagome::primitives {
       const Extrinsic &extrinsic) const {
     return extrinsic.data();
   }
-
   outcome::result<Extrinsic> ScaleCodecImpl::decodeExtrinsic(
       Stream &stream) const {
     Buffer out;
 
-    OUTCOME_TRY(extrinsic, collection::decodeCollection<uint8_t>(stream));
+    OUTCOME_TRY(extrinsic, decodeCollection<uint8_t>(stream));
     // extrinsic is an encoded byte array, so when we decode it from stream
     // we obtain just byte array, and in order to keep its form
     // we need do write its size first
-    OUTCOME_TRY(compact::encodeInteger(extrinsic.size(), out));
+    OUTCOME_TRY(encodeInteger(extrinsic.size(), out));
     // and then bytes as well
     out.put(extrinsic);
 
     return Extrinsic(out);
   }
+
+  outcome::result<Buffer> ScaleCodecImpl::encodeVersion(
+      const Version &version) const {
+    Buffer out;
+    OUTCOME_TRY(encodeString(version.specName(), out));
+    OUTCOME_TRY(encodeString(version.implName(), out));
+    encodeUint32(version.authoringVersion(), out);
+    encodeUint32(version.implVersion(), out);
+    OUTCOME_TRY(encodeCollection<Api>(version.apis(), out));
+    return out;
+  }
+
+  outcome::result<Version> ScaleCodecImpl::decodeVersion(
+      ScaleCodec::Stream &stream) const {
+    OUTCOME_TRY(spec_name, decodeString(stream));
+    OUTCOME_TRY(impl_name, decodeString(stream));
+    OUTCOME_TRY(authoring_version, decodeUint32(stream));
+    OUTCOME_TRY(impl_version, decodeUint32(stream));
+    OUTCOME_TRY(apis, decodeCollection<Api>(stream));
+
+    return Version(spec_name, impl_name, authoring_version, impl_version, apis);
+  }
+
+  outcome::result<Buffer> ScaleCodecImpl::encodeBlockId(
+      const BlockId &blockId) const {
+    Buffer out;
+    OUTCOME_TRY(encodeVariant(blockId, out));
+    return out;
+  }
+
+  outcome::result<BlockId> ScaleCodecImpl::decodeBlockId(
+      ScaleCodec::Stream &stream) const {
+    return decodeVariant<common::Hash256, BlockNumber>(stream);
+  }
+
+  outcome::result<Buffer> ScaleCodecImpl::encodeTransactionValidity(
+      const TransactionValidity &transactionValidity) const {
+    Buffer out;
+    OUTCOME_TRY(encodeVariant(transactionValidity, out));
+    return out;
+  }
+
+  outcome::result<TransactionValidity>
+  ScaleCodecImpl::decodeTransactionValidity(ScaleCodec::Stream &stream) const {
+    return decodeVariant<Invalid, Valid, Unknown>(stream);
+  }
 }  // namespace kagome::primitives
+
+/// custom types encoders and decoders
+namespace kagome::scale {
+  /// encodes std::array
+  template <class T, size_t sz>
+  struct TypeEncoder<std::array<T, sz>> {
+    outcome::result<void> encode(const std::array<T, sz> &array,
+                                 common::Buffer &out) {
+      return collection::encodeCollection(gsl::make_span(array), out);
+    }
+  };
+
+  /// encodes common::Hash256
+  template <>
+  struct TypeEncoder<common::Hash256> {
+    outcome::result<void> encode(const common::Hash256 &value,
+                                 common::Buffer &out) {
+      return collection::encodeCollection(gsl::make_span(value), out);
+    }
+  };
+
+  /// encodes primitives::Invalid
+  template <>
+  struct TypeEncoder<primitives::Invalid> {
+    outcome::result<void> encode(const primitives::Invalid &value,
+                                 common::Buffer &out) {
+      fixedwidth::encodeUInt8(value.error_, out);
+      return outcome::success();
+    }
+  };
+
+  /// encodes primitives::Unknown
+  template <>
+  struct TypeEncoder<primitives::Unknown> {
+    outcome::result<void> encode(const primitives::Unknown &value,
+                                 common::Buffer &out) {
+      fixedwidth::encodeUInt8(value.error_, out);
+      return outcome::success();
+    }
+  };
+
+  /// encodes primitives::Valid
+  template <>
+  struct TypeEncoder<primitives::Valid> {
+    outcome::result<void> encode(const primitives::Valid &value,
+                                 common::Buffer &out) {
+      fixedwidth::encodeUint64(value.priority_, out);
+      OUTCOME_TRY(collection::encodeCollection(value.requires_, out));
+      OUTCOME_TRY(collection::encodeCollection(value.provides_, out));
+      fixedwidth::encodeUint64(value.longevity_, out);
+
+      return outcome::success();
+    }
+  };
+
+  /// encodes std::vector
+  template <class T>
+  struct TypeEncoder<std::vector<T>> {
+    outcome::result<void> encode(const std::vector<T> &value,
+                                 common::Buffer &out) {
+      return collection::encodeCollection(value, out);
+    }
+  };
+
+  /// decodes std::array
+  template <class T, size_t sz>
+  struct TypeDecoder<std::array<T, sz>> {
+    using array_type = std::array<T, sz>;
+    outcome::result<array_type> decode(common::ByteStream &stream) {
+      OUTCOME_TRY(collection, collection::decodeCollection<T>(stream));
+      if (collection.size() != sz) {
+        return DecodeError::INVALID_DATA;
+      }
+      array_type array;
+      std::copy(collection.begin(), collection.end(), array.begin());
+      return array;
+    }
+  };
+
+  /// decodes common::Hash256
+  template <>
+  struct TypeDecoder<common::Hash256> {
+    outcome::result<common::Hash256> decode(common::ByteStream &stream) {
+      OUTCOME_TRY(collection,
+                  collection::decodeCollection<common::byte_t>(stream));
+      common::Hash256 hash;
+      if (collection.size() != common::Hash256::size()) {
+        return DecodeError::INVALID_DATA;
+      }
+      std::copy(collection.begin(), collection.end(), hash.begin());
+      return hash;
+    }
+  };
+
+  /// decodes primitives::Invalid
+  template <>
+  struct TypeDecoder<primitives::Invalid> {
+    outcome::result<primitives::Invalid> decode(common::ByteStream &stream) {
+      OUTCOME_TRY(value, fixedwidth::decodeUint8(stream));
+      return primitives::Invalid{value};
+    }
+  };
+
+  /// decodes primitives::Unknown
+  template <>
+  struct TypeDecoder<primitives::Unknown> {
+    outcome::result<primitives::Unknown> decode(common::ByteStream &stream) {
+      OUTCOME_TRY(value, fixedwidth::decodeUint8(stream));
+      return primitives::Unknown{value};
+    }
+  };
+
+  /// decodes primitives::Valid
+  template <>
+  struct TypeDecoder<primitives::Valid> {
+    outcome::result<primitives::Valid> decode(common::ByteStream &stream) {
+      OUTCOME_TRY(priority, fixedwidth::decodeUint64(stream));
+      OUTCOME_TRY(
+          requires,
+          collection::decodeCollection<primitives::TransactionTag>(stream));
+      OUTCOME_TRY(
+          provides,
+          collection::decodeCollection<primitives::TransactionTag>(stream));
+      OUTCOME_TRY(longevity, fixedwidth::decodeUint64(stream));
+
+      return primitives::Valid{priority, requires, provides, longevity};
+    }
+  };
+
+  /// decodes primitives::TransactionTag
+  template <>
+  struct TypeDecoder<primitives::TransactionTag> {
+    outcome::result<primitives::TransactionTag> decode(
+        common::ByteStream &stream) {
+      return collection::decodeCollection<uint8_t>(stream);
+    }
+  };
+}  // namespace kagome::scale

--- a/core/primitives/impl/scale_codec_impl.hpp
+++ b/core/primitives/impl/scale_codec_impl.hpp
@@ -61,6 +61,53 @@ namespace kagome::primitives {
      * @return decoded extrinsic or error
      */
     outcome::result<Extrinsic> decodeExtrinsic(Stream &stream) const override;
+
+    /**
+     * @brief scale-encodes Version instance
+     * @param version value which should be encoded
+     * @return scale-encoded value
+     */
+    outcome::result<Buffer> encodeVersion(
+        const Version &version) const override;
+
+    /**
+     * @brief decodes scale-encoded Version instance from stream
+     * @param stream source stream containing encoded bytes
+     * @return scale-encoded value or error
+     */
+    outcome::result<Version> decodeVersion(Stream &stream) const override;
+
+    /**
+     * @brief scale-encodes block id
+     * @param blockId value which should be encoded
+     * @return scale-encoded value or error
+     */
+    outcome::result<Buffer> encodeBlockId(
+        const BlockId &blockId) const override;
+
+    /**
+     * @brief decodes scale-encoded BlockId instance
+     * @param stream source stream containing encoded bytes
+     * @return decoded BlockId instance or error
+     */
+    outcome::result<BlockId> decodeBlockId(
+        Stream &stream) const override;
+
+    /**
+     * @brief scale-encodes TransactionValidity instance
+     * @param transactionValidity value which should be encoded
+     * @return encoded value or error
+     */
+    outcome::result<Buffer> encodeTransactionValidity(
+        const TransactionValidity &transactionValidity) const override;
+
+    /**
+     * @brief decodes scale-encoded TransactionActivity instance
+     * @param stream source stream containing encoded bytes
+     * @return decoded TransactionValidity instance or error
+     */
+    outcome::result<TransactionValidity> decodeTransactionValidity(
+        Stream &stream) const override;
   };
 }  // namespace kagome::primitives
 

--- a/core/primitives/scale_codec.hpp
+++ b/core/primitives/scale_codec.hpp
@@ -9,16 +9,19 @@
 #include <outcome/outcome.hpp>
 #include "common/buffer.hpp"
 #include "common/byte_stream.hpp"
+#include "primitives/block_id.hpp"
+#include "primitives/transaction_validity.hpp"
 #include "scale/types.hpp"
 
+
 namespace kagome::primitives {
-  class Block;  ///< forward declarations of class Block
+  class Block;  ///< forward declaration of class Block
 
-  class BlockHeader;  ///< forward declarations of class BlockHeader
+  class BlockHeader;  ///< forward declaration of class BlockHeader
 
-  class Extrinsic;  ///< forward declarations of class Extrinsic
+  class Extrinsic;  ///< forward declaration of class Extrinsic
 
-  class Version;  ///< forward declarations of class Version
+  class Version;  ///< forward declaration of class Version
 
   /**
    * class ScaleCodec is an interface declaring methods
@@ -38,7 +41,7 @@ namespace kagome::primitives {
     /**
      * @brief scale-encodes Block instance
      * @param block value which should be encoded
-     * @return scale-encoded value
+     * @return scale-encoded value or error
      */
     virtual outcome::result<Buffer> encodeBlock(const Block &block) const = 0;
 
@@ -52,13 +55,13 @@ namespace kagome::primitives {
     /**
      * @brief scale-encodes BlockHeader instance
      * @param block_header value which should be encoded
-     * @return scale-encoded value
+     * @return scale-encoded value or error
      */
     virtual outcome::result<Buffer> encodeBlockHeader(
         const BlockHeader &block_header) const = 0;
 
     /**
-     * @brief decodes scale-encoded block header from stream
+     * @brief decodes scale-encoded block header
      * @param stream source stream containing encoded bytes
      * @return decoded block header or error
      */
@@ -67,18 +70,64 @@ namespace kagome::primitives {
 
     /**
      * @brief scale-encodes Extrinsic instance
-     * @param extrinsic extrinsic value which should be encoded
-     * @return scale-encoded value
+     * @param extrinsic value which should be encoded
+     * @return scale-encoded value or error
      */
     virtual outcome::result<Buffer> encodeExtrinsic(
         const Extrinsic &extrinsic) const = 0;
 
     /**
-     * @brief decodes scale-encoded extrinsic from stream
+     * @brief decodes scale-encoded extrinsic
      * @param stream source stream containing encoded bytes
      * @return decoded extrinsic or error
      */
     virtual outcome::result<Extrinsic> decodeExtrinsic(
+        Stream &stream) const = 0;
+
+    /**
+     * @brief scale-encodes Version instance
+     * @param version value which should be encoded
+     * @return scale-encoded value or error
+     */
+    virtual outcome::result<Buffer> encodeVersion(
+        const Version &version) const = 0;
+
+    /**
+     * @brief decodes scale-encoded Version instance
+     * @param stream source stream containing encoded bytes
+     * @return decoded Version instance or error
+     */
+    virtual outcome::result<Version> decodeVersion(Stream &stream) const = 0;
+
+    /**
+     * @brief scale-encodes block id
+     * @param blockId value which should be encoded
+     * @return scale-encoded value or error
+     */
+    virtual outcome::result<Buffer> encodeBlockId(
+        const BlockId &blockId) const = 0;
+
+    /**
+     * @brief decodes scale-encoded BlockId instance
+     * @param stream source stream containing encoded bytes
+     * @return decoded BlockId instance or error
+     */
+    virtual outcome::result<BlockId> decodeBlockId(Stream &stream) const = 0;
+
+    /**
+     * @brief scale-encodes TransactionValidity instance
+     * @param transactionValidity value which should be encoded
+     * @return encoded value or error
+     */
+    virtual outcome::result<Buffer> encodeTransactionValidity(
+        const TransactionValidity &transactionValidity) const = 0;
+
+    /**
+     * @brief decodes scale-encoded TransactionActivity instance
+     * @param stream source stream containing encoded bytes
+     * @return decoded TransactionValidity instance or error
+     */
+    virtual outcome::result<TransactionValidity> decodeTransactionValidity(
         Stream &stream) const = 0;
   };
 }  // namespace kagome::primitives

--- a/core/primitives/transaction_validity.hpp
+++ b/core/primitives/transaction_validity.hpp
@@ -7,8 +7,9 @@
 #define KAGOME_CORE_PRIMITIVES_TRANSACTION_VALIDITY_HPP
 
 #include <cstdint>
-#include <variant>
 #include <vector>
+
+#include <boost/variant.hpp>
 
 namespace kagome::primitives {
 
@@ -81,7 +82,7 @@ namespace kagome::primitives {
    * Information on a transaction's validity and, if valid, on how it relate to
    * other transactions.
    */
-  using TransactionValidity = std::variant<Invalid, Valid, Unknown>;
+  using TransactionValidity = boost::variant<Invalid, Valid, Unknown>;
 
 }  // namespace kagome::primitives
 

--- a/core/primitives/version.cpp
+++ b/core/primitives/version.cpp
@@ -16,23 +16,23 @@ namespace kagome::primitives {
         impl_version_(impl_version),
         apis_(std::move(apis)) {}
 
-  const std::string &Version::specName() {
+  const std::string &Version::specName() const {
     return spec_name_;
   }
 
-  const std::string &Version::implName() {
+  const std::string &Version::implName() const {
     return impl_name_;
   }
 
-  uint32_t Version::authoringVersion() {
+  uint32_t Version::authoringVersion() const {
     return authoring_version_;
   }
 
-  uint32_t Version::implVersion() {
+  uint32_t Version::implVersion() const {
     return impl_version_;
   }
 
-  const ApisVec &Version::apis() {
+  const ApisVec &Version::apis() const {
     return apis_;
   }
 

--- a/core/primitives/version.hpp
+++ b/core/primitives/version.hpp
@@ -44,7 +44,7 @@ namespace kagome::primitives {
      * Identifies the different Substrate runtimes. There'll be at least
      * polkadot and node.
      */
-    const std::string &specName();
+    const std::string &specName() const;
 
     /**
      * Name of the implementation of the spec. This is of little consequence
@@ -53,12 +53,12 @@ namespace kagome::primitives {
      * were a non-Rust implementation of the Polkadot runtime (e.g. C++), then
      * it would identify itself with an accordingly different impl_name.
      */
-    const std::string &implName();
+    const std::string &implName() const;
 
     /**
      * authoring_version is the version of the authorship interface
      */
-    uint32_t authoringVersion();
+    uint32_t authoringVersion() const;
 
     /**
      * Version of the implementation of the specification. Nodes are free to
@@ -68,10 +68,10 @@ namespace kagome::primitives {
      * Non-consensus-breaking optimizations are about the only changes that
      * could be made which would result in only the impl_version changing.
      */
-    uint32_t implVersion();
+    uint32_t implVersion() const;
 
     /// List of supported API "features" along with their versions.
-    const ApisVec &apis();
+    const ApisVec &apis() const;
 
    private:
     std::string spec_name_;

--- a/core/scale/boolean.cpp
+++ b/core/scale/boolean.cpp
@@ -16,7 +16,7 @@ namespace kagome::scale::boolean {
   outcome::result<bool> decodeBool(common::ByteStream &stream) {
     auto byte = stream.nextByte();
     if (!byte.has_value()) {
-      return outcome::failure(DecodeError::NOT_ENOUGH_DATA);
+      return DecodeError::NOT_ENOUGH_DATA;
     }
 
     switch (*byte) {
@@ -28,7 +28,7 @@ namespace kagome::scale::boolean {
         break;
     }
 
-    return outcome::failure(DecodeError::UNEXPECTED_VALUE);
+    return DecodeError::UNEXPECTED_VALUE;
   }
 
   void encodeTribool(tribool value, common::Buffer &out) {
@@ -47,7 +47,7 @@ namespace kagome::scale::boolean {
   outcome::result<tribool> decodeTribool(common::ByteStream &stream) {
     auto byte = stream.nextByte();
     if (!byte.has_value()) {
-      return outcome::failure(DecodeError::NOT_ENOUGH_DATA);
+      return DecodeError::NOT_ENOUGH_DATA;
     }
 
     switch (*byte) {
@@ -61,6 +61,6 @@ namespace kagome::scale::boolean {
         break;
     }
 
-    return outcome::failure(DecodeError::UNEXPECTED_VALUE);
+    return DecodeError::UNEXPECTED_VALUE;
   }
 }  // namespace kagome::scale::boolean

--- a/core/scale/boolean.cpp
+++ b/core/scale/boolean.cpp
@@ -16,7 +16,7 @@ namespace kagome::scale::boolean {
   outcome::result<bool> decodeBool(common::ByteStream &stream) {
     auto byte = stream.nextByte();
     if (!byte.has_value()) {
-      return outcome::failure(DecodeError::kNotEnoughData);
+      return outcome::failure(DecodeError::NOT_ENOUGH_DATA);
     }
 
     switch (*byte) {
@@ -28,7 +28,7 @@ namespace kagome::scale::boolean {
         break;
     }
 
-    return outcome::failure(DecodeError::kUnexpectedValue);
+    return outcome::failure(DecodeError::UNEXPECTED_VALUE);
   }
 
   void encodeTribool(tribool value, common::Buffer &out) {
@@ -47,7 +47,7 @@ namespace kagome::scale::boolean {
   outcome::result<tribool> decodeTribool(common::ByteStream &stream) {
     auto byte = stream.nextByte();
     if (!byte.has_value()) {
-      return outcome::failure(DecodeError::kNotEnoughData);
+      return outcome::failure(DecodeError::NOT_ENOUGH_DATA);
     }
 
     switch (*byte) {
@@ -61,6 +61,6 @@ namespace kagome::scale::boolean {
         break;
     }
 
-    return outcome::failure(DecodeError::kUnexpectedValue);
+    return outcome::failure(DecodeError::UNEXPECTED_VALUE);
   }
 }  // namespace kagome::scale::boolean

--- a/core/scale/boolean.hpp
+++ b/core/scale/boolean.hpp
@@ -6,11 +6,10 @@
 #ifndef KAGOME_SCALE_BOOLEAN_HPP
 #define KAGOME_SCALE_BOOLEAN_HPP
 
+#include <outcome/outcome.hpp>
 #include "common/buffer.hpp"
 #include "common/byte_stream.hpp"
 #include "scale/types.hpp"
-
-#include <outcome/outcome.hpp>
 
 namespace kagome::scale::boolean {
   /**

--- a/core/scale/collection.cpp
+++ b/core/scale/collection.cpp
@@ -6,9 +6,21 @@
 #include "scale/collection.hpp"
 
 namespace kagome::scale::collection {
-  outcome::result<void> encodeBuffer(const common::Buffer &buf, common::Buffer &out) {
+  outcome::result<void> encodeBuffer(const common::Buffer &buf,
+                                     common::Buffer &out) {
     OUTCOME_TRY(compact::encodeInteger(buf.size(), out));
     out.putBuffer(buf);
     return outcome::success();
   }
-}  // namespace kagome::common::scale::collection
+
+  outcome::result<void> encodeString(std::string_view string,
+                                     common::Buffer &out) {
+    OUTCOME_TRY(compact::encodeInteger(string.length(), out));
+    out.put(std::string_view(string));
+    return outcome::success();
+  }
+  outcome::result<std::string> decodeString(common::ByteStream &stream) {
+    OUTCOME_TRY(s, collection::decodeCollection<unsigned char>(stream));
+    return std::string(s.begin(), s.end());
+  }
+}  // namespace kagome::scale::collection

--- a/core/scale/compact.cpp
+++ b/core/scale/compact.cpp
@@ -28,7 +28,7 @@ namespace kagome::scale::compact {
     outcome::result<void> encodeFirstCategory(uint8_t value,
                                               common::Buffer &out) {
       if (value >= EncodingCategoryLimits::kMinUint16) {
-        return EncodeError::kWrongCategory;
+        return EncodeError::WRONG_CATEGORY;
       }
       // only values from [0, kMinUint16) can be put here
       out.putUint8(static_cast<uint8_t>(value << 2));
@@ -39,7 +39,7 @@ namespace kagome::scale::compact {
     outcome::result<void> encodeSecondCategory(uint16_t value,
                                                common::Buffer &out) {
       if (value >= EncodingCategoryLimits::kMinUint32) {
-        return EncodeError::kWrongCategory;
+        return EncodeError::WRONG_CATEGORY;
       };
       // only values from [kMinUint16, kMinUint32) can be put here
       auto v = value;
@@ -58,7 +58,7 @@ namespace kagome::scale::compact {
     outcome::result<void> encodeThirdCategory(uint32_t value,
                                               common::Buffer &out) {
       if (value >= EncodingCategoryLimits::kMinBigInteger) {
-        return EncodeError::kWrongCategory;
+        return EncodeError::WRONG_CATEGORY;
       };
 
       uint32_t v = (value << 2) + 2;
@@ -91,7 +91,7 @@ namespace kagome::scale::compact {
     // cannot encode negative numbers
     // there is no description how to encode compact negative numbers
     if (value < 0) {
-      return EncodeError::kCompactIntegerIsNegative;
+      return EncodeError::NEGATIVE_COMPACT_INTEGER;
     }
 
     if (value < EncodingCategoryLimits::kMinUint16) {
@@ -114,7 +114,7 @@ namespace kagome::scale::compact {
     size_t requiredLength = 1 + bigIntLength;
 
     if (bigIntLength > 67) {
-      return EncodeError::kCompactIntegerIsTooBig;
+      return EncodeError::COMPACT_INTEGER_TOO_BIG;
     }
 
     ByteArray result;
@@ -151,7 +151,7 @@ namespace kagome::scale::compact {
   outcome::result<BigInteger> decodeInteger(common::ByteStream &stream) {
     auto first_byte = stream.nextByte();
     if (!first_byte.has_value()) {
-      return outcome::failure(DecodeError::kNotEnoughData);
+      return outcome::failure(DecodeError::NOT_ENOUGH_DATA);
     }
 
     const uint8_t flag = (*first_byte) & 0b00000011;
@@ -167,7 +167,7 @@ namespace kagome::scale::compact {
       case 0b01: {
         auto second_byte = stream.nextByte();
         if (!second_byte.has_value()) {
-          return outcome::failure(DecodeError::kNotEnoughData);
+          return outcome::failure(DecodeError::NOT_ENOUGH_DATA);
         }
 
         number = (static_cast<size_t>((*first_byte) & 0b11111100)
@@ -181,7 +181,7 @@ namespace kagome::scale::compact {
         size_t multiplier = 256;
         if (!stream.hasMore(3)) {
           // not enough data to decode integer
-          return outcome::failure(DecodeError::kNotEnoughData);
+          return outcome::failure(DecodeError::NOT_ENOUGH_DATA);
         }
 
         for (int i = 0; i < 3; ++i) {
@@ -198,7 +198,7 @@ namespace kagome::scale::compact {
         auto bytes_count = ((*first_byte) >> 2) + 4;
         if (!stream.hasMore(bytes_count)) {
           // not enough data to decode integer
-          return outcome::failure(DecodeError::kNotEnoughData);
+          return outcome::failure(DecodeError::NOT_ENOUGH_DATA);
         }
 
         BigInteger multiplier{1};

--- a/core/scale/compact.hpp
+++ b/core/scale/compact.hpp
@@ -7,8 +7,8 @@
 #define KAGOME_SCALE_COMPACT_HPP
 
 #include <optional>
-#include <outcome/outcome.hpp>
 
+#include <outcome/outcome.hpp>
 #include "common/buffer.hpp"
 #include "common/byte_stream.hpp"
 #include "common/result.hpp"

--- a/core/scale/fixedwidth.cpp
+++ b/core/scale/fixedwidth.cpp
@@ -6,10 +6,7 @@
 #include "fixedwidth.hpp"
 
 #include <boost/endian/buffers.hpp>
-
 #include "scale/util.hpp"
-
-using namespace boost::endian;          // NOLINT
 
 namespace kagome::scale::fixedwidth {
   void encodeInt8(int8_t value, common::Buffer &out) {

--- a/core/scale/optional.hpp
+++ b/core/scale/optional.hpp
@@ -46,7 +46,7 @@ namespace kagome::scale::optional {
   outcome::result<std::optional<T>> decodeOptional(common::ByteStream &stream) {
     auto flag = stream.nextByte();
     if (!flag.has_value()) {
-      return outcome::failure(DecodeError::kNotEnoughData);
+      return outcome::failure(DecodeError::NOT_ENOUGH_DATA);
     }
 
     if (*flag != 1) {
@@ -88,7 +88,7 @@ namespace kagome::scale::optional {
       common::ByteStream &stream) {
     auto byte = stream.nextByte();
     if (!byte.has_value()) {
-      return outcome::failure(DecodeError::kNotEnoughData);
+      return outcome::failure(DecodeError::NOT_ENOUGH_DATA);
     }
 
     switch (*byte) {
@@ -102,7 +102,7 @@ namespace kagome::scale::optional {
         break;
     }
 
-    return outcome::failure(DecodeError::kUnexpectedValue);
+    return outcome::failure(DecodeError::UNEXPECTED_VALUE);
   }
 
 }  // namespace kagome::scale::optional

--- a/core/scale/scale_error.cpp
+++ b/core/scale/scale_error.cpp
@@ -8,11 +8,11 @@
 OUTCOME_CPP_DEFINE_CATEGORY(kagome::scale, EncodeError, e) {
   using kagome::scale::EncodeError;
   switch (e) {
-    case EncodeError::kCompactIntegerIsNegative:
+    case EncodeError::NEGATIVE_COMPACT_INTEGER:
       return "compact integers cannot be negative";
-    case EncodeError::kCompactIntegerIsTooBig:
+    case EncodeError::COMPACT_INTEGER_TOO_BIG:
       return "compact integers cannot be negative";
-    case EncodeError::kWrongCategory:
+    case EncodeError::WRONG_CATEGORY:
       return "wrong compact encoding category";
     default:
       break;
@@ -23,13 +23,13 @@ OUTCOME_CPP_DEFINE_CATEGORY(kagome::scale, EncodeError, e) {
 OUTCOME_CPP_DEFINE_CATEGORY(kagome::scale, DecodeError, e) {
   using kagome::scale::DecodeError;
   switch (e) {
-    case DecodeError::kNotEnoughData:
+    case DecodeError::NOT_ENOUGH_DATA:
       return "not enough data to decode";
-    case DecodeError::kUnexpectedValue:
+    case DecodeError::UNEXPECTED_VALUE:
       return "unexpected value occured";
-    case DecodeError::kTooManyItems:
+    case DecodeError::TOO_MANY_ITEMS:
       return "collection has too many items, unable to unpack";
-    case DecodeError::kWrongTypeIndex:
+    case DecodeError::WRONG_TYPE_INDEX:
       return "wrong type index, cannot decode variant";
     default:
       break;

--- a/core/scale/scale_error.hpp
+++ b/core/scale/scale_error.hpp
@@ -14,22 +14,23 @@ namespace kagome::scale {
    * @brief EncodeError enum provides error codes for Encode methods
    */
   enum class EncodeError {        // 0 is reserved for success
-    kCompactIntegerIsTooBig = 1,  ///< compact integer can't be more than 2**536
-    kCompactIntegerIsNegative,    ///< cannot compact-encode negative integers
-    kWrongCategory,               ///< wrong compact category
-    kNoAlternative,               ///< wrong cast to alternative
+    COMPACT_INTEGER_TOO_BIG = 1,  ///< compact integer can't be more than 2**536
+    NEGATIVE_COMPACT_INTEGER,     ///< cannot compact-encode negative integers
+    WRONG_CATEGORY,               ///< wrong compact category
+    WRONG_ALTERNATIVE,            ///< wrong cast to alternative
   };
 
   /**
    * @brief DecoderError enum provides codes of errors for Decoder methods
    */
   enum class DecodeError {  // 0 is reserved for success
-    kNotEnoughData = 1,     ///< not enough data to decode value
-    kUnexpectedValue,       ///< unexpected value
-    kTooManyItems,          ///< too many items, cannot address them in memory
-    kWrongTypeIndex,        ///< wrong type index, cannot decode variant
+    NOT_ENOUGH_DATA = 1,    ///< not enough data to decode value
+    UNEXPECTED_VALUE,       ///< unexpected value
+    TOO_MANY_ITEMS,         ///< too many items, cannot address them in memory
+    WRONG_TYPE_INDEX,       ///< wrong type index, cannot decode variant
+    INVALID_DATA            ///< invalid data
   };
-}  // namespace kagome::common::scale
+}  // namespace kagome::scale
 
 OUTCOME_HPP_DECLARE_ERROR(kagome::scale, EncodeError)
 OUTCOME_HPP_DECLARE_ERROR(kagome::scale, DecodeError)

--- a/core/scale/type_decoder.hpp
+++ b/core/scale/type_decoder.hpp
@@ -12,6 +12,9 @@
 #include "scale/types.hpp"
 #include "scale/util.hpp"
 
+// TODO(yuraz): PRE-119 conception of TypeEncoder/TypeDecoder needs to be
+// refactored
+
 namespace kagome::scale {
   /**
    * Type decoders are nested decoders used to decode types in optionals,
@@ -62,6 +65,22 @@ namespace kagome::scale {
   struct TypeDecoder<tribool> {
     auto decode(common::ByteStream &stream) {
       return boolean::decodeTribool(stream);
+    }
+  };
+
+  /**
+   * @class TypeDecoder<std::pair<F,S>> is specialization of TypeDecoder class
+   * it implements decoding std::pair from stream
+   * @tparam F first type
+   * @tparam S second type
+   */
+  template <class F, class S>
+  struct TypeDecoder<std::pair<F, S>> {
+    using value_type = std::pair<F, S>;
+    outcome::result<value_type> decode(common::ByteStream &stream) {
+      OUTCOME_TRY(first_value, TypeDecoder<F>{}.decode(stream));
+      OUTCOME_TRY(second_value, TypeDecoder<S>{}.decode(stream));
+      return std::pair<F, S>(first_value, second_value);
     }
   };
 }  // namespace kagome::scale

--- a/core/scale/type_encoder.hpp
+++ b/core/scale/type_encoder.hpp
@@ -7,11 +7,13 @@
 #define KAGOME_SCALE_TYPE_ENCODER_HPP
 
 #include "scale/boolean.hpp"
-#include "scale/compact.hpp"
 #include "scale/fixedwidth.hpp"
 #include "scale/scale_error.hpp"
 #include "scale/types.hpp"
 #include "scale/util.hpp"
+
+// TODO(yuraz): PRE-119 conception of TypeEncoder/TypeDecoder needs to be
+// refactored
 
 namespace kagome::scale {
   template <class T>
@@ -27,6 +29,7 @@ namespace kagome::scale {
     };
   };
 
+  /// encoder for bool
   template <>
   struct TypeEncoder<bool> {
     outcome::result<void> encode(bool item, common::Buffer &out) const {
@@ -35,10 +38,22 @@ namespace kagome::scale {
     }
   };
 
+  /// encoder for tribool
   template <>
   struct TypeEncoder<tribool> {
     outcome::result<void> encode(tribool item, common::Buffer &out) const {
       boolean::encodeTribool(item, out);
+      return outcome::success();
+    }
+  };
+
+  /// encoder for std::pair
+  template <class F, class S>
+  struct TypeEncoder<std::pair<F, S>> {
+    outcome::result<void> encode(const std::pair<F, S> &pair,
+                                 common::Buffer &out) {
+      OUTCOME_TRY(TypeEncoder<F>{}.encode(pair.first, out));
+      OUTCOME_TRY(TypeEncoder<S>{}.encode(pair.second, out));
       return outcome::success();
     }
   };

--- a/core/scale/util.hpp
+++ b/core/scale/util.hpp
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include <boost/endian/arithmetic.hpp>
-
 #include "common/buffer.hpp"
 #include "scale/scale_error.hpp"
 #include "scale/types.hpp"
@@ -75,7 +74,7 @@ namespace kagome::scale::impl {
     // clang-format on
 
     if (!stream.hasMore(size)) {
-      return outcome::failure(DecodeError::kNotEnoughData);
+      return outcome::failure(DecodeError::NOT_ENOUGH_DATA);
     }
 
     // get integer as 4 bytes from little-endian stream

--- a/test/core/primitives/primitives_codec_test.cpp
+++ b/test/core/primitives/primitives_codec_test.cpp
@@ -3,88 +3,125 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <gtest/gtest.h>
-
-#include <outcome/outcome.hpp>
-#include "primitives/block.hpp"
 #include "primitives/impl/scale_codec_impl.hpp"
+
+#include <gtest/gtest.h>
+#include <boost/variant.hpp>
+#include <outcome/outcome.hpp>
+#include "common/visitor.hpp"
+#include "primitives/block.hpp"
+#include "primitives/version.hpp"
 #include "scale/byte_array_stream.hpp"
 
 using kagome::common::Buffer;
+using kagome::primitives::Block;
+using kagome::primitives::BlockHeader;
+using kagome::primitives::BlockId;
+using kagome::primitives::Extrinsic;
+using kagome::primitives::Invalid;
+using kagome::primitives::ScaleCodec;
+using kagome::primitives::ScaleCodecImpl;
+using kagome::primitives::TransactionValidity;
+using kagome::primitives::Unknown;
+using kagome::primitives::Valid;
+using kagome::primitives::Version;
 using kagome::scale::ByteArrayStream;
-
-using namespace kagome::primitives;  // NOLINT
 
 /**
  * @class Primitives is a test fixture which contains useful data
  */
 class Primitives : public testing::Test {
- public:
-  Primitives()
-      : header_{{1},   // buffer: parent_hash
-                2,     // number: number
-                {3},   // buffer: state_root
-                {4},   // buffer: extrinsic root
-                {5}},  // buffer: digest
-        extrinsic_{{12, 1, 2, 3}},
-        // sequence of 3 bytes: 1, 2, 3; 12 == (3 << 2)
+  void SetUp() override {
+    block_id_hash_ = kagome::common::Hash256::fromHex(
+                         "000102030405060708090A0B0C0D0E0F"
+                         "101112131415161718191A1B1C1D1E1F")
+                         .getValue();
 
-        header_match_{
-            4, 1,                    // {1}
-            2, 0, 0, 0, 0, 0, 0, 0,  // 2 as uint64
-            4, 3,                    // {3}
-            4, 4,                    // {4}
-            4, 5                     // {5}
-        },
-        extrinsic_match_{12, 1, 2, 3},
-        block_{header_, {extrinsic_}},
-        block_match_{4,  1,                    // {1}
-                     2,  0, 0, 0, 0, 0, 0, 0,  // 2 as uint64
-                     4,  3,                    // {3}
-                     4,  4,                    // {4}
-                     4,  5,                    // {5}
-                     4,                        // (1 << 2) number of extrinsics
-                     12, 1, 2, 3}              // extrinsic itself {1, 2, 3}
-  {
     codec_ = std::make_shared<ScaleCodecImpl>();
   }
 
-  const BlockHeader &header() const {
-    return header_;
-  }
-
-  const Buffer &headerMatch() const {
-    return header_match_;
-  }
-
-  const Extrinsic &extrinsic() const {
-    return extrinsic_;
-  }
-
-  const Buffer &extrinsicMatch() const {
-    return extrinsic_match_;
-  }
-
-  const Block &block() const {
-    return block_;
-  }
-
-  const Buffer &blockMatch() const {
-    return block_match_;
-  }
-
-  auto codec() const {
-    return codec_;
-  }
-
- private:
-  BlockHeader header_;
-  Extrinsic extrinsic_;
-  Buffer header_match_;
-  Buffer extrinsic_match_;
-  Block block_;
-  Buffer block_match_;
-
+ protected:
+  /// block header and corresponding scale representation
+  BlockHeader block_header_{{1},   // buffer: parent_hash
+                            2,     // number: number
+                            {3},   // buffer: state_root
+                            {4},   // buffer: extrinsic root
+                            {5}};  // buffer: digest;
+  Buffer encoded_header_{
+      4, 1,                    // {1}
+      2, 0, 0, 0, 0, 0, 0, 0,  // 2 as uint64
+      4, 3,                    // {3}
+      4, 4,                    // {4}
+      4, 5                     // {5}
+  };
+  /// Extrinsic instance and corresponding scale representation
+  Extrinsic extrinsic_{{12,  /// sequence of 3 bytes: 1, 2, 3; 12 == (3 << 2)
+                        1, 2, 3}};
+  Buffer encoded_extrinsic_{12, 1, 2, 3};
+  /// block instance and corresponding scale representation
+  Block block_{block_header_, {extrinsic_}};
+  Buffer encoded_block_{4,  1,                    // {1}
+                        2,  0, 0, 0, 0, 0, 0, 0,  // 2 as uint64
+                        4,  3,                    // {3}
+                        4,  4,                    // {4}
+                        4,  5,                    // {5}
+                        4,             // (1 << 2) number of extrinsics
+                        12, 1, 2, 3};  // extrinsic itself {1, 2, 3}
+  /// Version instance and corresponding scale representation
+  Version version_{
+      "qwe",                                           // spec name
+      "asd",                                           // impl_name
+      1,                                               // auth version
+      2,                                               // impl version
+      {{{'1', '2', '3', '4', '5', '6', '7', '8'}, 1},  // ApiId_1
+       {{'8', '7', '6', '5', '4', '3', '2', '1'}, 2}}  // ApiId_2
+  };
+  Buffer encoded_version_{
+      12, 'q', 'w', 'e',                           // spec name
+      12, 'a', 's', 'd',                           // impl name
+      1,  0,   0,   0,                             // auth version
+      2,  0,   0,   0,                             // impl version
+      8,                                           // collection of 2 items
+      32, '1', '2', '3', '4', '5', '6', '7', '8',  // id1
+      1,  0,   0,   0,                             // id1 version
+      32, '8', '7', '6', '5', '4', '3', '2', '1',  // id2
+      2,  0,   0,   0,                             // id2 version
+  };
+  /// block id variant number alternative and corresponding scale representation
+  BlockId block_id_number_{1ull};
+  Buffer encoded_block_id_number_{1, 1, 0, 0, 0, 0, 0, 0, 0};
+  /// block id variant hash alternative and corresponding scale representation
+  BlockId block_id_hash_;
+  Buffer encoded_block_id_hash_{
+      0,    // variant type order
+      128,  // collection size compact-encoded = 32 << 2 + 0x00
+      0x0,  0x1,  0x2,  0x3,  0x4,  0x5,  0x6,  0x7,  0x8,  0x9,  0xA,
+      0xB,  0xC,  0xD,  0xE,  0xF,  0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+      0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F};
+  /// TransactionValidity variant instance as Valid alternative and
+  /// corresponding scale representation
+  Valid valid_transaction_{1,                    // priority
+                           {{0, 1}, {2, 3}},     // requires
+                           {{4, 5}, {6, 7, 8}},  // provides
+                           2};                   // longivity
+  Buffer encoded_valid_transaction_{
+      1,                       // variant type order
+      1, 0, 0, 0, 0, 0, 0, 0,  // priority
+      8,                       // compact-encoded collection size (2)
+      // collection of collections
+      8,     // compact-encoded collection size (2)
+      0, 1,  // collection items
+      8,     // compact-encoded collection size (2)
+      2, 3,  // collection items
+      8,     // compact-encoded collection size (2)
+      // collection of collections
+      8,                       // compact-encoded collection size (2)
+      4, 5,                    // collection items
+      12,                      // compact-encoded collection size (3)
+      6, 7, 8,                 // collection items
+      2, 0, 0, 0, 0, 0, 0, 0,  // longevity
+  };
+  /// ScaleCodec impl instance
   std::shared_ptr<ScaleCodec> codec_;
 };
 
@@ -94,10 +131,10 @@ class Primitives : public testing::Test {
  * @then expected result obtained
  */
 TEST_F(Primitives, encodeBlockHeader) {
-  auto &&res = codec()->encodeBlockHeader(header());
+  auto &&res = codec_->encodeBlockHeader(block_header_);
 
   ASSERT_TRUE(res);
-  ASSERT_EQ(res.value(), headerMatch());
+  ASSERT_EQ(res.value(), encoded_header_);
 }
 
 /**
@@ -106,18 +143,18 @@ TEST_F(Primitives, encodeBlockHeader) {
  * @then decoded instance of BlockHeader matches predefined block header
  */
 TEST_F(Primitives, decodeBlockHeader) {
-  ByteArrayStream stream{headerMatch()};
+  ByteArrayStream stream{encoded_header_};
 
-  auto &&res = codec()->decodeBlockHeader(stream);
+  auto &&res = codec_->decodeBlockHeader(stream);
   ASSERT_TRUE(res);
 
   auto &&val = res.value();
 
-  ASSERT_EQ(val.parentHash(), header().parentHash());
-  ASSERT_EQ(val.number(), header().number());
-  ASSERT_EQ(val.stateRoot(), header().stateRoot());
-  ASSERT_EQ(val.extrinsicsRoot(), header().extrinsicsRoot());
-  ASSERT_EQ(val.digest(), header().digest());
+  ASSERT_EQ(val.parentHash(), block_header_.parentHash());
+  ASSERT_EQ(val.number(), block_header_.number());
+  ASSERT_EQ(val.stateRoot(), block_header_.stateRoot());
+  ASSERT_EQ(val.extrinsicsRoot(), block_header_.extrinsicsRoot());
+  ASSERT_EQ(val.digest(), block_header_.digest());
 }
 
 /**
@@ -126,11 +163,11 @@ TEST_F(Primitives, decodeBlockHeader) {
  * @then the same expected buffer obtained {12, 1, 2, 3}
  */
 TEST_F(Primitives, encodeExtrinsic) {
-  auto &&res = codec()->encodeExtrinsic(extrinsic());
+  auto &&res = codec_->encodeExtrinsic(extrinsic_);
   ASSERT_TRUE(res);
 
   auto &&val = res.value();
-  ASSERT_EQ(val, extrinsicMatch());
+  ASSERT_EQ(val, encoded_extrinsic_);
 }
 
 /**
@@ -139,10 +176,10 @@ TEST_F(Primitives, encodeExtrinsic) {
  * @then decoded instance of Extrinsic matches predefined block header
  */
 TEST_F(Primitives, decodeExtrinsic) {
-  ByteArrayStream stream{extrinsicMatch()};
-  auto &&res = codec()->decodeExtrinsic(stream);
+  ByteArrayStream stream{encoded_extrinsic_};
+  auto &&res = codec_->decodeExtrinsic(stream);
   ASSERT_TRUE(res);
-  ASSERT_EQ(res.value().data(), extrinsic().data());
+  ASSERT_EQ(res.value().data(), extrinsic_.data());
 }
 
 /**
@@ -151,9 +188,9 @@ TEST_F(Primitives, decodeExtrinsic) {
  * @then expected result obtained
  */
 TEST_F(Primitives, encodeBlock) {
-  auto &&res = codec()->encodeBlock(block());
+  auto &&res = codec_->encodeBlock(block_);
   ASSERT_TRUE(res);
-  ASSERT_EQ(res.value(), blockMatch());
+  ASSERT_EQ(res.value(), encoded_block_);
 }
 
 /**
@@ -162,20 +199,201 @@ TEST_F(Primitives, encodeBlock) {
  * @then decoded instance of Block matches predefined Block instance
  */
 TEST_F(Primitives, decodeBlock) {
-  ByteArrayStream stream{blockMatch()};
-  auto &&res = codec()->decodeBlock(stream);
+  ByteArrayStream stream{encoded_block_};
+  auto &&res = codec_->decodeBlock(stream);
   ASSERT_TRUE(res);
 
   auto &&h = res.value().header();
 
-  ASSERT_EQ(h.parentHash(), header().parentHash());
-  ASSERT_EQ(h.number(), header().number());
-  ASSERT_EQ(h.stateRoot(), header().stateRoot());
-  ASSERT_EQ(h.extrinsicsRoot(), header().extrinsicsRoot());
-  ASSERT_EQ(h.digest(), header().digest());
+  ASSERT_EQ(h.parentHash(), block_header_.parentHash());
+  ASSERT_EQ(h.number(), block_header_.number());
+  ASSERT_EQ(h.stateRoot(), block_header_.stateRoot());
+  ASSERT_EQ(h.extrinsicsRoot(), block_header_.extrinsicsRoot());
+  ASSERT_EQ(h.digest(), block_header_.digest());
 
   auto &&extrinsics = res.value().extrinsics();
 
   ASSERT_EQ(extrinsics.size(), 1);
-  ASSERT_EQ(extrinsics[0].data(), extrinsic().data());
+  ASSERT_EQ(extrinsics[0].data(), extrinsic_.data());
+}
+
+/// Version
+
+/**
+ * @given version instance and predefined match for encoded instance
+ * @when codec_->encodeVersion() is applied
+ * @then obtained result equal to predefined match
+ */
+TEST_F(Primitives, encodeVersion) {
+  auto &&res = codec_->encodeVersion(version_);
+  ASSERT_TRUE(res);
+  ASSERT_EQ(res.value(), encoded_version_);
+}
+
+/**
+ * @given byte array containing encoded version and predefined version
+ * @when codec_->decodeVersion() is applied
+ * @then obtained result matches predefined version instance
+ */
+TEST_F(Primitives, decodeVersion) {
+  auto stream = ByteArrayStream(encoded_version_);
+  auto &&res = codec_->decodeVersion(stream);
+  ASSERT_TRUE(res);
+  auto &&ver = res.value();
+  ASSERT_EQ(ver.specName(), version_.specName());
+  ASSERT_EQ(ver.implName(), version_.implName());
+  ASSERT_EQ(ver.authoringVersion(), version_.authoringVersion());
+  ASSERT_EQ(ver.apis(), version_.apis());
+}
+
+/// BlockId
+
+/**
+ * @given block id constructed as hash256 and predefined match
+ * @when codec_->encodeBlockId() is applied
+ * @then obtained result matches predefined value
+ */
+TEST_F(Primitives, encodeBlockIdHash256) {
+  auto &&res = codec_->encodeBlockId(block_id_hash_);
+  ASSERT_TRUE(res);
+  ASSERT_EQ(res.value(), encoded_block_id_hash_);
+}
+
+/**
+ * @given block id constructed as BlockNumber and predefined match
+ * @when codec_->encodeBlockId() is applied
+ * @then obtained result matches predefined value
+ */
+TEST_F(Primitives, encodeBlockIdBlockNumber) {
+  auto &&res = codec_->encodeBlockId(block_id_number_);
+  ASSERT_TRUE(res);
+  ASSERT_EQ(res.value(), (encoded_block_id_number_));
+}
+
+/**
+ * @given byte array containing encoded block id
+ * and predefined block id as Hash256
+ * @when codec_->decodeBlockId() is applied
+ * @thenobtained result matches predefined block id instance
+ */
+TEST_F(Primitives, decodeBlockIdHash) {
+  auto stream = ByteArrayStream(encoded_block_id_hash_);
+  auto &&res = codec_->decodeBlockId(stream);
+  ASSERT_TRUE(res);
+  // ASSERT_EQ has problems with pretty-printing variants
+  ASSERT_TRUE(res.value() == block_id_hash_);
+}
+
+/**
+ * @given byte array containing encoded block id
+ * and predefined block id as BlockNumber
+ * @when codec_->decodeBlockId() is applied
+ * @thenobtained result matches predefined block id instance
+ */
+TEST_F(Primitives, decodeBlockIdNumber) {
+  auto stream = ByteArrayStream(encoded_block_id_number_);
+  auto &&res = codec_->decodeBlockId(stream);
+  ASSERT_TRUE(res);
+  // ASSERT_EQ has problems with pretty-printing variants
+  ASSERT_TRUE(res.value() == block_id_number_);
+}
+
+/// TransactionValidity
+
+/**
+ * @given TransactionValidity instance as Invalid and predefined match
+ * @when codec_->encodeTransactionValidity() is applied
+ * @then obtained result matches predefined value
+ */
+TEST_F(Primitives, encodeTransactionValidityInvalid) {
+  TransactionValidity invalid = Invalid{1};
+  auto &&res = codec_->encodeTransactionValidity(invalid);
+  ASSERT_TRUE(res);
+  ASSERT_EQ(res.value(), (Buffer{0, 1}));
+}
+
+/**
+ * @given TransactionValidity instance as Unknown and predefined match
+ * @when codec_->encodeTransactionValidity() is applied
+ * @then obtained result matches predefined value
+ */
+TEST_F(Primitives, encodeTransactionValidityUnknown) {
+  TransactionValidity unknown = Unknown{2};
+  auto &&res = codec_->encodeTransactionValidity(unknown);
+  ASSERT_TRUE(res);
+  ASSERT_EQ(res.value(), (Buffer{2, 2}));
+}
+
+/**
+ * @given TransactionValidity instance as Valid and predefined match
+ * @when codec_->encodeTransactionValidity() is applied
+ * @then obtained result matches predefined value
+ */
+TEST_F(Primitives, encodeTransactionValidity) {
+  auto &&res = codec_->encodeTransactionValidity(valid_transaction_);
+  ASSERT_TRUE(res);
+  ASSERT_EQ(res.value(), encoded_valid_transaction_);
+}
+
+/**
+ * @given byte array containing encoded
+ * and TransactionValidity instance as Valid
+ * @when codec_->decodeBlockId() is applied
+ * @thenobtained result matches predefined block id instance
+ */
+TEST_F(Primitives, decodeTransactionValidityInvalid) {
+  Buffer bytes = {0, 1};
+  auto stream = ByteArrayStream(bytes);
+  auto &&res = codec_->decodeTransactionValidity(stream);
+  ASSERT_TRUE(res);
+  TransactionValidity value = res.value();
+  kagome::visit_in_place(
+      value,                                       // value
+      [](Invalid &v) { ASSERT_EQ(v.error_, 1); },  // ok
+      [](Unknown &v) { FAIL(); },                  // fail
+      [](Valid &v) { FAIL(); });                   // fail
+}
+
+/**
+ * @given byte array containing encoded
+ * and TransactionValidity instance as Valid
+ * @when codec_->decodeBlockId() is applied
+ * @thenobtained result matches predefined block id instance
+ */
+TEST_F(Primitives, decodeTransactionValidityUnknown) {
+  Buffer bytes = {2, 2};
+  auto stream = ByteArrayStream(bytes);
+  auto &&res = codec_->decodeTransactionValidity(stream);
+  ASSERT_TRUE(res);
+  TransactionValidity value = res.value();
+  kagome::visit_in_place(
+      value,                                       // value
+      [](Invalid &v) { FAIL(); },                  // fail
+      [](Unknown &v) { ASSERT_EQ(v.error_, 2); },  // ok
+      [](Valid &v) { FAIL(); }                     // fail
+  );
+}
+
+/**
+ * @given byte array containing encoded
+ * and TransactionValidity instance as Valid
+ * @when codec_->decodeBlockId() is applied
+ * @thenobtained result matches predefined block id instance
+ */
+TEST_F(Primitives, decodeTransactionValidityValid) {
+  auto stream = ByteArrayStream(encoded_valid_transaction_);
+  auto &&res = codec_->decodeTransactionValidity(stream);
+  ASSERT_TRUE(res);
+  TransactionValidity value = res.value();
+  kagome::visit_in_place(
+      value,                       // value
+      [](Invalid &v) { FAIL(); },  // fail
+      [](Unknown &v) { FAIL(); },  // fail
+      [this](Valid &v) {           // ok
+        auto &valid = valid_transaction_;
+        ASSERT_EQ(v.priority_, valid.priority_);
+        ASSERT_EQ(v.requires_, valid.requires_);
+        ASSERT_EQ(v.provides_, valid.provides_);
+        ASSERT_EQ(v.longevity_, valid.longevity_);
+      });
 }

--- a/test/core/primitives/primitives_codec_test.cpp
+++ b/test/core/primitives/primitives_codec_test.cpp
@@ -35,7 +35,7 @@ class Primitives : public testing::Test {
     block_id_hash_ = kagome::common::Hash256::fromHex(
                          "000102030405060708090A0B0C0D0E0F"
                          "101112131415161718191A1B1C1D1E1F")
-                         .getValue();
+                         .value();
 
     codec_ = std::make_shared<ScaleCodecImpl>();
   }

--- a/test/core/scale/CMakeLists.txt
+++ b/test/core/scale/CMakeLists.txt
@@ -57,3 +57,11 @@ target_link_libraries(scale_variant_test
     scale
     buffer
     )
+
+addtest(scale_pair_test
+    scale_pair_test.cpp
+    )
+target_link_libraries(scale_pair_test
+    scale
+    buffer
+    )

--- a/test/core/scale/scale_boolean_test.cpp
+++ b/test/core/scale/scale_boolean_test.cpp
@@ -54,7 +54,7 @@ TEST(Scale, fixedwidthDecodeBool) {
   auto &&res2 = boolean::decodeBool(stream);
   ASSERT_FALSE(res2);
   ASSERT_EQ(res2.error().value(),
-            static_cast<int>(DecodeError::kUnexpectedValue));
+            static_cast<int>(DecodeError::UNEXPECTED_VALUE));
 }
 
 /**
@@ -107,5 +107,5 @@ TEST(Scale, fixedwidthDecodeTribool) {
   auto &&res3 = boolean::decodeTribool(stream);
   ASSERT_FALSE(res3);
   ASSERT_EQ(res3.error().value(),
-            static_cast<int>(DecodeError::kUnexpectedValue));
+            static_cast<int>(DecodeError::UNEXPECTED_VALUE));
 }

--- a/test/core/scale/scale_collection_test.cpp
+++ b/test/core/scale/scale_collection_test.cpp
@@ -20,11 +20,11 @@ using namespace kagome::scale;   // NOLINT
  */
 TEST(Scale, encodeCollectionOf80) {
   // 80 items of value 1
-  const Buffer collection(80, 1);
+  std::vector<uint8_t> collection(80, 1);
   auto out_bytes = Buffer{65, 1};
-  out_bytes.put(collection.toVector());
+  out_bytes.put(collection);
   Buffer out;
-  auto &&res = collection::encodeCollection(collection.toVector(), out);
+  auto &&res = collection::encodeCollection(collection, out);
   ASSERT_TRUE(res);
   ASSERT_EQ(out.toVector().size(), 82);
   // clang-format off

--- a/test/core/scale/scale_compact_test.cpp
+++ b/test/core/scale/scale_compact_test.cpp
@@ -165,7 +165,7 @@ TEST(Scale, compactDecodeBigIntegerError) {
   auto &&result = compact::decodeInteger(stream);
   ASSERT_FALSE(result);
   ASSERT_EQ(result.error().value(),
-            static_cast<int>(DecodeError::kNotEnoughData));
+            static_cast<int>(DecodeError::NOT_ENOUGH_DATA));
 }
 
 /**

--- a/test/core/scale/scale_optional_test.cpp
+++ b/test/core/scale/scale_optional_test.cpp
@@ -180,7 +180,7 @@ TEST(Scale, decodeOptionalBool) {
     auto &&res = optional::decodeOptional<bool>(stream);
     ASSERT_FALSE(res);
     ASSERT_EQ(res.error().value(),
-              static_cast<int>(DecodeError::kUnexpectedValue));
+              static_cast<int>(DecodeError::UNEXPECTED_VALUE));
   }
 
   // not enough data
@@ -188,7 +188,7 @@ TEST(Scale, decodeOptionalBool) {
     auto &&res = optional::decodeOptional<bool>(stream);
     ASSERT_FALSE(res);
     ASSERT_EQ(res.error().value(),
-              static_cast<int>(DecodeError::kNotEnoughData));
+              static_cast<int>(DecodeError::NOT_ENOUGH_DATA));
   }
 }
 

--- a/test/core/scale/scale_pair_test.cpp
+++ b/test/core/scale/scale_pair_test.cpp
@@ -1,0 +1,49 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include "common/result.hpp"
+#include "scale/byte_array_stream.hpp"
+#include "scale/type_decoder.hpp"
+#include "scale/type_encoder.hpp"
+
+using kagome::common::Buffer;
+using kagome::common::ByteStream;
+using kagome::scale::ByteArray;
+using kagome::scale::ByteArrayStream;
+
+/**
+ * @given pair of values of different types: uint8_t and uint32_t
+ * @when encode is applied
+ * @then obtained serialized value meets predefined one
+ */
+TEST(Scale, encodePair) {
+  uint8_t v1 = 1;
+  uint32_t v2 = 1;
+  using Pair = std::pair<uint8_t, uint32_t>;
+  kagome::scale::TypeEncoder<Pair> encoder;
+  Buffer out;
+  auto &&res = encoder.encode(std::make_pair(v1, v2), out);
+  ASSERT_TRUE(res);
+  ASSERT_EQ(out.toVector(), (std::vector<uint8_t>{1, 1, 0, 0, 0}));
+}
+
+/**
+ * @given byte sequence containign 2 encoded values of
+ * different types: uint8_t and uint32_t
+ * @when decode is applied
+ * @then obtained pair mathces predefined one
+ */
+TEST(Scale, decodePair) {
+  ByteArray bytes = {1, 1, 0, 0, 0};
+  auto stream = ByteArrayStream{bytes};
+  using Pair = std::pair<uint8_t, uint32_t>;
+  kagome::scale::TypeDecoder<Pair> decoder;
+  auto &&res = decoder.decode(stream);
+  ASSERT_TRUE(res);
+  ASSERT_EQ(res.value().first, 1);
+  ASSERT_EQ(res.value().second, 1);
+}

--- a/test/core/scale/scale_pair_test.cpp
+++ b/test/core/scale/scale_pair_test.cpp
@@ -4,7 +4,6 @@
  */
 
 #include <gtest/gtest.h>
-
 #include "common/result.hpp"
 #include "scale/byte_array_stream.hpp"
 #include "scale/type_decoder.hpp"

--- a/test/core/scale/scale_variant_test.cpp
+++ b/test/core/scale/scale_variant_test.cpp
@@ -3,30 +3,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "scale/variant.hpp"
 #include <gtest/gtest.h>
-
 #include "common/result.hpp"
 #include "scale/byte_array_stream.hpp"
-#include "scale/variant.hpp"
 
-#include <boost/variant/get.hpp>
 
-using namespace kagome::common;  // NOLINT
-using namespace kagome::scale;   // NOLINT
+using kagome::common::Buffer;
+using kagome::scale::ByteArrayStream;
+using kagome::scale::variant::encodeVariant;
+using kagome::scale::variant::decodeVariant;
 
 TEST(Scale, encodeVariant) {
   {
-    std::variant<uint8_t, uint32_t> v = static_cast<uint8_t>(1);
+    boost::variant<uint8_t, uint32_t> v = static_cast<uint8_t>(1);
     Buffer out;
-    auto &&res = variant::encodeVariant(v, out);
+    auto &&res = encodeVariant(v, out);
     ASSERT_TRUE(res);
     Buffer match = {0, 1};
     ASSERT_EQ(out, match);
   }
   {
-    std::variant<uint8_t, uint32_t> v = static_cast<uint32_t>(1);
+    boost::variant<uint8_t, uint32_t> v = static_cast<uint32_t>(1);
     Buffer out;
-    auto &&res = variant::encodeVariant(v, out);
+    auto &&res = encodeVariant(v, out);
     ASSERT_TRUE(res);
     Buffer match = {1, 1, 0, 0, 0};
     ASSERT_EQ(out, match);
@@ -38,14 +38,14 @@ TEST(Scale, decodeVariant) {
                   1, 1, 0, 0, 0};  // uint32_t{1}
 
   auto stream = ByteArrayStream{match};
-  auto &&res = variant::decodeVariant<uint8_t, uint32_t>(stream);
+  auto &&res = decodeVariant<uint8_t, uint32_t>(stream);
   ASSERT_TRUE(res);
   auto &&val = res.value();
-  ASSERT_TRUE(std::holds_alternative<uint8_t>(val));
-  ASSERT_EQ(*std::get_if<uint8_t>(&val), 1);
 
-  auto &&res1 = variant::decodeVariant<uint8_t, uint32_t>(stream);
+  kagome::visit_in_place(val, [](uint8_t v) {ASSERT_EQ(v, 1);}, [](uint32_t v) {FAIL();});
+
+  auto &&res1 = decodeVariant<uint8_t, uint32_t>(stream);
   auto &&val1 = res1.value();
-  ASSERT_TRUE(std::holds_alternative<uint32_t>(val1));
-  ASSERT_EQ(*std::get_if<uint32_t>(&val1), 1);
+
+  kagome::visit_in_place(val1, [](uint32_t v) {ASSERT_EQ(v, 1);}, [](uint8_t v) {FAIL();});
 }

--- a/test/core/scale/scale_variant_test.cpp
+++ b/test/core/scale/scale_variant_test.cpp
@@ -3,16 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "scale/variant.hpp"
 #include <gtest/gtest.h>
 #include "common/result.hpp"
 #include "scale/byte_array_stream.hpp"
-
+#include "scale/variant.hpp"
 
 using kagome::common::Buffer;
 using kagome::scale::ByteArrayStream;
-using kagome::scale::variant::encodeVariant;
 using kagome::scale::variant::decodeVariant;
+using kagome::scale::variant::encodeVariant;
 
 TEST(Scale, encodeVariant) {
   {
@@ -42,10 +41,12 @@ TEST(Scale, decodeVariant) {
   ASSERT_TRUE(res);
   auto &&val = res.value();
 
-  kagome::visit_in_place(val, [](uint8_t v) {ASSERT_EQ(v, 1);}, [](uint32_t v) {FAIL();});
+  kagome::visit_in_place(
+      val, [](uint8_t v) { ASSERT_EQ(v, 1); }, [](uint32_t v) { FAIL(); });
 
   auto &&res1 = decodeVariant<uint8_t, uint32_t>(stream);
   auto &&val1 = res1.value();
 
-  kagome::visit_in_place(val1, [](uint32_t v) {ASSERT_EQ(v, 1);}, [](uint8_t v) {FAIL();});
+  kagome::visit_in_place(
+      val1, [](uint32_t v) { ASSERT_EQ(v, 1); }, [](uint8_t v) { FAIL(); });
 }


### PR DESCRIPTION
Version, BlockId, TransactionValidity

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Implemented new methods in ScaleCodec for serializing and deserializing new primitives: Version, BlockId, TransactionValidity.
Added TypeEncoder and TypeDecoder for std::pair, and type encoders and decoders for custom types used as members in primitives above.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
ScaleCodec now allows working with new primitives.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->