### PR TITLE
ed25519 provider

### DIFF
--- a/core/crypto/CMakeLists.txt
+++ b/core/crypto/CMakeLists.txt
@@ -25,6 +25,15 @@ target_link_libraries(sr25519_types
     sr25519
     )
 
+add_library(ed25519_types
+    ed25519_types.cpp
+    ed25519_types.hpp
+    )
+target_link_libraries(ed25519_types
+    blob
+    iroha::ed25519
+    )
+
 add_library(crypto_util
     hash_creator.cpp
     util.hpp
@@ -53,8 +62,17 @@ add_library(sr25519_provider
     )
 target_link_libraries(sr25519_provider
     random_generator # generator from libp2p
-    sr25519
     sr25519_types
+    )
+
+add_library(ed25519_provider
+    ed25519_provider.hpp
+    ed25519/ed25519_provider_impl.hpp
+    ed25519/ed25519_provider_impl.cpp
+    )
+target_link_libraries(ed25519_provider
+    random_generator # generator from libp2p
+    ed25519_types
     )
 
 add_subdirectory(blake2)

--- a/core/crypto/ed25519/ed25519_provider_impl.cpp
+++ b/core/crypto/ed25519/ed25519_provider_impl.cpp
@@ -1,0 +1,107 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "crypto/ed25519/ed25519_provider_impl.hpp"
+
+namespace kagome::crypto {
+
+  outcome::result<ED25519Keypair> ED25519ProviderImpl::generateKeypair() const {
+    private_key_t private_key_low{};
+    public_key_t public_key_low{};
+
+    auto res = ed25519_create_keypair(&private_key_low, &public_key_low);
+    if (!res) {
+      return ED25519ProviderError::FAILED_GENERATE_KEYPAIR;
+    }
+
+    auto priv_span = gsl::make_span<uint8_t>(private_key_low.data,
+                                             constants::ed25519::PRIVKEY_SIZE);
+
+    auto pub_span = gsl::make_span<uint8_t>(public_key_low.data,
+                                            constants::ed25519::PUBKEY_SIZE);
+
+    OUTCOME_TRY(private_key_high, ED25519PrivateKey::fromSpan(priv_span));
+    OUTCOME_TRY(public_key_high, ED25519PublicKey::fromSpan(pub_span));
+
+    return ED25519Keypair{private_key_high, public_key_high};
+  }
+
+  outcome::result<ED25519Signature> ED25519ProviderImpl::sign(
+      const ED25519Keypair &keypair, gsl::span<uint8_t> message) const {
+    signature_t signature_low{};
+    public_key_t public_key{};
+    private_key_t private_key{};
+    auto private_span = gsl::make_span<uint8_t>(
+        private_key.data, constants::ed25519::PRIVKEY_SIZE);
+    auto public_span = gsl::make_span<uint8_t>(public_key.data,
+                                               constants::ed25519::PUBKEY_SIZE);
+    std::copy_n(keypair.private_key.begin(),
+                constants::ed25519::PRIVKEY_SIZE,
+                private_span.begin());
+    std::copy_n(keypair.public_key.begin(),
+                constants::ed25519::PUBKEY_SIZE,
+                public_span.begin());
+
+    try {
+      ed25519_sign(&signature_low,
+                   message.data(),
+                   message.size(),
+                   &public_key,
+                   &private_key);
+    } catch (...) {
+      return ED25519ProviderError::SIGN_UNKNOWN_ERROR;
+    }
+
+    ED25519Signature signature{};
+    auto signature_span = gsl::make_span<uint8_t>(
+        signature_low.data, constants::ed25519::SIGNATURE_SIZE);
+    std::copy_n(signature_span.begin(),
+                constants::ed25519::SIGNATURE_SIZE,
+                signature.begin());
+
+    return signature;
+  }
+
+  outcome::result<bool> ED25519ProviderImpl::verify(
+      const ED25519Signature &signature,
+      gsl::span<uint8_t> message,
+      const ED25519PublicKey &public_key) const {
+    public_key_t public_key_low{};
+    signature_t signature_low{};
+    auto public_span = gsl::span<uint8_t>(public_key_low.data,
+                                          constants::ed25519::PUBKEY_SIZE);
+    auto signature_span = gsl::span<uint8_t>(
+        signature_low.data, constants::ed25519::SIGNATURE_SIZE);
+
+    std::copy_n(signature.data(),
+                constants::ed25519::SIGNATURE_SIZE,
+                signature_low.data);
+
+    std::copy_n(public_key.data(),
+                constants::ed25519::PUBKEY_SIZE,
+                public_key_low.data);
+
+    try {
+      const auto res = ed25519_verify(
+          &signature_low, message.data(), message.size(), &public_key_low);
+      return res == ED25519_SUCCESS;
+    } catch (...) {
+      return ED25519ProviderError::VERIFY_UNKNOWN_ERROR;
+    }
+  }
+}  // namespace kagome::crypto
+
+OUTCOME_CPP_DEFINE_CATEGORY(kagome::crypto, ED25519ProviderError, e) {
+  using kagome::crypto::ED25519ProviderError;
+  switch (e) {
+    case ED25519ProviderError::FAILED_GENERATE_KEYPAIR:
+      return "failed to generate keypair, maybe problems with random source";
+    case ED25519ProviderError::SIGN_UNKNOWN_ERROR:
+      return "failed to sign message, unknown error occured";
+    case ED25519ProviderError::VERIFY_UNKNOWN_ERROR:
+      return "faield to verify message, unknown error occured";
+  }
+  return "unknown SR25519ProviderError";
+}

--- a/core/crypto/ed25519/ed25519_provider_impl.hpp
+++ b/core/crypto/ed25519/ed25519_provider_impl.hpp
@@ -1,0 +1,31 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_CORE_CRYPTO_ED25519_ED25519_PROVIDER_IMPL_HPP
+#define KAGOME_CORE_CRYPTO_ED25519_ED25519_PROVIDER_IMPL_HPP
+
+#include "crypto/ed25519_provider.hpp"
+
+namespace kagome::crypto {
+
+  class ED25519ProviderImpl : public ED25519Provider {
+   public:
+    ~ED25519ProviderImpl() override = default;
+
+    outcome::result<ED25519Keypair> generateKeypair() const override;
+
+    outcome::result<kagome::crypto::ED25519Signature> sign(
+        const ED25519Keypair &keypair,
+        gsl::span<uint8_t> message) const override;
+
+    outcome::result<bool> verify(
+        const ED25519Signature &signature,
+        gsl::span<uint8_t> message,
+        const ED25519PublicKey &public_key) const override;
+  };
+
+}  // namespace kagome::crypto
+
+#endif  //KAGOME_CORE_CRYPTO_ED25519_ED25519_PROVIDER_IMPL_HPP

--- a/core/crypto/ed25519_provider.hpp
+++ b/core/crypto/ed25519_provider.hpp
@@ -14,8 +14,10 @@ namespace kagome::crypto {
 
   enum class ED25519ProviderError {
     FAILED_GENERATE_KEYPAIR = 1,
-    SIGN_UNKNOWN_ERROR,
-    VERIFY_UNKNOWN_ERROR
+    SIGN_UNKNOWN_ERROR,   // unknown error occurred during call to `sign` method
+                          // of bound function
+    VERIFY_UNKNOWN_ERROR  // unknown error occured during call to `verify`
+                          // method of bound function
   };
 
   class ED25519Provider {

--- a/core/crypto/ed25519_provider.hpp
+++ b/core/crypto/ed25519_provider.hpp
@@ -1,0 +1,55 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_CORE_CRYPTO_ED25519_PROVIDER_HPP
+#define KAGOME_CORE_CRYPTO_ED25519_PROVIDER_HPP
+
+#include <gsl/span>
+#include <outcome/outcome.hpp>
+#include "crypto/ed25519_types.hpp"
+
+namespace kagome::crypto {
+
+  enum class ED25519ProviderError {
+    FAILED_GENERATE_KEYPAIR = 1,
+    SIGN_UNKNOWN_ERROR,
+    VERIFY_UNKNOWN_ERROR
+  };
+
+  class ED25519Provider {
+   public:
+    virtual ~ED25519Provider() = default;
+
+    /**
+     * Generates random keypair for signing the message
+     * @return ed25519 key pair if succeeded of error if failed
+     */
+    virtual outcome::result<ED25519Keypair> generateKeypair() const = 0;
+
+    /**
+     * Sign message \param msg using \param keypair. If computed value is less
+     * than \param threshold then return optional containing this value and
+     * proof. Otherwise none returned
+     * @param keypair pair of public and private ed25519 keys
+     * @param message bytes to be signed
+     * @return signed message
+     */
+    virtual outcome::result<ED25519Signature> sign(
+        const ED25519Keypair &keypair, gsl::span<uint8_t> message) const = 0;
+
+    /**
+     * Verifies that \param message was derived using \param public_key on
+     * \param signature
+     */
+    virtual outcome::result<bool> verify(
+        const ED25519Signature &signature,
+        gsl::span<uint8_t> message,
+        const ED25519PublicKey &public_key) const = 0;
+  };
+}  // namespace kagome::crypto
+
+OUTCOME_HPP_DECLARE_ERROR(kagome::crypto, ED25519ProviderError)
+
+#endif  // KAGOME_CORE_CRYPTO_ED25519_PROVIDER_HPP

--- a/core/crypto/ed25519_types.cpp
+++ b/core/crypto/ed25519_types.cpp
@@ -1,0 +1,16 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ed25519_types.hpp"
+
+namespace kagome::crypto {
+  bool ED25519Keypair::operator==(const ED25519Keypair &other) const {
+    return private_key == other.private_key && public_key == other.public_key;
+  }
+
+  bool ED25519Keypair::operator!=(const ED25519Keypair &other) const {
+    return !(*this == other);
+  }
+}  // namespace kagome::crypto

--- a/core/crypto/ed25519_types.hpp
+++ b/core/crypto/ed25519_types.hpp
@@ -11,14 +11,29 @@
 
 namespace kagome::crypto {
 
-  using ED25519PrivateKey = common::Blob<ed25519_privkey_SIZE>;
-  using ED25519PublicKey = common::Blob<ed25519_pubkey_SIZE>;
-  struct ED25519KeyPair {
-    ED25519PrivateKey private_key_{};
-    ED25519PublicKey public_key_{};
-  };
-  using ED25519Signature = common::Blob<ed25519_signature_SIZE>;
+  namespace constants::ed25519 {
+    /**
+     * Important constants to deal with ed25519
+     */
+    enum {
+      PRIVKEY_SIZE = ed25519_privkey_SIZE,
+      PUBKEY_SIZE = ed25519_pubkey_SIZE,
+      SIGNATURE_SIZE = ed25519_signature_SIZE
+    };
+  }  // namespace constants::ed25519
 
+  using ED25519PrivateKey = common::Blob<constants::ed25519::PRIVKEY_SIZE>;
+  using ED25519PublicKey = common::Blob<constants::ed25519::PUBKEY_SIZE>;
+
+  struct ED25519Keypair {
+    ED25519PrivateKey private_key;
+    ED25519PublicKey public_key;
+
+    bool operator==(const ED25519Keypair &other) const;
+    bool operator!=(const ED25519Keypair &other) const;
+  };
+
+  using ED25519Signature = common::Blob<constants::ed25519::SIGNATURE_SIZE>;
 }  // namespace kagome::crypto
 
 #endif  // KAGOME_CORE_CRYPTO_ED25519_TYPES_HPP

--- a/core/crypto/sr25519/sr25519_provider_impl.cpp
+++ b/core/crypto/sr25519/sr25519_provider_impl.cpp
@@ -10,7 +10,9 @@
 
 namespace kagome::crypto {
   SR25519ProviderImpl::SR25519ProviderImpl(std::shared_ptr<CSPRNG> generator)
-      : generator_(std::move(generator)) {}
+      : generator_(std::move(generator)) {
+    BOOST_ASSERT(generator_ != nullptr);
+  }
 
   SR25519Keypair SR25519ProviderImpl::generateKeypair() const {
     auto seed = generator_->randomBytes(constants::sr25519::SEED_SIZE);

--- a/core/crypto/sr25519/sr25519_provider_impl.hpp
+++ b/core/crypto/sr25519/sr25519_provider_impl.hpp
@@ -15,11 +15,6 @@ namespace libp2p::crypto::random {
 
 namespace kagome::crypto {
 
-  enum class SR25519ProviderError {
-    SIGN_UNKNOWN_ERROR = 1,
-    VERIFY_UNKNOWN_ERROR
-  };
-
   class SR25519ProviderImpl : public SR25519Provider {
     using CSPRNG = libp2p::crypto::random::CSPRNG;
 
@@ -44,7 +39,5 @@ namespace kagome::crypto {
   };
 
 }  // namespace kagome::crypto
-
-OUTCOME_HPP_DECLARE_ERROR(kagome::crypto, SR25519ProviderError)
 
 #endif  // KAGOME_CORE_CRYPTO_SR25519_SR25519_PROVIDER_IMPL_HPP

--- a/core/crypto/sr25519_provider.hpp
+++ b/core/crypto/sr25519_provider.hpp
@@ -11,6 +11,12 @@
 #include "crypto/sr25519_types.hpp"
 
 namespace kagome::crypto {
+
+  enum class SR25519ProviderError {
+    SIGN_UNKNOWN_ERROR = 1,
+    VERIFY_UNKNOWN_ERROR
+  };
+
   class SR25519Provider {
    public:
     virtual ~SR25519Provider() = default;
@@ -41,5 +47,7 @@ namespace kagome::crypto {
         const SR25519PublicKey &public_key) const = 0;
   };
 }  // namespace kagome::crypto
+
+OUTCOME_HPP_DECLARE_ERROR(kagome::crypto, SR25519ProviderError)
 
 #endif  // KAGOME_CORE_CRYPTO_SR25519_PROVIDER_HPP

--- a/core/crypto/sr25519_provider.hpp
+++ b/core/crypto/sr25519_provider.hpp
@@ -12,9 +12,14 @@
 
 namespace kagome::crypto {
 
+  /**
+   * sr25519 provider error codes
+   */
   enum class SR25519ProviderError {
-    SIGN_UNKNOWN_ERROR = 1,
-    VERIFY_UNKNOWN_ERROR
+    SIGN_UNKNOWN_ERROR = 1,  // unknown error occured during call to `sign`
+                             // method of bound function
+    VERIFY_UNKNOWN_ERROR  // unknown error occured during call to `verify`
+                          // method of bound function
   };
 
   class SR25519Provider {

--- a/core/extensions/extension_impl.cpp
+++ b/core/extensions/extension_impl.cpp
@@ -5,6 +5,7 @@
 
 #include "extensions/extension_impl.hpp"
 
+#include "crypto/ed25519/ed25519_provider_impl.hpp"
 #include "crypto/random_generator/boost_generator.hpp"
 #include "crypto/sr25519/sr25519_provider_impl.hpp"
 
@@ -17,7 +18,8 @@ namespace kagome::extensions {
         db_(std::move(db)),
         crypto_ext_(memory,
                     std::make_shared<crypto::SR25519ProviderImpl>(
-                        std::make_shared<crypto::BoostRandomGenerator>())),
+                        std::make_shared<crypto::BoostRandomGenerator>()),
+                    std::make_shared<crypto::ED25519ProviderImpl>()),
         io_ext_(memory),
         memory_ext_(memory),
         storage_ext_(db_, memory_) {}

--- a/core/extensions/impl/CMakeLists.txt
+++ b/core/extensions/impl/CMakeLists.txt
@@ -8,10 +8,9 @@ add_library(crypto_extension
     )
 target_link_libraries(crypto_extension
     blake2
-    iroha::ed25519
     random_generator
     sr25519_provider
-    sr25519_types
+    ed25519_provider
     twox
     )
 

--- a/core/extensions/impl/crypto_extension.cpp
+++ b/core/extensions/impl/crypto_extension.cpp
@@ -8,20 +8,27 @@
 #include <algorithm>
 #include <exception>
 
-#include <ed25519/ed25519.h>
 #include <gsl/span>
 #include "crypto/blake2/blake2b.h"
-#include "crypto/sr25519/sr25519_provider_impl.hpp"
+#include "crypto/ed25519_provider.hpp"
+#include "crypto/sr25519_provider.hpp"
 #include "crypto/twox/twox.hpp"
 
 namespace kagome::extensions {
   namespace sr25519_constants = crypto::constants::sr25519;
+  namespace ed25519_constants = crypto::constants::ed25519;
 
   CryptoExtension::CryptoExtension(
       std::shared_ptr<runtime::WasmMemory> memory,
-      std::shared_ptr<crypto::SR25519Provider> sr25519_provider)
+      std::shared_ptr<crypto::SR25519Provider> sr25519_provider,
+      std::shared_ptr<crypto::ED25519Provider> ed25519_provider)
       : memory_(std::move(memory)),
-        sr25519_provider_(std::move(sr25519_provider)) {}
+        sr25519_provider_(std::move(sr25519_provider)),
+        ed25519_provider_(std::move(ed25519_provider)) {
+    BOOST_ASSERT(memory_ != nullptr);
+    BOOST_ASSERT(sr25519_provider_ != nullptr);
+    BOOST_ASSERT(ed25519_provider_ != nullptr);
+  }
 
   void CryptoExtension::ext_blake2_256(runtime::WasmPointer data,
                                        runtime::SizeType len,
@@ -44,23 +51,28 @@ namespace kagome::extensions {
     static constexpr uint32_t kVerifySuccess = 0;
     static constexpr uint32_t kVerifyFail = 5;
 
-    const auto &msg = memory_->loadN(msg_data, msg_len);
+    auto msg = memory_->loadN(msg_data, msg_len);
     auto sig_bytes =
-        memory_->loadN(sig_data, ed25519_signature_SIZE).toVector();
-    signature_t signature{};
-    gsl::span<uint8_t> sig_span(signature.data);
-    std::copy(sig_bytes.begin(), sig_bytes.end(), sig_span.begin());
+        memory_->loadN(sig_data, ed25519_constants::SIGNATURE_SIZE).toVector();
+
+    auto signature_res = crypto::ED25519Signature::fromSpan(sig_bytes);
+    if (!signature_res) {
+      BOOST_UNREACHABLE_RETURN(kVerifyFail);
+    }
+    auto &&signature = signature_res.value();
 
     auto pubkey_bytes =
-        memory_->loadN(pubkey_data, ed25519_pubkey_SIZE).toVector();
-    public_key_t pubkey{};
-    gsl::span<uint8_t> pubkey_span(pubkey.data);
-    std::copy(pubkey_bytes.begin(), pubkey_bytes.end(), pubkey_span.begin());
+        memory_->loadN(pubkey_data, ed25519_constants::PUBKEY_SIZE).toVector();
+    auto pubkey_res = crypto::ED25519PublicKey::fromSpan(pubkey_bytes);
+    if (!pubkey_res) {
+      BOOST_UNREACHABLE_RETURN(kVerifyFail);
+    }
+    auto &&pubkey = pubkey_res.value();
 
-    return ed25519_verify(&signature, msg.data(), msg_len, &pubkey)
-                   == ED25519_SUCCESS
-               ? kVerifySuccess
-               : kVerifyFail;
+    auto result = ed25519_provider_->verify(signature, msg, pubkey);
+    auto is_succeeded = result && result.value();
+
+    return is_succeeded ? kVerifySuccess : kVerifyFail;
   }
 
   runtime::SizeType CryptoExtension::ext_sr25519_verify(

--- a/core/extensions/impl/crypto_extension.hpp
+++ b/core/extensions/impl/crypto_extension.hpp
@@ -12,7 +12,8 @@
 
 namespace kagome::crypto {
   class SR25519Provider;
-}
+  class ED25519Provider;
+}  // namespace kagome::crypto
 
 namespace kagome::extensions {
   /**
@@ -20,8 +21,10 @@ namespace kagome::extensions {
    */
   class CryptoExtension {
    public:
-    explicit CryptoExtension(std::shared_ptr<runtime::WasmMemory> memory,
-                             std::shared_ptr<crypto::SR25519Provider> sr25519_provider);
+    explicit CryptoExtension(
+        std::shared_ptr<runtime::WasmMemory> memory,
+        std::shared_ptr<crypto::SR25519Provider> sr25519_provider,
+        std::shared_ptr<crypto::ED25519Provider> ed25519_provider);
 
     /**
      * @see Extension::ext_blake2_256
@@ -62,6 +65,7 @@ namespace kagome::extensions {
    private:
     std::shared_ptr<runtime::WasmMemory> memory_;
     std::shared_ptr<crypto::SR25519Provider> sr25519_provider_;
+    std::shared_ptr<crypto::ED25519Provider> ed25519_provider_;
   };
 }  // namespace kagome::extensions
 

--- a/test/core/crypto/CMakeLists.txt
+++ b/test/core/crypto/CMakeLists.txt
@@ -4,6 +4,7 @@
 #
 
 add_subdirectory(blake2)
+add_subdirectory(ed25519)
 add_subdirectory(hasher)
 add_subdirectory(sha)
 add_subdirectory(sr25519)

--- a/test/core/crypto/ed25519/CMakeLists.txt
+++ b/test/core/crypto/ed25519/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Copyright Soramitsu Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+addtest(ed25519_provider_test
+    ed25519_provider_test.cpp
+    )
+target_link_libraries(ed25519_provider_test
+    ed25519_provider
+    )

--- a/test/core/crypto/ed25519/ed25519_provider_test.cpp
+++ b/test/core/crypto/ed25519/ed25519_provider_test.cpp
@@ -30,7 +30,7 @@ struct ED25519ProviderTest : public ::testing::Test {
 };
 
 /**
- * @given sr25519 provider instance configured with boost random generator
+ * @given ed25519 provider instance configured with boost random generator
  * @when generate 2 keypairs, repeat it 10 times
  * @then each time keys are different
  */
@@ -41,4 +41,73 @@ TEST_F(ED25519ProviderTest, GenerateKeysNotEqual) {
     ASSERT_NE(kp1.public_key, kp2.public_key);
     ASSERT_NE(kp1.private_key, kp2.private_key);
   }
+}
+
+/**
+ * @given ed25519 provider instance configured with boost random generator
+ * @and a predefined message
+ * @when generate a keypair @and sign message
+ * @and verify signed message with generated public key
+ * @then verification succeeds
+ */
+TEST_F(ED25519ProviderTest, SignVerifySuccess) {
+  EXPECT_OUTCOME_TRUE(kp, ed25519_provider->generateKeypair());
+  EXPECT_OUTCOME_TRUE(signature, ed25519_provider->sign(kp, message_span));
+  EXPECT_OUTCOME_TRUE(
+      res, ed25519_provider->verify(signature, message_span, kp.public_key));
+  ASSERT_EQ(res, true);
+}
+
+/**
+ * Don't try to sign a message using invalid key pair, this may lead to
+ * program termination
+ *
+ * @given ed25519 provider instance configured with boost random generator
+ * @and a predefined message
+ * @when generate a keypair @and make public key invalid @and sign message
+ * @then sign fails
+ */
+TEST_F(ED25519ProviderTest, DISABLED_SignWithInvalidKeyFails) {
+  EXPECT_OUTCOME_TRUE(kp, ed25519_provider->generateKeypair());
+  kp.public_key.fill(1);
+  EXPECT_OUTCOME_FALSE_1(ed25519_provider->sign(kp, message_span));
+}
+
+/**
+ * @given ed25519 provider instance configured with boost random generator
+ * @and and a predefined message
+ * @when generate keypair @and sign message @and take another public key
+ * @and verify signed message
+ * @then verification succeeds, but verification result is false
+ */
+TEST_F(ED25519ProviderTest, VerifyWrongKeyFail) {
+  EXPECT_OUTCOME_TRUE(kp, ed25519_provider->generateKeypair());
+  EXPECT_OUTCOME_TRUE(signature, ed25519_provider->sign(kp, message_span));
+  // generate another valid key pair and take public one
+  EXPECT_OUTCOME_TRUE(kp1, ed25519_provider->generateKeypair());
+  EXPECT_OUTCOME_TRUE(
+      ver_res,
+      ed25519_provider->verify(signature, message_span, kp1.public_key));
+
+  ASSERT_FALSE(ver_res);
+}
+
+/**
+ * Don't try to verify a message and signature against an invalid key, this may
+ * lead to program termination
+ *
+ * @given ed25519 provider instance configured with boost random generator
+ * @and and a predefined message
+ * @when generate keypair @and sign message
+ * @and generate another keypair and take public part for verification
+ * @and verify signed message
+ * @then verification fails
+ */
+TEST_F(ED25519ProviderTest, DISABLED_VerifyInvalidKeyFail) {
+  EXPECT_OUTCOME_TRUE(kp, ed25519_provider->generateKeypair());
+  EXPECT_OUTCOME_TRUE(signature, ed25519_provider->sign(kp, message_span));
+  // make public key invalid
+  kp.public_key.fill(1);
+  EXPECT_OUTCOME_FALSE_1(
+      ed25519_provider->verify(signature, message_span, kp.public_key));
 }

--- a/test/core/crypto/ed25519/ed25519_provider_test.cpp
+++ b/test/core/crypto/ed25519/ed25519_provider_test.cpp
@@ -1,0 +1,44 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "crypto/ed25519/ed25519_provider_impl.hpp"
+
+#include <gtest/gtest.h>
+#include <gsl/span>
+#include "testutil/outcome.hpp"
+
+using kagome::crypto::ED25519Provider;
+using kagome::crypto::ED25519ProviderImpl;
+
+struct ED25519ProviderTest : public ::testing::Test {
+  void SetUp() override {
+    ed25519_provider = std::make_shared<ED25519ProviderImpl>();
+
+    std::string_view m = "i am a message";
+    message.clear();
+    message.reserve(m.length());
+    for (auto c : m) {
+      message.push_back(c);
+    }
+  }
+
+  gsl::span<uint8_t> message_span;
+  std::vector<uint8_t> message;
+  std::shared_ptr<ED25519Provider> ed25519_provider;
+};
+
+/**
+ * @given sr25519 provider instance configured with boost random generator
+ * @when generate 2 keypairs, repeat it 10 times
+ * @then each time keys are different
+ */
+TEST_F(ED25519ProviderTest, GenerateKeysNotEqual) {
+  for (auto i = 0; i < 10; ++i) {
+    EXPECT_OUTCOME_TRUE(kp1, ed25519_provider->generateKeypair());
+    EXPECT_OUTCOME_TRUE(kp2, ed25519_provider->generateKeypair());
+    ASSERT_NE(kp1.public_key, kp2.public_key);
+    ASSERT_NE(kp1.private_key, kp2.private_key);
+  }
+}


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
ed25519 provider interface and impl were implemented.
usages of row interfaces and constants from iroha::ed25519 library were replaced.
tests corrected.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
ed25519 provider behaves as a layer of abstraction between program and C library
using provider is more comfortable than row functions
using constants instead of macro definitions is more correct
concept of provider allows mocking functionality

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
In case of using invalid keys, bindings can raise panic, which may lead to program termination. 
Probably should change bindings to return error code.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
