### PR TITLE
Whitelist all builds except feature builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ language: cpp
 git:
   depth: 1
 
+branches:
+  except:
+    - /^feature.*/
+
 env:
   global:
     - CTEST_OUTPUT_ON_FAILURE=1


### PR DESCRIPTION
Enable travis-ci on master, after merge.

So, basically all push builds now are enabled for all branches that do not start with `feature`. Feature branches should be built only for PRs.