### PR TITLE
Make sr25519-crust external project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "sml"]
 	path = deps/sml
 	url = https://github.com/boost-experimental/sml
-[submodule "deps/sr25519-crust"]
-	path = deps/sr25519-crust
-	url = https://github.com/Warchant/sr25519-crust.git
 [submodule "ufiber"]
 	path = deps/ufiber
 	url = https://github.com/djarek/ufiber/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ HunterGate(
 
 PROJECT(kagome C CXX)
 
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_SOURCE_DIR}/cmake/Modules")
+
 include(CheckCXXCompilerFlag)
 include(cmake/dependencies.cmake)
 include(cmake/functions.cmake)

--- a/cmake/Modules/Findsr25519-crust.cmake
+++ b/cmake/Modules/Findsr25519-crust.cmake
@@ -1,0 +1,31 @@
+add_library(sr25519 UNKNOWN IMPORTED)
+
+set(URL https://github.com/Warchant/sr25519-crust)
+set(VERSION 4f430f55b7418a14de116cf173f972d1b23e0181)
+
+externalproject_add(warchant_sr25519_crust
+    GIT_REPOSITORY ${URL}
+    GIT_TAG        ${VERSION}
+    CMAKE_ARGS
+      -DTESTING=OFF
+      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+      -DBUILD_SHARED_LIBS=FALSE
+    PATCH_COMMAND   ""
+    INSTALL_COMMAND "" # remove install step
+    TEST_COMMAND    "" # remove test step
+    UPDATE_COMMAND  "" # remove update step
+    )
+
+externalproject_get_property(warchant_sr25519_crust binary_dir)
+externalproject_get_property(warchant_sr25519_crust source_dir)
+set(sr25519_INCLUDE_DIR ${source_dir}/include)
+set(sr25519_LIBRARY ${binary_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}sr25519${CMAKE_STATIC_LIBRARY_SUFFIX})
+file(MAKE_DIRECTORY ${sr25519_INCLUDE_DIR})
+link_directories(${binary_dir})
+
+add_dependencies(sr25519 warchant_sr25519_crust)
+
+set_target_properties(sr25519 PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES ${sr25519_INCLUDE_DIR}
+    IMPORTED_LOCATION ${sr25519_LIBRARY}
+    )

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,3 +1,7 @@
+## other Modules
+include(ExternalProject)
+find_package(sr25519-crust REQUIRED)
+
 # hunter dependencies
 # https://docs.hunter.sh/en/latest/packages/
 

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(outcome)
-add_subdirectory(sr25519-crust)
 
 ########
 # ufiber


### PR DESCRIPTION
Make sr25519-crust external project instead of submodule.
This prevents tests building of sr25519 and speeds up compilation