### PR TITLE
Add ufiber

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "sml"]
 	path = deps/sml
 	url = https://github.com/boost-experimental/sml
+[submodule "ufiber"]
+	path = deps/ufiber
+	url = https://github.com/djarek/ufiber/

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -7,8 +7,8 @@ find_package(GTest CONFIG REQUIRED)
 find_package(GMock CONFIG REQUIRED)
 
 # https://docs.hunter.sh/en/latest/packages/pkg/Boost.html
-hunter_add_package(Boost COMPONENTS random filesystem system context fiber)
-find_package(Boost CONFIG REQUIRED  random filesystem system context fiber)
+hunter_add_package(Boost COMPONENTS random filesystem system context)
+find_package(Boost CONFIG REQUIRED  random filesystem system context)
 
 ## TODO: uncomment when it is really needed
 ## https://docs.hunter.sh/en/latest/packages/pkg/libjson-rpc-cpp.html

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -2,3 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(outcome)
+
+########
+# ufiber
+add_library(ufiber INTERFACE)
+find_package(Threads REQUIRED)
+target_include_directories(ufiber INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/ufiber/include>
+    $<INSTALL_INTERFACE:include>)
+target_link_libraries(ufiber INTERFACE
+    Boost::boost
+    Boost::context
+    Threads::Threads
+    )
+########


### PR DESCRIPTION
Signed-off-by: Bogdan Vaneev <warchantua@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

Remove boost.fiber. The library is good but it turned out that integration with asio is pretty bad. Some implications of using boost.fiber:
- io_context::run_one(), run_for(), and similar will not work as intended - they will be working in the same way as run(); so testing would become pain.
- unability to run io_context::run on multiple threads

Instead, tiny library [ufiber](https://github.com/djarek/ufiber/) will be used. It solves above problems and perfectly fit for our use-case.  

### Benefits

<!-- What benefits will be realized by the code change? -->

PRE-173 is completed.

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

None.

### Usage Examples or Tests *[optional]*

See https://github.com/djarek/ufiber/blob/master/examples/echo.cpp

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
