### PR TITLE
Deduplicate cargo install in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,6 @@ matrix:
         - export CC=${_CC}
         - export CXX=${_CXX}
         - export PATH="$HOME/.cargo/bin:$PATH"
-        - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
-        - rustup install nightly
-        - rustup default nightly
         - cmake . -Bbuild -DCOVERAGE=${COVERAGE:OFF}
         - cmake --build build -- -j2
         - cmake --build build --target test
@@ -93,7 +90,7 @@ matrix:
         - sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-8 90
         - gcov --version || true
         - cmake --build build --target ctest_coverage
-        - bash <(curl -s https://codecov.io/bash) -s build 2>/dev/null
+        - bash <(curl -s https://codecov.io/bash) -s build 2>&1 | grep -v "arcs"
 
 
     - os: linux
@@ -127,6 +124,10 @@ install:
         pip3 install --user pyyaml
       fi
     pip3 install --user --upgrade requests gitpython cmake gcovr
+  - export PATH="$HOME/.cargo/bin:$PATH"
+  - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
+  - rustup install nightly
+  - rustup default nightly
 
 before_script:
   - cmake --version
@@ -140,9 +141,6 @@ script:
   - export CC=${_CC}
   - export CXX=${_CXX}
   - export PATH="$HOME/.cargo/bin:$PATH"
-  - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
-  - rustup install nightly
-  - rustup default nightly
   - cmake . -Bbuild -DCOVERAGE=${COVERAGE:OFF}
   - cmake --build build -- -j2
   - cmake --build build --target test

--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -4,10 +4,12 @@ include(cmake/3rdparty/CodeCoverage.cmake)
 
 append_coverage_compiler_flags()
 
+
 set(COVERAGE_LCOV_EXCLUDES
     'deps/*'
     'build/*'
     )
+set(COVERAGE_GCOVR_EXCLUDES ${COVERAGE_LCOV_EXCLUDES})
 
 setup_target_for_coverage_gcovr_xml(
     NAME ctest_coverage                    # New target name


### PR DESCRIPTION
Some small fixes in travis:

- deduplicate cargo installation
- try remove stderr silencing from cooverage submission (this *may* influence coverage)