### PR TITLE
Libp2p Upgrader

### DIFF
--- a/core/libp2p/CMakeLists.txt
+++ b/core/libp2p/CMakeLists.txt
@@ -34,4 +34,5 @@ target_link_libraries(libp2p
     libp2p_inmem_protocol_repository
     security_plaintext
     libp2p_yamux
+    libp2p_upgrader
     )

--- a/core/libp2p/basic/adaptor.hpp
+++ b/core/libp2p/basic/adaptor.hpp
@@ -1,0 +1,28 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_ADAPTOR_HPP
+#define KAGOME_ADAPTOR_HPP
+
+#include "libp2p/peer/protocol.hpp"
+
+namespace libp2p::basic {
+  /**
+   * Base class of adaptor - entity, which encapsulates logic of upgrading the
+   * connection
+   */
+  struct Adaptor {
+    virtual ~Adaptor() = default;
+
+    /**
+     * Get a string identifier, associated with this adaptor
+     * @return protocol id of the adaptor
+     * @example '/yamux/1.0.0' or '/plaintext/1.5.0'
+     */
+    virtual peer::Protocol getProtocolId() const = 0;
+  };
+}  // namespace libp2p::basic
+
+#endif  // KAGOME_ADAPTOR_HPP

--- a/core/libp2p/basic/readwritecloser.hpp
+++ b/core/libp2p/basic/readwritecloser.hpp
@@ -7,12 +7,11 @@
 #define KAGOME_READWRITECLOSER_HPP
 
 #include "libp2p/basic/closeable.hpp"
