### PR TITLE
[PRE-131] Fix types of BlockHeader fields

### DIFF
--- a/core/primitives/block_header.cpp
+++ b/core/primitives/block_header.cpp
@@ -6,18 +6,19 @@
 #include "primitives/block_header.hpp"
 
 using kagome::common::Buffer;
+using kagome::common::Hash256;
 
 namespace kagome::primitives {
 
-  BlockHeader::BlockHeader(Buffer parent_hash, size_t number, Buffer state_root,
-                           Buffer extrinsics_root, Buffer digest)
+  BlockHeader::BlockHeader(Hash256 parent_hash, size_t number, Hash256 state_root,
+                           Hash256 extrinsics_root, Buffer digest)
       : parent_hash_(std::move(parent_hash)),
         number_(number),
         state_root_(std::move(state_root)),
         extrinsics_root_(std::move(extrinsics_root)),
         digest_(std::move(digest)) {}
 
-  const Buffer &BlockHeader::parentHash() const {
+  const Hash256 &BlockHeader::parentHash() const {
     return parent_hash_;
   }
 
@@ -25,13 +26,14 @@ namespace kagome::primitives {
     return number_;
   }
 
-  const Buffer &BlockHeader::stateRoot() const {
+  const Hash256 &BlockHeader::stateRoot() const {
     return state_root_;
   }
 
-  const Buffer &BlockHeader::extrinsicsRoot() const {
+  const Hash256 &BlockHeader::extrinsicsRoot() const {
     return extrinsics_root_;
   }
+
   const Buffer &BlockHeader::digest() const {
     return digest_;
   }

--- a/core/primitives/block_header.hpp
+++ b/core/primitives/block_header.hpp
@@ -6,7 +6,7 @@
 #ifndef KAGOME_PRIMITIVES_BLOCK_HEADER_HPP
 #define KAGOME_PRIMITIVES_BLOCK_HEADER_HPP
 
-#include <common/blob.hpp>
+#include "common/blob.hpp"
 #include "common/buffer.hpp"
 #include "primitives/common.hpp"
 

--- a/core/primitives/block_header.hpp
+++ b/core/primitives/block_header.hpp
@@ -6,6 +6,7 @@
 #ifndef KAGOME_PRIMITIVES_BLOCK_HEADER_HPP
 #define KAGOME_PRIMITIVES_BLOCK_HEADER_HPP
 
+#include <common/blob.hpp>
 #include "common/buffer.hpp"
 #include "primitives/common.hpp"
 
@@ -24,13 +25,13 @@ namespace kagome::primitives {
      * @param extrinsics_root extrinsics root
      * @param digest digest collection
      */
-    BlockHeader(Buffer parent_hash, size_t number, Buffer state_root,
-                Buffer extrinsics_root, Buffer digest);
+    BlockHeader(common::Hash256 parent_hash, size_t number, common::Hash256 state_root,
+                common::Hash256 extrinsics_root, Buffer digest);
 
     /**
      * @return parent hash const reference
      */
-    const Buffer &parentHash() const;
+    const common::Hash256 &parentHash() const;
 
     /**
      * @return number
@@ -40,12 +41,12 @@ namespace kagome::primitives {
     /**
      * @return state root const reference
      */
-    const Buffer &stateRoot() const;
+    const common::Hash256 &stateRoot() const;
 
     /**
      * @return extrinsics root const reference
      */
-    const Buffer &extrinsicsRoot() const;
+    const common::Hash256 &extrinsicsRoot() const;
 
     /**
      * @return digest const reference
@@ -53,10 +54,10 @@ namespace kagome::primitives {
     const Buffer &digest() const;
 
    private:
-    Buffer parent_hash_;  ///< 32-byte Blake2s hash of the header of the parent
+    common::Hash256 parent_hash_;  ///< 32-byte Blake2s hash of the header of the parent
     BlockNumber number_;  ///< index of current block in the chain
-    Buffer state_root_;    ///< root of the Merkle trie
-    Buffer extrinsics_root_;  ///< field for validation integrity
+    common::Hash256 state_root_;    ///< root of the Merkle trie
+    common::Hash256 extrinsics_root_;  ///< field for validation integrity
     Buffer digest_;           ///< chain-specific auxiliary data
   };
 

--- a/core/primitives/impl/scale_codec_impl.cpp
+++ b/core/primitives/impl/scale_codec_impl.cpp
@@ -23,7 +23,7 @@ namespace kagome::scale {
     outcome::result<void> encode(const std::array<T, sz> &array,
                                  common::Buffer &out) {
       for (int i = 0; i < sz; i++) {
-        fixedwidth::encodeUInt8(array[i], out);
+        fixedwidth::encodeUInt8(gsl::at(array, i), out);
       }
       return outcome::success();
     }

--- a/test/core/primitives/primitives_codec_test.cpp
+++ b/test/core/primitives/primitives_codec_test.cpp
@@ -58,10 +58,10 @@ class Primitives : public testing::Test {
   Buffer encoded_header_ = [](){
     Buffer h;
     // SCALE-encoded
-    h.putUint8(128).put(std::vector<uint8_t>(32, 0)); // parent_hash: hash256 with value 0
+    h.put(std::vector<uint8_t>(32, 0)); // parent_hash: hash256 with value 0
     h.putUint8(2).put(std::vector<uint8_t>(7, 0)); // number: 2
-    h.putUint8(128).putUint8(1).put(std::vector<uint8_t>(31, 0)); // state_root: hash256 with value 1
-    h.putUint8(128).putUint8(2).put(std::vector<uint8_t>(31, 0)); // extrinsic_root: hash256 with value 2
+    h.putUint8(1).put(std::vector<uint8_t>(31, 0)); // state_root: hash256 with value 1
+    h.putUint8(2).put(std::vector<uint8_t>(31, 0)); // extrinsic_root: hash256 with value 2
     h.putUint8(4).putUint8(5); // digest: buffer with element 5
     return h;
   }();
@@ -90,9 +90,9 @@ class Primitives : public testing::Test {
       1,  0,   0,   0,                             // auth version
       2,  0,   0,   0,                             // impl version
       8,                                           // collection of 2 items
-      32, '1', '2', '3', '4', '5', '6', '7', '8',  // id1
+      '1', '2', '3', '4', '5', '6', '7', '8',  // id1
       1,  0,   0,   0,                             // id1 version
-      32, '8', '7', '6', '5', '4', '3', '2', '1',  // id2
+      '8', '7', '6', '5', '4', '3', '2', '1',  // id2
       2,  0,   0,   0,                             // id2 version
   };
   /// block id variant number alternative and corresponding scale representation
@@ -102,7 +102,6 @@ class Primitives : public testing::Test {
   BlockId block_id_hash_;
   Buffer encoded_block_id_hash_{
       0,    // variant type order
-      128,  // collection size compact-encoded = 32 << 2 + 0x00
       0x0,  0x1,  0x2,  0x3,  0x4,  0x5,  0x6,  0x7,  0x8,  0x9,  0xA,
       0xB,  0xC,  0xD,  0xE,  0xF,  0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
       0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F};

--- a/test/core/primitives/primitives_codec_test.cpp
+++ b/test/core/primitives/primitives_codec_test.cpp
@@ -14,6 +14,7 @@
 #include "scale/byte_array_stream.hpp"
 
 using kagome::common::Buffer;
+using kagome::common::Hash256;
 using kagome::primitives::Block;
 using kagome::primitives::BlockHeader;
 using kagome::primitives::BlockId;
@@ -27,12 +28,19 @@ using kagome::primitives::Valid;
 using kagome::primitives::Version;
 using kagome::scale::ByteArrayStream;
 
+Hash256 createHash(std::initializer_list<uint8_t> bytes) {
+  Hash256 h;
+  h.fill(0);
+  std::copy(bytes.begin(), bytes.end(), h.begin());
+  return h;
+}
+
 /**
  * @class Primitives is a test fixture which contains useful data
  */
 class Primitives : public testing::Test {
   void SetUp() override {
-    block_id_hash_ = kagome::common::Hash256::fromHex(
+    block_id_hash_ = Hash256::fromHex(
                          "000102030405060708090A0B0C0D0E0F"
                          "101112131415161718191A1B1C1D1E1F")
                          .value();
@@ -42,17 +50,17 @@ class Primitives : public testing::Test {
 
  protected:
   /// block header and corresponding scale representation
-  BlockHeader block_header_{{1},   // buffer: parent_hash
+  BlockHeader block_header_{createHash({0}),   // parent_hash
                             2,     // number: number
-                            {3},   // buffer: state_root
-                            {4},   // buffer: extrinsic root
+                            createHash({1}),   // state_root
+                            createHash({2}),   // extrinsic root
                             {5}};  // buffer: digest;
   Buffer encoded_header_{
-      4, 1,                    // {1}
-      2, 0, 0, 0, 0, 0, 0, 0,  // 2 as uint64
-      4, 3,                    // {3}
-      4, 4,                    // {4}
-      4, 5                     // {5}
+      128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      2, 0, 0, 0, 0, 0, 0, 0,
+      128, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      128, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      4, 5
   };
   /// Extrinsic instance and corresponding scale representation
   Extrinsic extrinsic_{{12,  /// sequence of 3 bytes: 1, 2, 3; 12 == (3 << 2)
@@ -60,13 +68,9 @@ class Primitives : public testing::Test {
   Buffer encoded_extrinsic_{12, 1, 2, 3};
   /// block instance and corresponding scale representation
   Block block_{block_header_, {extrinsic_}};
-  Buffer encoded_block_{4,  1,                    // {1}
-                        2,  0, 0, 0, 0, 0, 0, 0,  // 2 as uint64
-                        4,  3,                    // {3}
-                        4,  4,                    // {4}
-                        4,  5,                    // {5}
+  Buffer encoded_block_ = Buffer(encoded_header_).putBuffer({
                         4,             // (1 << 2) number of extrinsics
-                        12, 1, 2, 3};  // extrinsic itself {1, 2, 3}
+                        12, 1, 2, 3});  // extrinsic itself {1, 2, 3}
   /// Version instance and corresponding scale representation
   Version version_{
       "qwe",                                           // spec name


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Change type of several elements in BlockHeader from Buffer to Hash256, modify SCALE codec accordingly.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Consistency with PRE specification.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Encoded header takes significantly more space, as a hash is always 256 bit long, while buffer was dynamic.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
