### PR TITLE
Make rust version on CI fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -134,8 +134,8 @@ install:
     pip3 install --user --upgrade requests gitpython cmake gcovr
   - export PATH="$HOME/.cargo/bin:$PATH"
   - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
-  - rustup install nightly
-  - rustup default nightly
+  - rustup install nightly-2019-07-07
+  - rustup default nightly-2019-07-07
 
 
 before_script:


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Set rust version on CI to nightly build of 7th of July, 2019. This is made because the current nightly build is broken.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Project will be buildable again.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Rust on CI will have to be updated manually.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