-#include "libp2p/basic/reader.hpp"
-#include "libp2p/basic/writer.hpp"
+#include "libp2p/basic/readwriter.hpp"
 
 namespace libp2p::basic {
 
-  struct ReadWriteCloser : public Reader, public Writer, public Closeable {
+  struct ReadWriteCloser : public ReadWriter, public Closeable {
     ~ReadWriteCloser() override = default;
   };
 

--- a/core/libp2p/basic/readwriter.hpp
+++ b/core/libp2p/basic/readwriter.hpp
@@ -1,0 +1,18 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_READWRITER_HPP
+#define KAGOME_READWRITER_HPP
+
+#include "libp2p/basic/reader.hpp"
+#include "libp2p/basic/writer.hpp"
+
+namespace libp2p::basic {
+  struct ReadWriter : public Reader, public Writer {
+    ~ReadWriter() override = default;
+  };
+}  // namespace libp2p::basic
+
+#endif  // KAGOME_READWRITER_HPP

--- a/core/libp2p/config.hpp
+++ b/core/libp2p/config.hpp
@@ -17,6 +17,7 @@
 #include "libp2p/muxer/muxer_adaptor.hpp"
 #include "libp2p/peer/peer_id.hpp"
 #include "libp2p/peer/peer_repository.hpp"
+#include "libp2p/protocol_muxer/protocol_muxer.hpp"
 #include "libp2p/routing/routing_adaptor.hpp"
 #include "libp2p/security/security_adaptor.hpp"
 #include "libp2p/transport/transport.hpp"
@@ -53,6 +54,7 @@ namespace libp2p {
 
     detail::sptr<boost::asio::execution_context> context;
     detail::sptr<boost::asio::io_context::executor_type> executor;
+    detail::sptr<protocol_muxer::ProtocolMuxer> protocol_muxer;
     detail::sptr<transport::Upgrader> upgrader;
 
     bool enable_ping = true;

--- a/core/libp2p/connection/plaintext/plaintext.cpp
+++ b/core/libp2p/connection/plaintext/plaintext.cpp
@@ -9,7 +9,7 @@ OUTCOME_CPP_DEFINE_CATEGORY(libp2p::connection, PlaintextConnection::Error, e) {
   using E = libp2p::connection::PlaintextConnection::Error;
   switch (e) {
     case E::FIELD_IS_UNSUPPORTED:
-      return "this field is not supported in this connection implementation";
+      return "this field is either not supported or not set in this connection";
   }
   return "unknown error";
 }
@@ -19,11 +19,19 @@ namespace libp2p::connection {
       std::shared_ptr<RawConnection> raw_connection)
       : raw_connection_{std::move(raw_connection)} {}
 
+  PlaintextConnection::PlaintextConnection(
+      std::shared_ptr<RawConnection> raw_connection, peer::PeerId peer_id)
+      : raw_connection_{std::move(raw_connection)},
+        peer_id_{std::move(peer_id)} {}
+
   outcome::result<peer::PeerId> PlaintextConnection::localPeer() const {
     return Error::FIELD_IS_UNSUPPORTED;
   }
 
   outcome::result<peer::PeerId> PlaintextConnection::remotePeer() const {
+    if (peer_id_) {
+      return *peer_id_;
+    }
     return Error::FIELD_IS_UNSUPPORTED;
   }
 

--- a/core/libp2p/connection/plaintext/plaintext.hpp
+++ b/core/libp2p/connection/plaintext/plaintext.hpp
@@ -7,6 +7,7 @@
 #define KAGOME_PLAINTEXT_CONNECTION_HPP
 
 #include <memory>
+#include <optional>
 
 #include "libp2p/connection/secure_connection.hpp"
 
@@ -20,6 +21,9 @@ namespace libp2p::connection {
      * @param raw_connection, over which the security is to be established
      */
     explicit PlaintextConnection(std::shared_ptr<RawConnection> raw_connection);
+
+    PlaintextConnection(std::shared_ptr<RawConnection> raw_connection,
+                        peer::PeerId peer_id);
 
     ~PlaintextConnection() override = default;
 
@@ -55,6 +59,8 @@ namespace libp2p::connection {
 
    private:
     std::shared_ptr<RawConnection> raw_connection_;
+
+    std::optional<peer::PeerId> peer_id_;
   };
 }  // namespace libp2p::connection
 

--- a/core/libp2p/connection/stream.hpp
+++ b/core/libp2p/connection/stream.hpp
@@ -7,8 +7,7 @@
 #define KAGOME_CONNECTION_STREAM_HPP
 
 #include <outcome/outcome.hpp>
-#include "libp2p/basic/reader.hpp"
-#include "libp2p/basic/writer.hpp"
+#include "libp2p/basic/readwriter.hpp"
 
 namespace libp2p::connection {
 
@@ -25,7 +24,7 @@ namespace libp2p::connection {
    * possibility to read and write simultaneously, but double read or write is
    * forbidden
    */
-  struct Stream : public basic::Reader, public basic::Writer {
+  struct Stream : public basic::ReadWriter {
     using Handler = void(std::shared_ptr<Stream>);
     using VoidResultHandlerFunc = std::function<void(outcome::result<void>)>;
 

--- a/core/libp2p/host_builder.cpp
+++ b/core/libp2p/host_builder.cpp
@@ -14,8 +14,10 @@
 #include "libp2p/peer/address_repository/inmem_address_repository.hpp"
 #include "libp2p/peer/key_repository/inmem_key_repository.hpp"
 #include "libp2p/peer/protocol_repository/inmem_protocol_repository.hpp"
+#include "libp2p/protocol_muxer/multiselect.hpp"
 #include "libp2p/routing/routing_impl.hpp"
 #include "libp2p/security/plaintext.hpp"
+#include "libp2p/transport/impl/upgrader_impl.hpp"
 #include "libp2p/transport/tcp.hpp"
 
 namespace {
@@ -162,9 +164,6 @@ namespace libp2p {
               io_context->get_executor());
     }
 
-    // TODO(warchant): replace with real implementation PRE-149
-    //    config_.upgrader = std::make_shared<transport::UpgraderMock>();
-
     if (config_.transports.empty()) {
       //      using E = std::decay_t<decltype(*config_.executor)>;
       //      config_.transports.push_back(std::make_shared<transport::TcpTransport<E>>(
@@ -182,6 +181,11 @@ namespace libp2p {
     if (config_.securities.empty()) {
       config_.securities.push_back(std::make_shared<security::Plaintext>());
     }
+
+    config_.protocol_muxer = std::make_shared<protocol_muxer::Multiselect>();
+
+    config_.upgrader = std::make_shared<transport::UpgraderImpl>(
+        peer_id, config_.protocol_muxer, config_.securities, config_.muxers);
 
     return Host{config_, std::move(peer_id)};
   }

--- a/core/libp2p/host_builder.cpp
+++ b/core/libp2p/host_builder.cpp
@@ -14,11 +14,12 @@
 #include "libp2p/peer/address_repository/inmem_address_repository.hpp"
 #include "libp2p/peer/key_repository/inmem_key_repository.hpp"
 #include "libp2p/peer/protocol_repository/inmem_protocol_repository.hpp"
-#include "libp2p/protocol_muxer/multiselect.hpp"
 #include "libp2p/routing/routing_impl.hpp"
 #include "libp2p/security/plaintext.hpp"
 #include "libp2p/transport/impl/upgrader_impl.hpp"
 #include "libp2p/transport/tcp.hpp"
+// TODO(akvinikym) PRE-215 27.06.19: revert multiselect
+//#include "libp2p/protocol_muxer/multiselect.hpp"
 
 namespace {
   /**
@@ -182,7 +183,9 @@ namespace libp2p {
       config_.securities.push_back(std::make_shared<security::Plaintext>());
     }
 
-    config_.protocol_muxer = std::make_shared<protocol_muxer::Multiselect>();
+    // TODO(akvinikym) PRE-215 27.06.19: revert multiselect
+    //    config_.protocol_muxer =
+    //    std::make_shared<protocol_muxer::Multiselect>();
 
     config_.upgrader = std::make_shared<transport::UpgraderImpl>(
         peer_id, config_.protocol_muxer, config_.securities, config_.muxers);

--- a/core/libp2p/muxer/muxer_adaptor.hpp
+++ b/core/libp2p/muxer/muxer_adaptor.hpp
@@ -9,31 +9,26 @@
 #include <memory>
 
 #include <outcome/outcome.hpp>
+#include "libp2p/basic/adaptor.hpp"
 #include "libp2p/connection/capable_connection.hpp"
 #include "libp2p/connection/secure_connection.hpp"
-#include "libp2p/peer/protocol.hpp"
 
 namespace libp2p::muxer {
   /**
    * Strategy to upgrade connections to muxed
    */
-  struct MuxerAdaptor {
-    virtual ~MuxerAdaptor() = default;
-
-    /**
-     * Get a string identifier, associated with this adaptor
-     * @return protocol id of the adaptor
-     * @example '/yamux/1.0.0'
-     */
-    virtual peer::Protocol getProtocolId() const = 0;
+  struct MuxerAdaptor : public basic::Adaptor {
+    using CapConnCallbackFunc = std::function<void(
+        outcome::result<std::shared_ptr<connection::CapableConnection>>)>;
 
     /**
      * Make a muxed connection from the secure one, using this adaptor
      * @param conn - connection to be upgraded
-     * @return upgraded connection or error
+     * @param cb - callback with an upgraded connection or error
      */
-    virtual outcome::result<std::shared_ptr<connection::CapableConnection>>
-    muxConnection(std::shared_ptr<connection::SecureConnection> conn) const = 0;
+    virtual void muxConnection(
+        std::shared_ptr<connection::SecureConnection> conn,
+        CapConnCallbackFunc cb) const = 0;
   };
 }  // namespace libp2p::muxer
 

--- a/core/libp2p/muxer/yamux/yamux.cpp
+++ b/core/libp2p/muxer/yamux/yamux.cpp
@@ -14,10 +14,9 @@ namespace libp2p::muxer {
     return "/yamux/1.0.0";
   }
 
-  outcome::result<std::shared_ptr<connection::CapableConnection>>
-  Yamux::muxConnection(
-      std::shared_ptr<connection::SecureConnection> conn) const {
-    return std::make_shared<connection::YamuxedConnection>(std::move(conn),
-                                                           config_);
+  void Yamux::muxConnection(std::shared_ptr<connection::SecureConnection> conn,
+                            CapConnCallbackFunc cb) const {
+    cb(std::make_shared<connection::YamuxedConnection>(std::move(conn),
+                                                       config_));
   }
 }  // namespace libp2p::muxer

--- a/core/libp2p/muxer/yamux/yamux.hpp
+++ b/core/libp2p/muxer/yamux/yamux.hpp
@@ -22,9 +22,8 @@ namespace libp2p::muxer {
 
     peer::Protocol getProtocolId() const noexcept override;
 
-    outcome::result<std::shared_ptr<connection::CapableConnection>>
-    muxConnection(
-        std::shared_ptr<connection::SecureConnection> conn) const override;
+    void muxConnection(std::shared_ptr<connection::SecureConnection> conn,
+                       CapConnCallbackFunc cb) const override;
 
    private:
     MuxedConnectionConfig config_;

--- a/core/libp2p/protocol_muxer/protocol_muxer.hpp
+++ b/core/libp2p/protocol_muxer/protocol_muxer.hpp
@@ -10,7 +10,7 @@
 
 #include <gsl/span>
 #include <outcome/outcome.hpp>
-#include "libp2p/basic/readwritecloser.hpp"
+#include "libp2p/basic/readwriter.hpp"
 #include "libp2p/peer/protocol.hpp"
 
 namespace libp2p::protocol_muxer {
@@ -31,7 +31,7 @@ namespace libp2p::protocol_muxer {
      */
     virtual void selectOneOf(
         gsl::span<const peer::Protocol> protocols,
-        std::shared_ptr<basic::ReadWriteCloser> connection, bool is_initiator,
+        std::shared_ptr<basic::ReadWriter> connection, bool is_initiator,
         std::function<void(outcome::result<peer::Protocol>)> cb) const = 0;
 
     virtual ~ProtocolMuxer() = default;

--- a/core/libp2p/protocol_muxer/protocol_muxer.hpp
+++ b/core/libp2p/protocol_muxer/protocol_muxer.hpp
@@ -29,10 +29,10 @@ namespace libp2p::protocol_muxer {
      * taking lead in the Multiselect protocol; false otherwise
      * @return chosen protocol or error
      */
-    virtual outcome::result<peer::Protocol> selectOneOf(
+    virtual void selectOneOf(
         gsl::span<const peer::Protocol> protocols,
-        std::shared_ptr<basic::ReadWriteCloser> connection,
-        bool is_initiator) const = 0;
+        std::shared_ptr<basic::ReadWriteCloser> connection, bool is_initiator,
+        std::function<void(outcome::result<peer::Protocol>)> cb) const = 0;
 
     virtual ~ProtocolMuxer() = default;
   };

--- a/core/libp2p/security/plaintext/plaintext.cpp
+++ b/core/libp2p/security/plaintext/plaintext.cpp
@@ -13,16 +13,15 @@ namespace libp2p::security {
     return "/plaintext/1.0.0";
   }
 
-  outcome::result<std::shared_ptr<connection::SecureConnection>>
-  Plaintext::secureInbound(std::shared_ptr<connection::RawConnection> inbound) {
-    return std::make_shared<connection::PlaintextConnection>(
-        std::move(inbound));
+  void Plaintext::secureInbound(
+      std::shared_ptr<connection::RawConnection> inbound,
+      SecConnCallbackFunc cb) {
+    cb(std::make_shared<connection::PlaintextConnection>(std::move(inbound)));
   }
 
-  outcome::result<std::shared_ptr<connection::SecureConnection>>
-  Plaintext::secureOutbound(std::shared_ptr<connection::RawConnection> outbound,
-                            const peer::PeerId &) {
-    return std::make_shared<connection::PlaintextConnection>(
-        std::move(outbound));
+  void Plaintext::secureOutbound(
+      std::shared_ptr<connection::RawConnection> outbound, const peer::PeerId &,
+      SecConnCallbackFunc cb) {
+    cb(std::make_shared<connection::PlaintextConnection>(std::move(outbound)));
   }
 }  // namespace libp2p::security

--- a/core/libp2p/security/plaintext/plaintext.cpp
+++ b/core/libp2p/security/plaintext/plaintext.cpp
@@ -20,8 +20,9 @@ namespace libp2p::security {
   }
 
   void Plaintext::secureOutbound(
-      std::shared_ptr<connection::RawConnection> outbound, const peer::PeerId &,
-      SecConnCallbackFunc cb) {
-    cb(std::make_shared<connection::PlaintextConnection>(std::move(outbound)));
+      std::shared_ptr<connection::RawConnection> outbound,
+      const peer::PeerId &p, SecConnCallbackFunc cb) {
+    cb(std::make_shared<connection::PlaintextConnection>(std::move(outbound),
+                                                         p));
   }
 }  // namespace libp2p::security

--- a/core/libp2p/security/plaintext/plaintext.hpp
+++ b/core/libp2p/security/plaintext/plaintext.hpp
@@ -18,12 +18,11 @@ namespace libp2p::security {
 
     peer::Protocol getProtocolId() const override;
 
-    outcome::result<std::shared_ptr<connection::SecureConnection>>
-    secureInbound(std::shared_ptr<connection::RawConnection> inbound) override;
+    void secureInbound(std::shared_ptr<connection::RawConnection> inbound,
+                       SecConnCallbackFunc cb) override;
 
-    outcome::result<std::shared_ptr<connection::SecureConnection>>
-    secureOutbound(std::shared_ptr<connection::RawConnection> outbound,
-                   const peer::PeerId &p) override;
+    void secureOutbound(std::shared_ptr<connection::RawConnection> outbound,
+                        const peer::PeerId &p, SecConnCallbackFunc cb) override;
   };
 }  // namespace libp2p::security
 

--- a/core/libp2p/security/security_adaptor.hpp
+++ b/core/libp2p/security/security_adaptor.hpp
@@ -38,7 +38,6 @@ namespace libp2p::security {
      */
     virtual outcome::result<std::shared_ptr<connection::SecureConnection>>
     secureInbound(std::shared_ptr<connection::RawConnection> inbound) = 0;
-
     /**
      * @brief Secure the connection, either locally or by communicating with
      * opposing node via outbound connection (we are initiator).

--- a/core/libp2p/security/security_adaptor.hpp
+++ b/core/libp2p/security/security_adaptor.hpp
@@ -9,10 +9,10 @@
 #include <memory>
 
 #include <outcome/outcome.hpp>
+#include "libp2p/basic/adaptor.hpp"
 #include "libp2p/connection/raw_connection.hpp"
 #include "libp2p/connection/secure_connection.hpp"
 #include "libp2p/peer/peer_id.hpp"
-#include "libp2p/peer/protocol.hpp"
 
 namespace libp2p::security {
 
@@ -20,36 +20,31 @@ namespace libp2p::security {
    * @brief Adaptor, which is used as base class for all security modules (e.g.
    * SECIO, Noise, TLS...)
    */
-  struct SecurityAdaptor {
-    virtual ~SecurityAdaptor() = default;
-
-    /**
-     * @brief Returns a string-identifier, associated with this protocol.
-     * @example /tls/1.0.0
-     * (https://github.com/libp2p/go-libp2p-tls/blob/master/transport.go#L22)
-     */
-    virtual peer::Protocol getProtocolId() const = 0;
+  struct SecurityAdaptor : public basic::Adaptor {
+    using SecConnCallbackFunc = std::function<void(
+        outcome::result<std::shared_ptr<connection::SecureConnection>>)>;
 
     /**
      * @brief Secure the connection, either locally or by communicating with
      * opposing node via inbound connection (receid in listener).
      * @param inbound connection
-     * @return secured connection
+     * @param cb with secured connection or error
      */
-    virtual outcome::result<std::shared_ptr<connection::SecureConnection>>
-    secureInbound(std::shared_ptr<connection::RawConnection> inbound) = 0;
+    virtual void secureInbound(
+        std::shared_ptr<connection::RawConnection> inbound,
+        SecConnCallbackFunc cb) = 0;
+
     /**
      * @brief Secure the connection, either locally or by communicating with
      * opposing node via outbound connection (we are initiator).
      * @param outbound connection
      * @param p remote peer id, we want to establish a secure conn
-     * @return secured connection
+     * @param cb with secured connection or error
      */
-    virtual outcome::result<std::shared_ptr<connection::SecureConnection>>
-    secureOutbound(std::shared_ptr<connection::RawConnection> outbound,
-                   const peer::PeerId &p) = 0;
+    virtual void secureOutbound(
+        std::shared_ptr<connection::RawConnection> outbound,
+        const peer::PeerId &p, SecConnCallbackFunc cb) = 0;
   };
-
 }  // namespace libp2p::security
 
 #endif  // KAGOME_SECURITY_ADAPTOR_HPP

--- a/core/libp2p/transport/impl/CMakeLists.txt
+++ b/core/libp2p/transport/impl/CMakeLists.txt
@@ -16,6 +16,5 @@ add_library(libp2p_upgrader
     upgrader_impl.cpp
     )
 target_link_libraries(libp2p_upgrader
-    multiselect
     outcome
     )

--- a/core/libp2p/transport/impl/CMakeLists.txt
+++ b/core/libp2p/transport/impl/CMakeLists.txt
@@ -11,3 +11,11 @@ target_link_libraries(libp2p_transport_parser
     multiaddress
     )
 
+add_library(libp2p_upgrader
+    upgrader_impl.hpp
+    upgrader_impl.cpp
+    )
+target_link_libraries(libp2p_upgrader
+    multiselect
+    outcome
+    )

--- a/core/libp2p/transport/impl/upgrader_impl.cpp
+++ b/core/libp2p/transport/impl/upgrader_impl.cpp
@@ -1,0 +1,73 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "libp2p/transport/impl/upgrader_impl.hpp"
+
+#include <numeric>
+
+OUTCOME_CPP_DEFINE_CATEGORY(libp2p::transport, UpgraderImpl::Error, e) {
+  using E = libp2p::transport::UpgraderImpl::Error;
+  switch (e) {
+    case E::INTERNAL_ERROR:
+      return "internal error happened";
+  }
+  return "unknown error";
+}
+
+namespace libp2p::transport {
+  UpgraderImpl::UpgraderImpl(
+      peer::PeerId peer_id,
+      std::shared_ptr<protocol_muxer::ProtocolMuxer> protocol_muxer,
+      gsl::span<SecAdaptorSPtr> security_adaptors,
+      gsl::span<MuxAdaptorSPtr> muxer_adaptors)
+      : peer_id_{std::move(peer_id)},
+        protocol_muxer_{std::move(protocol_muxer)},
+        security_adaptors_{security_adaptors.begin(), security_adaptors.end()},
+        muxer_adaptors_{muxer_adaptors.begin(), muxer_adaptors.end()} {
+    // otherwise, we need to extract lists of supported protos every time
+    security_protocols_ = std::reduce(
+        security_adaptors_.begin(), security_adaptors_.end(),
+        std::vector<peer::Protocol>(),
+        [](const auto &adaptor) { return adaptor->getProtocolId(); });
+    muxer_protocols_ = std::reduce(
+        muxer_adaptors.begin(), muxer_adaptors.end(),
+        std::vector<peer::Protocol>(),
+        [](const auto &adaptor) { return adaptor->getProtocolId(); });
+  }
+
+  outcome::result<UpgraderImpl::SecureSPtr> UpgraderImpl::upgradeToSecure(
+      RawSPtr conn) {
+    auto initiator = conn->isInitiator();
+    OUTCOME_TRY(
+        selected_proto,
+        protocol_muxer_->selectOneOf(security_protocols_, conn, initiator));
+    if (auto adaptor =
+            std::find_if(security_adaptors_.begin(), security_adaptors_.end(),
+                         [&selected_proto](const auto &adaptor) {
+                           return selected_proto == adaptor->getProtocolId();
+                         });
+        adaptor != security_adaptors_.end()) {
+      return initiator ? (*adaptor)->secureOutbound(std::move(conn), peer_id_)
+                       : (*adaptor)->secureInbound(std::move(conn));
+    }
+    return Error::INTERNAL_ERROR;
+  }
+
+  outcome::result<UpgraderImpl::CapableSPtr> UpgraderImpl::upgradeToMuxed(
+      SecureSPtr conn) {
+    OUTCOME_TRY(selected_proto,
+                protocol_muxer_->selectOneOf(muxer_protocols_, conn,
+                                             conn->isInitiator()));
+    if (auto adaptor =
+            std::find_if(security_adaptors_.begin(), security_adaptors_.end(),
+                         [&selected_proto](const auto &adaptor) {
+                           return selected_proto == adaptor->getProtocolId();
+                         });
+        adaptor != security_adaptors_.end()) {
+      return (*adaptor)->mux(std::move(conn));
+    }
+    return Error::INTERNAL_ERROR;
+  }
+}  // namespace libp2p::transport

--- a/core/libp2p/transport/impl/upgrader_impl.cpp
+++ b/core/libp2p/transport/impl/upgrader_impl.cpp
@@ -29,12 +29,16 @@ namespace libp2p::transport {
     // otherwise, we need to extract lists of supported protos every time
     security_protocols_ = std::reduce(
         security_adaptors_.begin(), security_adaptors_.end(),
-        std::vector<peer::Protocol>(),
-        [](const auto &adaptor) { return adaptor->getProtocolId(); });
-    muxer_protocols_ = std::reduce(
-        muxer_adaptors.begin(), muxer_adaptors.end(),
-        std::vector<peer::Protocol>(),
-        [](const auto &adaptor) { return adaptor->getProtocolId(); });
+        std::vector<peer::Protocol>(), [](auto &&acc, const auto &adaptor) {
+          acc.push_back(adaptor->getProtocolId());
+          return acc;
+        });
+//    muxer_protocols_ = std::reduce(muxer_adaptors.begin(), muxer_adaptors.end(),
+//                                   std::vector<peer::Protocol>(),
+//                                   [](auto &&acc, const auto &adaptor) {
+//                                     acc.push_back(adaptor->getProtocolId());
+//                                     return acc;
+//                                   });
   }
 
   outcome::result<UpgraderImpl::SecureSPtr> UpgraderImpl::upgradeToSecure(
@@ -57,17 +61,19 @@ namespace libp2p::transport {
 
   outcome::result<UpgraderImpl::CapableSPtr> UpgraderImpl::upgradeToMuxed(
       SecureSPtr conn) {
-    OUTCOME_TRY(selected_proto,
-                protocol_muxer_->selectOneOf(muxer_protocols_, conn,
-                                             conn->isInitiator()));
-    if (auto adaptor =
-            std::find_if(security_adaptors_.begin(), security_adaptors_.end(),
-                         [&selected_proto](const auto &adaptor) {
-                           return selected_proto == adaptor->getProtocolId();
-                         });
-        adaptor != security_adaptors_.end()) {
-      return (*adaptor)->mux(std::move(conn));
-    }
+    //    OUTCOME_TRY(selected_proto,
+    //                protocol_muxer_->selectOneOf(muxer_protocols_, conn,
+    //                                             conn->isInitiator()));
+    //    if (auto adaptor =
+    //            std::find_if(security_adaptors_.begin(),
+    //            security_adaptors_.end(),
+    //                         [&selected_proto](const auto &adaptor) {
+    //                           return selected_proto ==
+    //                           adaptor->getProtocolId();
+    //                         });
+    //        adaptor != security_adaptors_.end()) {
+    //      return (*adaptor)->mux(std::move(conn));
+    //    }
     return Error::INTERNAL_ERROR;
   }
 }  // namespace libp2p::transport

--- a/core/libp2p/transport/impl/upgrader_impl.cpp
+++ b/core/libp2p/transport/impl/upgrader_impl.cpp
@@ -26,54 +26,77 @@ namespace libp2p::transport {
         protocol_muxer_{std::move(protocol_muxer)},
         security_adaptors_{security_adaptors.begin(), security_adaptors.end()},
         muxer_adaptors_{muxer_adaptors.begin(), muxer_adaptors.end()} {
-    // otherwise, we need to extract lists of supported protos every time
+    // so that we don't need to extract lists of supported protos every time
     security_protocols_ = std::reduce(
         security_adaptors_.begin(), security_adaptors_.end(),
         std::vector<peer::Protocol>(), [](auto &&acc, const auto &adaptor) {
           acc.push_back(adaptor->getProtocolId());
           return acc;
         });
-//    muxer_protocols_ = std::reduce(muxer_adaptors.begin(), muxer_adaptors.end(),
-//                                   std::vector<peer::Protocol>(),
-//                                   [](auto &&acc, const auto &adaptor) {
-//                                     acc.push_back(adaptor->getProtocolId());
-//                                     return acc;
-//                                   });
+    muxer_protocols_ = std::reduce(muxer_adaptors.begin(), muxer_adaptors.end(),
+                                   std::vector<peer::Protocol>(),
+                                   [](auto &&acc, const auto &adaptor) {
+                                     acc.push_back(adaptor->getProtocolId());
+                                     return acc;
+                                   });
   }
 
-  outcome::result<UpgraderImpl::SecureSPtr> UpgraderImpl::upgradeToSecure(
-      RawSPtr conn) {
+  void UpgraderImpl::upgradeToSecure(RawSPtr conn, OnSecuredCallbackFunc cb) {
     auto initiator = conn->isInitiator();
-    OUTCOME_TRY(
-        selected_proto,
-        protocol_muxer_->selectOneOf(security_protocols_, conn, initiator));
-    if (auto adaptor =
-            std::find_if(security_adaptors_.begin(), security_adaptors_.end(),
-                         [&selected_proto](const auto &adaptor) {
-                           return selected_proto == adaptor->getProtocolId();
-                         });
-        adaptor != security_adaptors_.end()) {
-      return initiator ? (*adaptor)->secureOutbound(std::move(conn), peer_id_)
-                       : (*adaptor)->secureInbound(std::move(conn));
-    }
-    return Error::INTERNAL_ERROR;
+
+    protocol_muxer_->selectOneOf(
+        security_protocols_, conn, initiator,
+        [self{shared_from_this()}, cb = std::move(cb), conn,
+         initiator](auto &&proto_res) mutable {
+          if (!proto_res) {
+            return cb(proto_res.error());
+          }
+
+          auto selected_proto = std::move(proto_res.value());
+          if (auto adaptor = std::find_if(
+                  self->security_adaptors_.begin(),
+                  self->security_adaptors_.end(),
+                  [&selected_proto](const auto &adaptor) {
+                    return selected_proto == adaptor->getProtocolId();
+                  });
+              adaptor != self->security_adaptors_.end()) {
+            return initiator
+                ? (*adaptor)->secureOutbound(std::move(conn), self->peer_id_,
+                                             std::move(cb))
+                : (*adaptor)->secureInbound(std::move(conn), std::move(cb));
+          }
+          cb(Error::INTERNAL_ERROR);
+        });
   }
 
-  outcome::result<UpgraderImpl::CapableSPtr> UpgraderImpl::upgradeToMuxed(
-      SecureSPtr conn) {
-    //    OUTCOME_TRY(selected_proto,
-    //                protocol_muxer_->selectOneOf(muxer_protocols_, conn,
-    //                                             conn->isInitiator()));
-    //    if (auto adaptor =
-    //            std::find_if(security_adaptors_.begin(),
-    //            security_adaptors_.end(),
-    //                         [&selected_proto](const auto &adaptor) {
-    //                           return selected_proto ==
-    //                           adaptor->getProtocolId();
-    //                         });
-    //        adaptor != security_adaptors_.end()) {
-    //      return (*adaptor)->mux(std::move(conn));
-    //    }
-    return Error::INTERNAL_ERROR;
+  void UpgraderImpl::upgradeToMuxed(SecSPtr conn, OnMuxedCallbackFunc cb) {
+    return protocol_muxer_->selectOneOf(
+        muxer_protocols_, conn, conn->isInitiator(),
+        [self{shared_from_this()}, cb = std::move(cb),
+         conn](auto &&proto_res) mutable {
+          if (!proto_res) {
+            return cb(proto_res.error());
+          }
+
+          auto selected_proto = std::move(proto_res.value());
+          if (auto adaptor = std::find_if(
+                  self->muxer_adaptors_.begin(), self->muxer_adaptors_.end(),
+                  [&selected_proto](const auto &adaptor) {
+                    return selected_proto == adaptor->getProtocolId();
+                  });
+              adaptor != self->muxer_adaptors_.end()) {
+            return (*adaptor)->muxConnection(
+                std::move(conn), [cb = std::move(cb)](auto &&conn_res) {
+                  if (!conn_res) {
+                    return cb(conn_res.error());
+                  }
+
+                  auto conn = std::move(conn_res.value());
+                  conn->start();
+                  return cb(std::move(conn));
+                });
+          }
+          cb(Error::INTERNAL_ERROR);
+        });
   }
 }  // namespace libp2p::transport

--- a/core/libp2p/transport/impl/upgrader_impl.hpp
+++ b/core/libp2p/transport/impl/upgrader_impl.hpp
@@ -1,0 +1,66 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_UPGRADER_IMPL_HPP
+#define KAGOME_UPGRADER_IMPL_HPP
+
+#include <vector>
+
+#include <gsl/span>
+#include "libp2p/muxer/muxer_adaptor.hpp"
+#include "libp2p/peer/peer_id.hpp"
+#include "libp2p/peer/protocol.hpp"
+#include "libp2p/protocol_muxer/multiselect.hpp"
+#include "libp2p/protocol_muxer/protocol_muxer.hpp"
+#include "libp2p/security/security_adaptor.hpp"
+#include "libp2p/transport/upgrader.hpp"
+
+namespace libp2p::transport {
+  class UpgraderImpl : public Upgrader {
+    using RawSPtr = std::shared_ptr<connection::RawConnection>;
+    using SecureSPtr = std::shared_ptr<connection::SecureConnection>;
+    using CapableSPtr = std::shared_ptr<connection::CapableConnection>;
+
+    using SecAdaptorSPtr = std::shared_ptr<security::SecurityAdaptor>;
+    using MuxAdaptorSPtr = std::shared_ptr<muxer::MuxerAdaptor>;
+
+   public:
+    /**
+     * Create an instance of upgrader
+     * @param peer_id - id of this peer
+     * @param protocol_muxer - protocol wrapper, allowing to negotiate about the
+     * protocols with the other side
+     * @param security_adaptors, which can be used to upgrade Raw connections to
+     * the Secure ones
+     * @param muxer_adaptors, which can be used to upgrade Secure connections to
+     * the Muxed (Capable) ones
+     */
+    UpgraderImpl(peer::PeerId peer_id,
+                 std::shared_ptr<protocol_muxer::ProtocolMuxer> protocol_muxer,
+                 gsl::span<SecAdaptorSPtr> security_adaptors,
+                 gsl::span<MuxAdaptorSPtr> muxer_adaptors);
+
+    outcome::result<SecureSPtr> upgradeToSecure(RawSPtr conn) override;
+
+    outcome::result<CapableSPtr> upgradeToMuxed(SecureSPtr conn) override;
+
+    enum class Error { INTERNAL_ERROR = 1 };
+
+   private:
+    peer::PeerId peer_id_;
+
+    std::shared_ptr<protocol_muxer::ProtocolMuxer> protocol_muxer_;
+
+    std::vector<SecAdaptorSPtr> security_adaptors_;
+    std::vector<peer::Protocol> security_protocols_;
+
+    std::vector<MuxAdaptorSPtr> muxer_adaptors_;
+    std::vector<peer::Protocol> muxer_protocols_;
+  };
+}  // namespace libp2p::transport
+
+OUTCOME_HPP_DECLARE_ERROR(libp2p::transport, UpgraderImpl::Error)
+
+#endif  // KAGOME_UPGRADER_IMPL_HPP

--- a/core/libp2p/transport/impl/upgrader_impl.hpp
+++ b/core/libp2p/transport/impl/upgrader_impl.hpp
@@ -17,11 +17,8 @@
 #include "libp2p/transport/upgrader.hpp"
 
 namespace libp2p::transport {
-  class UpgraderImpl : public Upgrader {
-    using RawSPtr = std::shared_ptr<connection::RawConnection>;
-    using SecureSPtr = std::shared_ptr<connection::SecureConnection>;
-    using CapableSPtr = std::shared_ptr<connection::CapableConnection>;
-
+  class UpgraderImpl : public Upgrader,
+                       public std::enable_shared_from_this<UpgraderImpl> {
     using SecAdaptorSPtr = std::shared_ptr<security::SecurityAdaptor>;
     using MuxAdaptorSPtr = std::shared_ptr<muxer::MuxerAdaptor>;
 
@@ -41,9 +38,11 @@ namespace libp2p::transport {
                  gsl::span<SecAdaptorSPtr> security_adaptors,
                  gsl::span<MuxAdaptorSPtr> muxer_adaptors);
 
-    outcome::result<SecureSPtr> upgradeToSecure(RawSPtr conn) override;
+    ~UpgraderImpl() override = default;
 
-    outcome::result<CapableSPtr> upgradeToMuxed(SecureSPtr conn) override;
+    void upgradeToSecure(RawSPtr conn, OnSecuredCallbackFunc cb) override;
+
+    void upgradeToMuxed(SecSPtr conn, OnMuxedCallbackFunc cb) override;
 
     enum class Error { INTERNAL_ERROR = 1 };
 

--- a/core/libp2p/transport/impl/upgrader_impl.hpp
+++ b/core/libp2p/transport/impl/upgrader_impl.hpp
@@ -12,7 +12,6 @@
 #include "libp2p/muxer/muxer_adaptor.hpp"
 #include "libp2p/peer/peer_id.hpp"
 #include "libp2p/peer/protocol.hpp"
-#include "libp2p/protocol_muxer/multiselect.hpp"
 #include "libp2p/protocol_muxer/protocol_muxer.hpp"
 #include "libp2p/security/security_adaptor.hpp"
 #include "libp2p/transport/upgrader.hpp"

--- a/core/libp2p/transport/upgrader.hpp
+++ b/core/libp2p/transport/upgrader.hpp
@@ -22,23 +22,30 @@ namespace libp2p::transport {
    * and using the chosen protocols to actually upgrade the connections
    */
   struct Upgrader {
+    using RawSPtr = std::shared_ptr<connection::RawConnection>;
+    using SecSPtr = std::shared_ptr<connection::SecureConnection>;
+    using CapSPtr = std::shared_ptr<connection::CapableConnection>;
+
+    using OnSecuredCallbackFunc = std::function<void(outcome::result<SecSPtr>)>;
+    using OnMuxedCallbackFunc = std::function<void(outcome::result<CapSPtr>)>;
+
     virtual ~Upgrader() = default;
 
     /**
      * Upgrade a raw connection to the secure one
      * @param conn to be upgraded
-     * @return upgraded connection or error
+     * @param cb - callback, which is called, when a connection is upgraded or
+     * error happens
      */
-    virtual outcome::result<std::shared_ptr<connection::SecureConnection>>
-    upgradeToSecure(std::shared_ptr<connection::RawConnection> conn) = 0;
+    virtual void upgradeToSecure(RawSPtr conn, OnSecuredCallbackFunc cb) = 0;
 
     /**
      * Upgrade a secure connection to the muxed (capable) one
      * @param conn to be upgraded
-     * @return upgraded connection or error
+     * @param cb - callback, which is called, when a connection is upgraded or
+     * error happens
      */
-    virtual outcome::result<std::shared_ptr<connection::CapableConnection>>
-    upgradeToMuxed(std::shared_ptr<connection::SecureConnection> conn) = 0;
+    virtual void upgradeToMuxed(SecSPtr conn, OnMuxedCallbackFunc cb) = 0;
   };
 
 }  // namespace libp2p::transport

--- a/test/acceptance/libp2p/muxer.cpp
+++ b/test/acceptance/libp2p/muxer.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <random>
+#include "libp2p/connection/stream.hpp"
 #include "libp2p/muxer/yamux.hpp"
 #include "libp2p/security/plaintext.hpp"
 #include "libp2p/transport/tcp.hpp"
@@ -38,19 +39,18 @@ struct UpgraderSemiMock : public Upgrader {
 
   void upgradeToSecure(RawSPtr conn, OnSecuredCallbackFunc cb) override {
     if (conn->isInitiator()) {
-      EXPECT_OUTCOME_TRUE(
-          s, security->secureOutbound(conn, testutil::randomPeerId()));
-      cb(s);
+      security->secureOutbound(conn, testutil::randomPeerId(), std::move(cb));
     } else {
-      EXPECT_OUTCOME_TRUE(s, security->secureInbound(conn));
-      cb(s);
+      security->secureInbound(conn, std::move(cb));
     }
   }
 
-  void upgradeToMuxed(SecureSPtr conn, OnMuxedCallbackFunc cb) override {
-    EXPECT_OUTCOME_TRUE(cc, mux->muxConnection(conn));
-    cc->start();
-    return cb(cc);
+  void upgradeToMuxed(SecSPtr conn, OnMuxedCallbackFunc cb) override {
+    mux->muxConnection(std::move(conn), [cb = std::move(cb)](auto &&conn_res) {
+      EXPECT_OUTCOME_TRUE(conn, conn_res)
+      conn->start();
+      cb(std::move(conn));
+    });
   }
 
   std::shared_ptr<SecurityAdaptor> security;

--- a/test/core/libp2p/security/plaintext_adaptor_test.cpp
+++ b/test/core/libp2p/security/plaintext_adaptor_test.cpp
@@ -6,6 +6,7 @@
 #include "libp2p/security/plaintext/plaintext.hpp"
 
 #include <gtest/gtest.h>
+#include <testutil/gmock_actions.hpp>
 #include <testutil/outcome.hpp>
 #include "common/buffer.hpp"
 #include "libp2p/multi/multihash.hpp"
@@ -48,11 +49,12 @@ TEST_F(PlaintextAdaptorTest, GetId) {
  * @then connection is secured
  */
 TEST_F(PlaintextAdaptorTest, SecureInbound) {
-  EXPECT_OUTCOME_TRUE(secure_conn, adaptor_->secureInbound(connection_))
-
   EXPECT_CALL(*connection_, isClosed()).WillOnce(Return(false));
 
-  ASSERT_FALSE(secure_conn->isClosed());
+  adaptor_->secureInbound(connection_, [](auto &&conn_res) {
+    EXPECT_OUTCOME_TRUE(sec_conn, conn_res)
+    ASSERT_FALSE(sec_conn->isClosed());
+  });
 }
 
 /**
@@ -61,10 +63,10 @@ TEST_F(PlaintextAdaptorTest, SecureInbound) {
  * @then connection is secured
  */
 TEST_F(PlaintextAdaptorTest, SecureOutbound) {
-  EXPECT_OUTCOME_TRUE(secure_conn,
-                      adaptor_->secureOutbound(connection_, kDefaultPeerId));
-
   EXPECT_CALL(*connection_, isClosed()).WillOnce(Return(false));
 
-  ASSERT_FALSE(secure_conn->isClosed());
+  adaptor_->secureOutbound(connection_, kDefaultPeerId, [](auto &&conn_res) {
+    EXPECT_OUTCOME_TRUE(sec_conn, conn_res)
+    ASSERT_FALSE(sec_conn->isClosed());
+  });
 }

--- a/test/core/libp2p/transport/CMakeLists.txt
+++ b/test/core/libp2p/transport/CMakeLists.txt
@@ -15,3 +15,11 @@ addtest(libp2p_transport_parser_test
 target_link_libraries(libp2p_transport_parser_test
     libp2p_transport_parser
     )
+
+addtest(libp2p_upgrader_test
+    upgrader_test.cpp
+    )
+target_link_libraries(libp2p_upgrader_test
+    libp2p_upgrader
+    miltihash
+    )

--- a/test/core/libp2p/transport/CMakeLists.txt
+++ b/test/core/libp2p/transport/CMakeLists.txt
@@ -21,5 +21,6 @@ addtest(libp2p_upgrader_test
     )
 target_link_libraries(libp2p_upgrader_test
     libp2p_upgrader
-    miltihash
+    multihash
+    libp2p_peer_id
     )

--- a/test/core/libp2p/transport/tcp_integration_test.cpp
+++ b/test/core/libp2p/transport/tcp_integration_test.cpp
@@ -54,12 +54,11 @@ namespace {
   auto makeUpgrader() {
     auto upgrader = std::make_shared<NiceMock<UpgraderMock>>();
     ON_CALL(*upgrader, upgradeToSecure(_, _))
-        .WillByDefault(Invoke(_upgrade<Upgrader::RawSPtr, Upgrader::SecureSPtr,
+        .WillByDefault(Invoke(_upgrade<Upgrader::RawSPtr, Upgrader::SecSPtr,
                                        Upgrader::OnSecuredCallbackFunc>));
     ON_CALL(*upgrader, upgradeToMuxed(_, _))
-        .WillByDefault(
-            Invoke(_upgrade<Upgrader::SecureSPtr, Upgrader::CapableSPtr,
-                            Upgrader::OnMuxedCallbackFunc>));
+        .WillByDefault(Invoke(_upgrade<Upgrader::SecSPtr, Upgrader::CapSPtr,
+                                       Upgrader::OnMuxedCallbackFunc>));
 
     return upgrader;
   }

--- a/test/core/libp2p/transport/upgrader_test.cpp
+++ b/test/core/libp2p/transport/upgrader_test.cpp
@@ -88,8 +88,8 @@ TEST_F(UpgraderTest, UpgradeSecureInitiator) {
   EXPECT_CALL(
       *std::static_pointer_cast<SecurityAdaptorMock>(security_mocks_[0]),
       secureOutbound(std::static_pointer_cast<RawConnection>(raw_conn_),
-                     peer_id_))
-      .WillOnce(Return(sec_conn_));
+                     peer_id_, _))
+      .WillOnce(Arg2CallbackWithArg(sec_conn_));
 
   upgrader_->upgradeToSecure(raw_conn_, [this](auto &&upgraded_conn_res) {
     ASSERT_TRUE(upgraded_conn_res);
@@ -106,8 +106,8 @@ TEST_F(UpgraderTest, UpgradeSecureNotInitiator) {
       .WillOnce(Arg3CallbackWithArg(outcome::success(security_protos_[1])));
   EXPECT_CALL(
       *std::static_pointer_cast<SecurityAdaptorMock>(security_mocks_[1]),
-      secureInbound(std::static_pointer_cast<RawConnection>(raw_conn_)))
-      .WillOnce(Return(outcome::success(sec_conn_)));
+      secureInbound(std::static_pointer_cast<RawConnection>(raw_conn_), _))
+      .WillOnce(Arg1CallbackWithArg(outcome::success(sec_conn_)));
 
   upgrader_->upgradeToSecure(raw_conn_, [this](auto &&upgraded_conn_res) {
     ASSERT_TRUE(upgraded_conn_res);
@@ -137,8 +137,8 @@ TEST_F(UpgraderTest, UpgradeMux) {
       .WillOnce(Arg3CallbackWithArg(outcome::success(muxer_protos_[0])));
   EXPECT_CALL(
       *std::static_pointer_cast<MuxerAdaptorMock>(muxer_mocks_[0]),
-      muxConnection(std::static_pointer_cast<SecureConnection>(sec_conn_)))
-      .WillOnce(Return(muxed_conn_));
+      muxConnection(std::static_pointer_cast<SecureConnection>(sec_conn_), _))
+      .WillOnce(Arg1CallbackWithArg(muxed_conn_));
 
   upgrader_->upgradeToMuxed(sec_conn_, [this](auto &&upgraded_conn_res) {
     ASSERT_TRUE(upgraded_conn_res);

--- a/test/core/libp2p/transport/upgrader_test.cpp
+++ b/test/core/libp2p/transport/upgrader_test.cpp
@@ -1,0 +1,107 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "libp2p/transport/impl/upgrader_impl.hpp"
+
+#include <numeric>
+#include <unordered_map>
+
+#include <gtest/gtest.h>
+#include <testutil/outcome.hpp>
+#include "libp2p/multi/multihash.hpp"
+#include "mock/libp2p/connection/raw_connection_mock.hpp"
+#include "mock/libp2p/connection/secure_connection_mock.hpp"
+#include "mock/libp2p/muxer/muxer_adaptor_mock.hpp"
+#include "mock/libp2p/protocol_muxer/protocol_muxer_mock.hpp"
+#include "mock/libp2p/security/security_adaptor_mock.hpp"
+
+using namespace libp2p::transport;
+using namespace libp2p::muxer;
+using namespace libp2p::security;
+using namespace libp2p::peer;
+using namespace libp2p::connection;
+using namespace libp2p::protocol_muxer;
+
+using testing::Return;
+
+class UpgraderTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    for (size_t i = 0; i < security_protos_.size(); ++i) {
+      ON_CALL(*security_mocks_[i], getProtocolId())
+          .WillByDefault(Return(security_protos_[i]));
+    }
+    for (size_t i = 0; i < muxer_protos_.size(); ++i) {
+      ON_CALL(*muxer_mocks_[i], getProtocolId())
+          .WillByDefault(Return(muxer_protos_[i]));
+    }
+
+    upgrader_ = UpgraderImpl{peer_id_, multiselect_mock_, security_mocks_,
+                             muxer_mocks_};
+  }
+
+  PeerId peer_id_ = PeerId::fromHash(libp2p::multi::Multihash::create(
+                                         libp2p::multi::HashType::sha256,
+                                         kagome::common::Buffer{0x11, 0x22})
+                                         .value())
+                        .value();
+
+  std::shared_ptr<ProtocolMuxerMock> multiselect_mock_ =
+      std::make_shared<ProtocolMuxerMock>();
+
+  std::vector<Protocol> security_protos_{"security_proto1", "security_proto2"};
+  std::vector<std::shared_ptr<SecurityAdaptorMock>> security_mocks_{
+      std::make_shared<SecurityAdaptorMock>(),
+      std::make_shared<SecurityAdaptorMock>()};
+
+  std::vector<Protocol> muxer_protos_{"muxer_proto1", "muxer_proto2"};
+  std::vector<std::shared_ptr<MuxerAdaptorMock>> muxer_mocks_{
+      std::make_shared<MuxerAdaptorMock>(),
+      std::make_shared<MuxerAdaptorMock>()};
+
+  UpgraderImpl upgrader_;
+
+  std::shared_ptr<RawConnectionMock> raw_conn_ =
+      std::make_shared<RawConnectionMock>();
+  std::shared_ptr<SecureConnectionMock> sec_conn_ =
+      std::make_shared<SecureConnectionMock>();
+};
+
+TEST_F(UpgraderTest, UpgradeSecureInitiator) {
+  EXPECT_CALL(*raw_conn_, isInitiator_hack()).WillOnce(Return(true));
+  EXPECT_CALL(*multiselect_mock_,
+              selectOneOf(security_protos_, raw_conn_, true))
+      .WillOnce(Return(security_protos_[0]));
+  EXPECT_CALL(*security_mocks_[0], secureOutbound(raw_conn_, peer_id_))
+      .WillOnce(Return(sec_conn_));
+
+  EXPECT_OUTCOME_TRUE(upgraded_conn, upgrader_.upgradeToSecure(raw_conn_))
+  ASSERT_EQ(upgraded_conn, sec_conn_);
+}
+
+TEST_F(UpgraderTest, UpgradeSecureNotInitiator) {
+  EXPECT_CALL(*raw_conn_, isInitiator_hack()).WillOnce(Return(false));
+  EXPECT_CALL(*multiselect_mock_,
+              selectOneOf(security_protos_, raw_conn_, false))
+      .WillOnce(Return(outcome::success(security_protos_[1])));
+  EXPECT_CALL(*security_mocks_[1], secureInbound(raw_conn_))
+      .WillOnce(Return(outcome::success(sec_conn_)));
+
+  EXPECT_OUTCOME_TRUE(upgraded_conn, upgrader_.upgradeToSecure(raw_conn_))
+  ASSERT_EQ(upgraded_conn, sec_conn_);
+}
+
+TEST_F(UpgraderTest, UpgradeSecureFail) {
+  EXPECT_CALL(*raw_conn_, isInitiator_hack()).WillOnce(Return(false));
+  EXPECT_CALL(*multiselect_mock_,
+              selectOneOf(security_protos_, raw_conn_, false))
+      .WillOnce(Return(outcome::failure(std::error_code())));
+
+  ASSERT_FALSE(upgrader_.upgradeToSecure(raw_conn_));
+}
+
+TEST_F(UpgraderTest, UpgradeMux) {}
+
+TEST_F(UpgraderTest, UpgradeMuxFail) {}

--- a/test/mock/libp2p/connection/secure_connection_mock.hpp
+++ b/test/mock/libp2p/connection/secure_connection_mock.hpp
@@ -42,7 +42,8 @@ namespace libp2p::connection {
 
     MOCK_CONST_METHOD0(remotePeer, outcome::result<peer::PeerId>(void));
 
-    MOCK_CONST_METHOD0(remotePublicKey, outcome::result<crypto::PublicKey>(void));
+    MOCK_CONST_METHOD0(remotePublicKey,
+                       outcome::result<crypto::PublicKey>(void));
   };
 }  // namespace libp2p::connection
 

--- a/test/mock/libp2p/muxer/muxer_adaptor_mock.hpp
+++ b/test/mock/libp2p/muxer/muxer_adaptor_mock.hpp
@@ -13,10 +13,9 @@ namespace libp2p::muxer {
   struct MuxerAdaptorMock : public MuxerAdaptor {
     MOCK_CONST_METHOD0(getProtocolId, peer::Protocol());
 
-    MOCK_CONST_METHOD1(
-        muxConnection,
-        outcome::result<std::shared_ptr<connection::CapableConnection>>(
-            std::shared_ptr<connection::SecureConnection>));
+    MOCK_CONST_METHOD2(muxConnection,
+                       void(std::shared_ptr<connection::SecureConnection>,
+                            CapConnCallbackFunc));
   };
 }  // namespace libp2p::muxer
 

--- a/test/mock/libp2p/muxer/muxer_adaptor_mock.hpp
+++ b/test/mock/libp2p/muxer/muxer_adaptor_mock.hpp
@@ -1,0 +1,15 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_MUXER_ADAPTOR_MOCK_HPP
+#define KAGOME_MUXER_ADAPTOR_MOCK_HPP
+
+#include "libp2p/muxer/muxer_adaptor.hpp"
+
+namespace libp2p::muxer {
+  struct MuxerAdaptorMock : public MuxerAdaptor {};
+}  // namespace libp2p::muxer
+
+#endif  // KAGOME_MUXER_ADAPTOR_MOCK_HPP

--- a/test/mock/libp2p/muxer/muxer_adaptor_mock.hpp
+++ b/test/mock/libp2p/muxer/muxer_adaptor_mock.hpp
@@ -6,10 +6,18 @@
 #ifndef KAGOME_MUXER_ADAPTOR_MOCK_HPP
 #define KAGOME_MUXER_ADAPTOR_MOCK_HPP
 
+#include <gmock/gmock.h>
 #include "libp2p/muxer/muxer_adaptor.hpp"
 
 namespace libp2p::muxer {
-  struct MuxerAdaptorMock : public MuxerAdaptor {};
+  struct MuxerAdaptorMock : public MuxerAdaptor {
+    MOCK_CONST_METHOD0(getProtocolId, peer::Protocol());
+
+    MOCK_CONST_METHOD1(
+        muxConnection,
+        outcome::result<std::shared_ptr<connection::CapableConnection>>(
+            std::shared_ptr<connection::SecureConnection>));
+  };
 }  // namespace libp2p::muxer
 
 #endif  // KAGOME_MUXER_ADAPTOR_MOCK_HPP

--- a/test/mock/libp2p/protocol_muxer/protocol_muxer_mock.hpp
+++ b/test/mock/libp2p/protocol_muxer/protocol_muxer_mock.hpp
@@ -12,10 +12,11 @@
 namespace libp2p::protocol_muxer {
   class ProtocolMuxerMock : public ProtocolMuxer {
    public:
-    MOCK_CONST_METHOD3(selectOneOf,
-                       outcome::result<peer::Protocol>(
-                           gsl::span<const peer::Protocol>,
-                           std::shared_ptr<basic::ReadWriteCloser>, bool));
+    MOCK_CONST_METHOD4(
+        selectOneOf,
+        void(gsl::span<const peer::Protocol>,
+             std::shared_ptr<basic::ReadWriteCloser>, bool,
+             std::function<void(outcome::result<peer::Protocol>)>));
   };
 }  // namespace libp2p::protocol_muxer
 

--- a/test/mock/libp2p/protocol_muxer/protocol_muxer_mock.hpp
+++ b/test/mock/libp2p/protocol_muxer/protocol_muxer_mock.hpp
@@ -15,7 +15,7 @@ namespace libp2p::protocol_muxer {
     MOCK_CONST_METHOD4(
         selectOneOf,
         void(gsl::span<const peer::Protocol>,
-             std::shared_ptr<basic::ReadWriteCloser>, bool,
+             std::shared_ptr<basic::ReadWriter>, bool,
              std::function<void(outcome::result<peer::Protocol>)>));
   };
 }  // namespace libp2p::protocol_muxer

--- a/test/mock/libp2p/protocol_muxer/protocol_muxer_mock.hpp
+++ b/test/mock/libp2p/protocol_muxer/protocol_muxer_mock.hpp
@@ -11,6 +11,7 @@
 
 namespace libp2p::protocol_muxer {
   class ProtocolMuxerMock : public ProtocolMuxer {
+   public:
     MOCK_CONST_METHOD3(selectOneOf,
                        outcome::result<peer::Protocol>(
                            gsl::span<const peer::Protocol>,

--- a/test/mock/libp2p/protocol_muxer/protocol_muxer_mock.hpp
+++ b/test/mock/libp2p/protocol_muxer/protocol_muxer_mock.hpp
@@ -1,0 +1,21 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_PROTOCOL_MUXER_MOCK_HPP
+#define KAGOME_PROTOCOL_MUXER_MOCK_HPP
+
+#include <gmock/gmock.h>
+#include "libp2p/protocol_muxer/protocol_muxer.hpp"
+
+namespace libp2p::protocol_muxer {
+  class ProtocolMuxerMock : public ProtocolMuxer {
+    MOCK_CONST_METHOD3(selectOneOf,
+                       outcome::result<peer::Protocol>(
+                           gsl::span<const peer::Protocol>,
+                           std::shared_ptr<basic::ReadWriteCloser>, bool));
+  };
+}  // namespace libp2p::protocol_muxer
+
+#endif  // KAGOME_PROTOCOL_MUXER_MOC_HPP

--- a/test/mock/libp2p/security/security_adaptor_mock.hpp
+++ b/test/mock/libp2p/security/security_adaptor_mock.hpp
@@ -1,0 +1,27 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_SECURITY_ADAPTOR_MOCK_HPP
+#define KAGOME_SECURITY_ADAPTOR_MOCK_HPP
+
+#include <gmock/gmock.h>
+#include "libp2p/security/security_adaptor.hpp"
+
+namespace libp2p::security {
+  struct SecurityAdaptorMock : public SecurityAdaptor {
+    MOCK_CONST_METHOD0(getProtocolId, peer::Protocol());
+
+    MOCK_METHOD1(secureInbound,
+                 outcome::result<std::shared_ptr<connection::SecureConnection>>(
+                     std::shared_ptr<connection::RawConnection>));
+
+    MOCK_METHOD2(secureOutbound,
+                 outcome::result<std::shared_ptr<connection::SecureConnection>>(
+                     std::shared_ptr<connection::RawConnection>,
+                     const peer::PeerId &));
+  };
+}  // namespace libp2p::security
+
+#endif  // KAGOME_SECURITY_ADAPTOR_MOCK_HPP

--- a/test/mock/libp2p/security/security_adaptor_mock.hpp
+++ b/test/mock/libp2p/security/security_adaptor_mock.hpp
@@ -14,14 +14,13 @@ namespace libp2p::security {
    public:
     MOCK_CONST_METHOD0(getProtocolId, peer::Protocol());
 
-    MOCK_METHOD1(secureInbound,
-                 outcome::result<std::shared_ptr<connection::SecureConnection>>(
-                     std::shared_ptr<connection::RawConnection>));
+    MOCK_METHOD2(secureInbound,
+                 void(std::shared_ptr<connection::RawConnection>,
+                      SecConnCallbackFunc));
 
-    MOCK_METHOD2(secureOutbound,
-                 outcome::result<std::shared_ptr<connection::SecureConnection>>(
-                     std::shared_ptr<connection::RawConnection>,
-                     const peer::PeerId &));
+    MOCK_METHOD3(secureOutbound,
+                 void(std::shared_ptr<connection::RawConnection>,
+                      const peer::PeerId &, SecConnCallbackFunc));
   };
 }  // namespace libp2p::security
 

--- a/test/mock/libp2p/security/security_adaptor_mock.hpp
+++ b/test/mock/libp2p/security/security_adaptor_mock.hpp
@@ -11,6 +11,7 @@
 
 namespace libp2p::security {
   struct SecurityAdaptorMock : public SecurityAdaptor {
+   public:
     MOCK_CONST_METHOD0(getProtocolId, peer::Protocol());
 
     MOCK_METHOD1(secureInbound,

--- a/test/mock/libp2p/transport/upgrader_mock.hpp
+++ b/test/mock/libp2p/transport/upgrader_mock.hpp
@@ -22,7 +22,7 @@ namespace libp2p::transport {
                  void(Upgrader::RawSPtr, Upgrader::OnSecuredCallbackFunc));
 
     MOCK_METHOD2(upgradeToMuxed,
-                 void(Upgrader::SecureSPtr, Upgrader::OnMuxedCallbackFunc));
+                 void(Upgrader::SecSPtr, Upgrader::OnMuxedCallbackFunc));
   };
 
   /**
@@ -37,11 +37,11 @@ namespace libp2p::transport {
 
    public:
     void upgradeToSecure(RawSPtr conn, OnSecuredCallbackFunc cb) override {
-      cb(security_adaptor_->secureInbound(std::move(conn)));
+      security_adaptor_->secureInbound(std::move(conn), std::move(cb));
     }
 
-    void upgradeToMuxed(SecureSPtr conn, OnMuxedCallbackFunc cb) override {
-      cb(muxer_adaptor_->muxConnection(std::move(conn)));
+    void upgradeToMuxed(SecSPtr conn, OnMuxedCallbackFunc cb) override {
+      muxer_adaptor_->muxConnection(std::move(conn), std::move(cb));
     }
   };
 

--- a/test/testutil/gmock_actions.hpp
+++ b/test/testutil/gmock_actions.hpp
@@ -34,9 +34,8 @@ ACTION_P(AsioSuccess, size) {
  * boost::system::error_code ec = ...;
  * EXPECT_CALL(*connection_, read(_, _, _)).WillOnce(AsioCallback(ec, size));
  * auto buf = std::make_shared<std::vector<uint8_t>>(size, 0);
- * secure_connection_->read(*buf, size, [&size, buf, e=ec](auto &&ec, size_t read) mutable {
- *   ASSERT_EQ(ec.value(), e.value());
- *   ASSERT_EQ(read, size);
+ * secure_connection_->read(*buf, size, [&size, buf, e=ec](auto &&ec, size_t
+ * read) mutable { ASSERT_EQ(ec.value(), e.value()); ASSERT_EQ(read, size);
  * });
  * @nocode
  */
@@ -47,16 +46,20 @@ ACTION_P2(AsioCallback, ec, size) {
   arg2(ec, size);
 }
 
-ACTION_P(Arg0CallbackWithArg, in){
+ACTION_P(Arg0CallbackWithArg, in) {
   arg0(in);
 }
 
-ACTION_P(Arg1CallbackWithArg, in){
+ACTION_P(Arg1CallbackWithArg, in) {
   arg1(in);
 }
 
-ACTION_P(Arg2CallbackWithArg, in){
+ACTION_P(Arg2CallbackWithArg, in) {
   arg2(in);
+}
+
+ACTION_P(Arg3CallbackWithArg, in) {
+  arg3(in);
 }
 
 #endif  // KAGOME_GMOCK_ACTIONS_HPP


### PR DESCRIPTION
### Description of the Change

Upgrader encapsulates the logic of choosing the right secure/muxer protocol and then using an existing adaptor to upgrade a provided connection using the chosen protocol.