### PR TITLE
Add identity manager

### DIFF
--- a/core/libp2p/peer/identity_manager.hpp
+++ b/core/libp2p/peer/identity_manager.hpp
@@ -1,0 +1,27 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_IDENTITY_MANAGER_HPP
+#define KAGOME_IDENTITY_MANAGER_HPP
+
+#include "libp2p/crypto/key.hpp"
+#include "libp2p/peer/peer_id.hpp"
+
+namespace libp2p::peer {
+
+  /**
+   * @brief Component, which "owns" information about current Host identity.
+   */
+  struct IdentityManager {
+    virtual ~IdentityManager() = default;
+
+    virtual const peer::PeerId &getId() const noexcept = 0;
+
+    virtual const crypto::KeyPair &getKeyPair() const noexcept = 0;
+  };
+
+}  // namespace libp2p::peer
+
+#endif  // KAGOME_IDENTITY_MANAGER_HPP

--- a/core/libp2p/peer/impl/identity_manager_impl.cpp
+++ b/core/libp2p/peer/impl/identity_manager_impl.cpp
@@ -1,0 +1,29 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "libp2p/peer/impl/identity_manager_impl.hpp"
+
+namespace libp2p::peer {
+
+  const peer::PeerId &IdentityManagerImpl::getId() const noexcept {
+    BOOST_ASSERT(id_ != nullptr);
+    return *id_;
+  }
+
+  const crypto::KeyPair &IdentityManagerImpl::getKeyPair() const noexcept {
+    BOOST_ASSERT(keyPair_ != nullptr);
+    return *keyPair_;
+  }
+
+  IdentityManagerImpl::IdentityManagerImpl(crypto::KeyPair keyPair) {
+    BOOST_ASSERT(keyPair.publicKey.data.size() > 0);
+
+    keyPair_ = std::make_unique<crypto::KeyPair>(std::move(keyPair));
+
+    // it is ok to use .value()
+    auto id = peer::PeerId::fromPublicKey(keyPair_->publicKey).value();
+    id_ = std::make_unique<peer::PeerId>(std::move(id));
+  }
+}  // namespace libp2p::peer

--- a/core/libp2p/peer/impl/identity_manager_impl.hpp
+++ b/core/libp2p/peer/impl/identity_manager_impl.hpp
@@ -1,0 +1,31 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_IDENTITY_MANAGER_IMPL_HPP
+#define KAGOME_IDENTITY_MANAGER_IMPL_HPP
+
+#include "libp2p/crypto/key_generator.hpp"
+#include "libp2p/peer/identity_manager.hpp"
+#include "libp2p/peer/key_repository.hpp"
+
+namespace libp2p::peer {
+  class IdentityManagerImpl : public IdentityManager {
+   public:
+    ~IdentityManagerImpl() override = default;
+
+    explicit IdentityManagerImpl(crypto::KeyPair keyPair);
+
+    const peer::PeerId &getId() const noexcept override;;
+
+    const crypto::KeyPair &getKeyPair() const noexcept override;;
+
+   private:
+    std::unique_ptr<peer::PeerId> id_;
+    std::unique_ptr<crypto::KeyPair> keyPair_;
+  };
+
+}  // namespace libp2p::peer
+
+#endif  // KAGOME_IDENTITY_MANAGER_IMPL_HPP

