### PR TITLE
Streams with tag

### DIFF
--- a/core/common/buffer.hpp
+++ b/core/common/buffer.hpp
@@ -224,9 +224,8 @@ namespace kagome::common {
    * @param buffer value to encode
    * @return reference to stream
    */
-  template <
-      class Stream,
-      typename = std::enable_if_t<!std::is_same<Stream, std::ostream>::value>>
+  template <class Stream,
+            typename = std::enable_if_t<Stream::is_encoder_stream>>
   Stream &operator<<(Stream &s, const Buffer &buffer) {
     return s << buffer.toVector();
   }
@@ -238,7 +237,8 @@ namespace kagome::common {
    * @param buffer value to decode
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream,
+            typename = std::enable_if_t<Stream::is_decoder_stream>>
   Stream &operator>>(Stream &s, Buffer &buffer) {
     std::vector<uint8_t> data;
     s >> data;

--- a/core/libp2p/muxer/yamux/yamuxed_connection.hpp
+++ b/core/libp2p/muxer/yamux/yamuxed_connection.hpp
@@ -47,7 +47,7 @@ namespace libp2p::connection {
      * @param config to configure this instance
      * @param logger to output messages
      */
-    YamuxedConnection(
+    explicit YamuxedConnection(
         std::shared_ptr<SecureConnection> connection,
         muxer::MuxedConnectionConfig config = {},
         kagome::common::Logger logger = kagome::common::createLogger("Yamux"));

--- a/core/primitives/block.hpp
+++ b/core/primitives/block.hpp
@@ -26,7 +26,8 @@ namespace kagome::primitives {
    * @param v value to output
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream,
+            typename = std::enable_if_t<Stream::is_encoder_stream>>
   Stream &operator<<(Stream &s, const Block &b) {
     return s << b.header << b.extrinsics;
   }
@@ -38,7 +39,8 @@ namespace kagome::primitives {
    * @param v value to decode
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream,
+            typename = std::enable_if_t<Stream::is_decoder_stream>>
   Stream &operator>>(Stream &s, Block &b) {
     return s >> b.header >> b.extrinsics;
   }

--- a/core/primitives/block_header.hpp
+++ b/core/primitives/block_header.hpp
@@ -29,7 +29,8 @@ namespace kagome::primitives {
    * @param v value to output
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream,
+            typename = std::enable_if_t<Stream::is_encoder_stream>>
   Stream &operator<<(Stream &s, const BlockHeader &bh) {
     return s << bh.parent_hash << bh.number << bh.state_root
              << bh.extrinsics_root << bh.digest;
@@ -42,7 +43,8 @@ namespace kagome::primitives {
    * @param v value to output
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream,
+            typename = std::enable_if_t<Stream::is_decoder_stream>>
   Stream &operator>>(Stream &s, BlockHeader &bh) {
     return s >> bh.parent_hash >> bh.number >> bh.state_root
         >> bh.extrinsics_root >> bh.digest;

--- a/core/primitives/check_inherents_result.hpp
+++ b/core/primitives/check_inherents_result.hpp
@@ -21,7 +21,8 @@ namespace kagome::primitives {
     primitives::InherentData errors;
   };
 
-  template <class Stream>
+  template <class Stream,
+            typename = std::enable_if_t<Stream::is_decoder_stream>>
   Stream &operator>>(Stream &s, CheckInherentsResult &v) {
     return s >> v.is_okay >> v.is_fatal_error >> v.errors;
   }

--- a/core/primitives/extrinsic.hpp
+++ b/core/primitives/extrinsic.hpp
@@ -23,9 +23,11 @@ namespace kagome::primitives {
    * @param v value to output
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream,
+            typename = std::enable_if_t<Stream::is_encoder_stream>>
   Stream &operator<<(Stream &s, const Extrinsic &v) {
-    return s << v.data.toVector();
+    //    return s << v.data.toVector();
+    return s;
   }
 
   /**
@@ -35,7 +37,8 @@ namespace kagome::primitives {
    * @param v value to output
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream,
+            typename = std::enable_if_t<Stream::is_decoder_stream>>
   Stream &operator>>(Stream &s, Extrinsic &v) {
     return s >> v.data;
   }

--- a/core/primitives/extrinsic.hpp
+++ b/core/primitives/extrinsic.hpp
@@ -26,8 +26,7 @@ namespace kagome::primitives {
   template <class Stream,
             typename = std::enable_if_t<Stream::is_encoder_stream>>
   Stream &operator<<(Stream &s, const Extrinsic &v) {
-    //    return s << v.data.toVector();
-    return s;
+    return s << v.data.toVector();
   }
 
   /**

--- a/core/primitives/inherent_data.hpp
+++ b/core/primitives/inherent_data.hpp
@@ -68,7 +68,7 @@ namespace kagome::primitives {
    * @param v value to output
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream, typename = std::enable_if_t<Stream::is_encoder_stream>>
   Stream &operator<<(Stream &s, const InherentData &v) {
     const auto &data = v.getDataCollection();
     // vectors
@@ -93,7 +93,8 @@ namespace kagome::primitives {
    * @param v value to decode
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream,
+            typename = std::enable_if_t<Stream::is_decoder_stream>>
   Stream &operator>>(Stream &s, InherentData &v) {
     std::vector<InherentIdentifier> ids;
     std::vector<common::Buffer> vals;

--- a/core/primitives/parachain_host.hpp
+++ b/core/primitives/parachain_host.hpp
@@ -54,7 +54,7 @@ namespace kagome::primitives::parachain {
    * @param v value to output
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream, typename = std::enable_if_t<Stream::is_encoder_stream>>
   Stream &operator<<(Stream &s, const Relay &v) {
     return s;
   }
@@ -66,7 +66,8 @@ namespace kagome::primitives::parachain {
    * @param v value to decode
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream,
+            typename = std::enable_if_t<Stream::is_decoder_stream>>
   Stream &operator>>(Stream &s, Relay &v) {
     return s;
   }

--- a/core/primitives/scheduled_change.hpp
+++ b/core/primitives/scheduled_change.hpp
@@ -36,7 +36,8 @@ namespace kagome::primitives {
    * @param v value to output
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream,
+            typename = std::enable_if_t<Stream::is_encoder_stream>>
   Stream &operator<<(Stream &s, const ScheduledChange &v) {
     return s << v.next_authorities << v.delay;
   }
@@ -48,7 +49,8 @@ namespace kagome::primitives {
    * @param v value to decode
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream,
+            typename = std::enable_if_t<Stream::is_decoder_stream>>
   Stream &operator>>(Stream &s, ScheduledChange &v) {
     return s >> v.next_authorities >> v.delay;
   }

--- a/core/primitives/transaction_validity.hpp
+++ b/core/primitives/transaction_validity.hpp
@@ -77,7 +77,7 @@ namespace kagome::primitives {
    * @param v value to output
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream, typename = std::enable_if_t<Stream::is_encoder_stream>>
   Stream &operator<<(Stream &s, const Invalid &v) {
     return s << v.error;
   }
@@ -89,7 +89,7 @@ namespace kagome::primitives {
    * @param v value to output
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream, typename = std::enable_if_t<Stream::is_encoder_stream>>
   Stream &operator<<(Stream &s, const Valid &v) {
     return s << v.priority << v.requires << v.provides << v.longevity;
   }
@@ -101,7 +101,7 @@ namespace kagome::primitives {
    * @param v value to output
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream, typename = std::enable_if_t<Stream::is_encoder_stream>>
   Stream &operator<<(Stream &s, const Unknown &v) {
     return s << v.error;
   }
@@ -113,7 +113,8 @@ namespace kagome::primitives {
    * @param v value to decode
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream,
+            typename = std::enable_if_t<Stream::is_decoder_stream>>
   Stream &operator>>(Stream &s, Invalid &v) {
     return s >> v.error;
   }
@@ -125,7 +126,8 @@ namespace kagome::primitives {
    * @param v value to decode
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream,
+            typename = std::enable_if_t<Stream::is_decoder_stream>>
   Stream &operator>>(Stream &s, Valid &v) {
     return s >> v.priority >> v.requires >> v.provides >> v.longevity;
   }
@@ -137,7 +139,8 @@ namespace kagome::primitives {
    * @param v value to decode
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream,
+            typename = std::enable_if_t<Stream::is_decoder_stream>>
   Stream &operator>>(Stream &s, Unknown &v) {
     return s >> v.error;
   }

--- a/core/primitives/version.hpp
+++ b/core/primitives/version.hpp
@@ -76,7 +76,7 @@ namespace kagome::primitives {
    * @param v value to output
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream, typename = std::enable_if_t<Stream::is_encoder_stream>>
   Stream &operator<<(Stream &s, const Version &v) {
     return s << v.spec_name << v.impl_name << v.authoring_version
              << v.impl_version << v.apis;
@@ -89,7 +89,8 @@ namespace kagome::primitives {
    * @param v value to decode
    * @return reference to stream
    */
-  template <class Stream>
+  template <class Stream,
+            typename = std::enable_if_t<Stream::is_decoder_stream>>
   Stream &operator>>(Stream &s, Version &v) {
     return s >> v.spec_name >> v.impl_name >> v.authoring_version
         >> v.impl_version >> v.apis;

--- a/core/scale/scale_decoder_stream.hpp
+++ b/core/scale/scale_decoder_stream.hpp
@@ -16,6 +16,9 @@
 namespace kagome::scale {
   class ScaleDecoderStream {
    public:
+    // special tag to differentiate decoding streams from others
+    static constexpr std::true_type is_decoder_stream;
+
     explicit ScaleDecoderStream(gsl::span<const uint8_t> span);
 
     /**

--- a/core/scale/scale_decoder_stream.hpp
+++ b/core/scale/scale_decoder_stream.hpp
@@ -17,7 +17,7 @@ namespace kagome::scale {
   class ScaleDecoderStream {
    public:
     // special tag to differentiate decoding streams from others
-    static constexpr std::true_type is_decoder_stream;
+    static constexpr auto is_decoder_stream = true;
 
     explicit ScaleDecoderStream(gsl::span<const uint8_t> span);
 

--- a/core/scale/scale_encoder_stream.hpp
+++ b/core/scale/scale_encoder_stream.hpp
@@ -19,6 +19,8 @@ namespace kagome::scale {
    */
   class ScaleEncoderStream {
    public:
+    // special tag to differentiate encoding streams from others
+    static constexpr std::true_type is_encoder_stream;
     /// Getters
     /**
      * @return vector of bytes containing encoded data

--- a/core/scale/scale_encoder_stream.hpp
+++ b/core/scale/scale_encoder_stream.hpp
@@ -20,7 +20,8 @@ namespace kagome::scale {
   class ScaleEncoderStream {
    public:
     // special tag to differentiate encoding streams from others
-    static constexpr std::true_type is_encoder_stream;
+    static constexpr auto is_encoder_stream = true;
+
     /// Getters
     /**
      * @return vector of bytes containing encoded data

--- a/core/transaction_pool/impl/transaction_pool_impl.hpp
+++ b/core/transaction_pool/impl/transaction_pool_impl.hpp
@@ -25,7 +25,7 @@ namespace kagome::transaction_pool {
     static constexpr size_t kDefaultMaxWaitingNum = 128;
 
    public:
-    TransactionPoolImpl(
+    explicit TransactionPoolImpl(
         std::unique_ptr<PoolModerator> moderator,
         Limits limits = Limits{kDefaultMaxReadyNum, kDefaultMaxWaitingNum},
         common::Logger logger = common::createLogger(kDefaultLoggerTag));

--- a/test/core/scale/scale_boolean_test.cpp
+++ b/test/core/scale/scale_boolean_test.cpp
@@ -45,8 +45,9 @@ struct ThreeBooleans {
   bool b3 = false;
 };
 
-template <class Stream>
-Stream &operator>>(Stream &s, ThreeBooleans &v) {
+template <class Stream,
+            typename = std::enable_if_t<Stream::is_decoder_stream>>
+  Stream &operator>>(Stream &s, ThreeBooleans &v) {
   return s >> v.b1 >> v.b2 >> v.b3;
 }
 

--- a/test/core/scale/scale_convenience_functions_test.cpp
+++ b/test/core/scale/scale_convenience_functions_test.cpp
@@ -20,14 +20,6 @@ struct TestStruct {
   }
 };
 
-namespace std {
-  inline std::ostream &operator<<(std::ostream &s,
-                                  const TestStruct &test_struct) {
-    s << test_struct.a << test_struct.b;
-    return s;
-  }
-}  // namespace std
-
 template <class Stream, typename = std::enable_if_t<Stream::is_encoder_stream>>
   Stream &operator<<(Stream &s, const TestStruct &test_struct) {
   return s << test_struct.a << test_struct.b;

--- a/test/core/scale/scale_convenience_functions_test.cpp
+++ b/test/core/scale/scale_convenience_functions_test.cpp
@@ -28,13 +28,14 @@ namespace std {
   }
 }  // namespace std
 
-template <class Stream>
-Stream &operator<<(Stream &s, const TestStruct &test_struct) {
+template <class Stream, typename = std::enable_if_t<Stream::is_encoder_stream>>
+  Stream &operator<<(Stream &s, const TestStruct &test_struct) {
   return s << test_struct.a << test_struct.b;
 }
 
-template <class Stream>
-Stream &operator>>(Stream &s, TestStruct &test_struct) {
+template <class Stream,
+            typename = std::enable_if_t<Stream::is_decoder_stream>>
+  Stream &operator>>(Stream &s, TestStruct &test_struct) {
   return s >> test_struct.a >> test_struct.b;
 }
 

--- a/test/core/scale/scale_optional_test.cpp
+++ b/test/core/scale/scale_optional_test.cpp
@@ -160,7 +160,7 @@ struct FourOptBools {
   std::optional<bool> b4;
 };
 
-template <class Stream>
+template <class Stream, typename = std::enable_if_t<Stream::is_decoder_stream>>
 Stream &operator>>(Stream &s, FourOptBools &v) {
   return s >> v.b1 >> v.b2 >> v.b3 >> v.b4;
 }


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Due to ambiguity of operators << and >> introduced by template functions created by us, there should be done some fix to avoid cases when some libraries have their own implementations for such operators

### Benefits

No more problems with GTest, which could not build tests where our structs with operators << and >> introduce ambguity

### Possible Drawbacks 

If we want to use our operators, we need to add encoding/decoding tags to stream classes