--- a/core/libp2p/peer/key_repository.hpp
+++ b/core/libp2p/peer/key_repository.hpp
@@ -52,24 +52,22 @@ namespace libp2p::peer {
      * @param pub public key
      * @return error code in case of error.
      */
-    virtual void addPublicKey(const PeerId &p,
-                              const crypto::PublicKey &pub) = 0;
+    virtual outcome::result<void> addPublicKey(
+        const PeerId &p, const crypto::PublicKey &pub) = 0;
 
     /**
-     * @brief Getter for keypairs associated with {@param p} PeerId. Mostly used
-     * to store our (current peer) keypair(s).
+     * @brief Getter for keypairs associated with this peer.
      * @param p PeerId.
      * @return pointer to a set of keypairs associated with {@param p}.
      */
-    virtual outcome::result<KeyPairVecPtr> getKeyPairs(const PeerId &p) = 0;
+    virtual outcome::result<KeyPairVecPtr> getKeyPairs() = 0;
 
     /**
-     * @brief Associate a keypair {@param kp} with a given {@param p} PeerId.
-     * @param p PeerId
+     * @brief Associate a keypair {@param kp} with current peer.
      * @param kp KeyPair
      * @return error code in case of error.
      */
-    virtual void addKeyPair(const PeerId &p, const KeyPair &kp) = 0;
+    virtual outcome::result<void> addKeyPair(const KeyPair &kp) = 0;
 
     /**
      * @brief Returns set of peer ids known by this repository.

--- a/core/libp2p/peer/key_repository/inmem_key_repository.cpp
+++ b/core/libp2p/peer/key_repository/inmem_key_repository.cpp
@@ -10,9 +10,7 @@
 namespace libp2p::peer {
 
   InmemKeyRepository::InmemKeyRepository()
-      : kp_(std::make_shared<std::unordered_set<crypto::KeyPair>>()){
-
-      };
+      : kp_(std::make_shared<std::unordered_set<crypto::KeyPair>>()){};
 
   void InmemKeyRepository::clear(const PeerId &p) {
     auto it1 = pub_.find(p);

--- a/core/libp2p/peer/key_repository/inmem_key_repository.cpp
+++ b/core/libp2p/peer/key_repository/inmem_key_repository.cpp
@@ -9,6 +9,11 @@
 
 namespace libp2p::peer {
 
+  InmemKeyRepository::InmemKeyRepository()
+      : kp_(std::make_shared<std::unordered_set<crypto::KeyPair>>()){
+
+      };
+
   void InmemKeyRepository::clear(const PeerId &p) {
     auto it1 = pub_.find(p);
     if (it1 != pub_.end()) {
@@ -16,11 +21,7 @@ namespace libp2p::peer {
       it1->second->clear();
     }
 
-    auto it2 = kp_.find(p);
-    if (it2 != kp_.end()) {
-      // if vector is found, then clear it
-      it2->second->clear();
-    }
+    kp_->clear();
   }
 
   outcome::result<InmemKeyRepository::PubVecPtr>
@@ -33,53 +34,36 @@ namespace libp2p::peer {
     return it->second;
   }
 
-  void InmemKeyRepository::addPublicKey(const PeerId &p, const Pub &pub) {
+  outcome::result<void> InmemKeyRepository::addPublicKey(const PeerId &p,
+                                                         const Pub &pub) {
     auto it = pub_.find(p);
     if (it != pub_.end()) {
       // vector if sound
       PubVecPtr &ptr = it->second;
       ptr->insert(pub);
-      return;
+      return outcome::success();
     }
 
     // pub_[p] = [pub]
     auto ptr = std::make_shared<PubVec>();
     ptr->insert(pub);
     pub_.insert({p, std::move(ptr)});
+
+    return outcome::success();
   }
 
   outcome::result<InmemKeyRepository::KeyPairVecPtr>
-  InmemKeyRepository::getKeyPairs(const PeerId &p) {
-    auto it = kp_.find(p);
-    if (it == kp_.end()) {
-      return PeerError::NOT_FOUND;
-    }
-
-    return it->second;
+  InmemKeyRepository::getKeyPairs() {
+    return kp_;
   };
 
-  void InmemKeyRepository::addKeyPair(const PeerId &p, const KeyPair &kp) {
-    auto it = kp_.find(p);
-    if (it != kp_.end()) {
-      // vector if sound
-      KeyPairVecPtr &ptr = it->second;
-      ptr->insert(kp);
-      return;
-    }
-
-    // kp_[p] = [kp]
-    auto ptr = std::make_shared<KeyPairVec>();
-    ptr->insert(kp);
-    kp_.insert({p, std::move(ptr)});
+  outcome::result<void> InmemKeyRepository::addKeyPair(const KeyPair &kp) {
+    kp_->insert(kp);
+    return outcome::success();
   }
 
   std::unordered_set<PeerId> InmemKeyRepository::getPeers() const {
     std::unordered_set<PeerId> peers;
-
-    for (const auto &it : kp_) {
-      peers.insert(it.first);
-    }
-
     for (const auto &it : pub_) {
       peers.insert(it.first);
     }

--- a/core/libp2p/peer/key_repository/inmem_key_repository.hpp
+++ b/core/libp2p/peer/key_repository/inmem_key_repository.hpp
@@ -23,7 +23,8 @@ namespace libp2p::peer {
 
     outcome::result<PubVecPtr> getPublicKeys(const PeerId &p) override;
 
-    outcome::result<void> addPublicKey(const PeerId &p, const crypto::PublicKey &pub) override;
+    outcome::result<void> addPublicKey(const PeerId &p,
+                                       const crypto::PublicKey &pub) override;
 
     outcome::result<KeyPairVecPtr> getKeyPairs() override;
 
@@ -38,4 +39,4 @@ namespace libp2p::peer {
 
 }  // namespace libp2p::peer
 
-#endif  //KAGOME_INMEM_KEY_REPOSITORY_HPP
+#endif  // KAGOME_INMEM_KEY_REPOSITORY_HPP

--- a/core/libp2p/peer/key_repository/inmem_key_repository.hpp
+++ b/core/libp2p/peer/key_repository/inmem_key_repository.hpp
@@ -17,22 +17,23 @@ namespace libp2p::peer {
    public:
     ~InmemKeyRepository() override = default;
 
+    InmemKeyRepository();
+
     void clear(const PeerId &p) override;
 
     outcome::result<PubVecPtr> getPublicKeys(const PeerId &p) override;
 
-    void addPublicKey(const PeerId &p, const crypto::PublicKey &pub) override;
+    outcome::result<void> addPublicKey(const PeerId &p, const crypto::PublicKey &pub) override;
 
-    outcome::result<KeyPairVecPtr> getKeyPairs(const PeerId &p) override;
+    outcome::result<KeyPairVecPtr> getKeyPairs() override;
 
-    void addKeyPair(const PeerId &p, const KeyPair &kp) override;
+    outcome::result<void> addKeyPair(const KeyPair &kp) override;
 
     std::unordered_set<PeerId> getPeers() const override;
 
-
    private:
     std::unordered_map<PeerId, PubVecPtr> pub_;
-    std::unordered_map<PeerId, KeyPairVecPtr> kp_;
+    KeyPairVecPtr kp_;
   };
 
 }  // namespace libp2p::peer

--- a/test/core/libp2p/peer/key_book/inmem_key_repository_test.cpp
+++ b/test/core/libp2p/peer/key_book/inmem_key_repository_test.cpp
@@ -38,14 +38,14 @@ struct InmemKeyRepositoryTest : ::testing::Test {
 };
 
 TEST_F(InmemKeyRepositoryTest, PubkeyStore) {
-  db_->addPublicKey(p1_, {{Key::Type::ED25519, Buffer{'a'}}});
-  db_->addPublicKey(p1_, {{Key::Type::ED25519, Buffer{'b'}}});
+  EXPECT_OUTCOME_TRUE_1(db_->addPublicKey(p1_, {{Key::Type::ED25519, Buffer{'a'}}}));
+  EXPECT_OUTCOME_TRUE_1(db_->addPublicKey(p1_, {{Key::Type::ED25519, Buffer{'b'}}}));
   // insert same pubkey. it should not be inserted
-  db_->addPublicKey(p1_, {{Key::Type::ED25519, Buffer{'b'}}});
+  EXPECT_OUTCOME_TRUE_1(db_->addPublicKey(p1_, {{Key::Type::ED25519, Buffer{'b'}}}));
   // same pubkey but different type
-  db_->addPublicKey(p1_, {{Key::Type::RSA1024, Buffer{'b'}}});
+  EXPECT_OUTCOME_TRUE_1(db_->addPublicKey(p1_, {{Key::Type::RSA1024, Buffer{'b'}}}));
   // put pubkey to different peer
-  db_->addPublicKey(p2_, {{Key::Type::RSA4096, Buffer{'c'}}});
+  EXPECT_OUTCOME_TRUE_1(db_->addPublicKey(p2_, {{Key::Type::RSA4096, Buffer{'c'}}}));
 
   EXPECT_OUTCOME_TRUE(v, db_->getPublicKeys(p1_));
   EXPECT_EQ(v->size(), 3);
@@ -59,9 +59,9 @@ TEST_F(InmemKeyRepositoryTest, KeyPairStore) {
   PublicKey pub = {{Key::Type::RSA1024, Buffer{'a'}}};
   PrivateKey priv = {{Key::Type::RSA1024, Buffer{'b'}}};
   KeyPair kp{pub, priv};
-  db_->addKeyPair(p1_, {pub, priv});
+  EXPECT_OUTCOME_TRUE_1(db_->addKeyPair({pub, priv}));
 
-  EXPECT_OUTCOME_TRUE(v, db_->getKeyPairs(p1_));
+  EXPECT_OUTCOME_TRUE(v, db_->getKeyPairs());
   EXPECT_EQ(v->size(), 1);
 
   EXPECT_EQ(*v, std::unordered_set<KeyPair>{kp});
@@ -76,9 +76,9 @@ TEST_F(InmemKeyRepositoryTest, GetPeers) {
   PublicKey z{};
   KeyPair kp{};
 
-  db_->addPublicKey(p1_, z);
-  db_->addKeyPair(p2_, kp);
+  EXPECT_OUTCOME_TRUE_1(db_->addPublicKey(p1_, z));
+  EXPECT_OUTCOME_TRUE_1(db_->addKeyPair(kp));
 
   auto s = db_->getPeers();
-  EXPECT_EQ(s.size(), 2);
+  EXPECT_EQ(s.size(), 1);
 }


### PR DESCRIPTION
- Identity manager is a component, which "owns" node's keypair (e.g. peer id), and lets others consume this info