### PR TITLE
Use new libp2p version

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -4,6 +4,12 @@ hunter_config(
     CMAKE_ARGS CMAKE_POSITION_INDEPENDENT_CODE=ON
 )
 
+hunter_config(
+    GTest
+    VERSION 1.8.0-hunter-p11
+    CMAKE_ARGS "CMAKE_CXX_FLAGS=-Wno-deprecated-copy"
+)
+
 hunter_config(sr25519
     URL https://github.com/Warchant/sr25519-crust/archive/1.0.1.tar.gz
     SHA1 3005d79b23b92ff27848c24a7751543a03a2dd13

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -4,12 +4,6 @@ hunter_config(
     CMAKE_ARGS CMAKE_POSITION_INDEPENDENT_CODE=ON
 )
 
-hunter_config(
-    GTest
-    VERSION 1.8.0-hunter-p11
-    CMAKE_ARGS "CMAKE_CXX_FLAGS=-Wno-deprecated-copy"
-)
-
 hunter_config(sr25519
     URL https://github.com/Warchant/sr25519-crust/archive/1.0.1.tar.gz
     SHA1 3005d79b23b92ff27848c24a7751543a03a2dd13
@@ -21,7 +15,21 @@ hunter_config(
     SHA1 4b10e9aa17f7d568e24f464b48358ab46cb6f39c
 )
 
+hunter_config(
+    tsl_hat_trie
+    URL https://github.com/masterjedy/hat-trie/archive/343e0dac54fc8491065e8a059a02db9a2b1248ab.zip
+    SHA1 7b0051e9388d629f382752dd6a12aa8918cdc022
+)
+
+hunter_config(
+    Boost.DI
+    URL https://github.com/masterjedy/di/archive/c5287ee710ad90f5286d0cc2b9e49b72d89267a6.zip
+    SHA1 802b64a6242be45771f3d4c86257eac0a3c7b289
+    # disable building examples and tests, disable testing
+    CMAKE_ARGS BOOST_DI_OPT_BUILD_TESTS=OFF BOOST_DI_OPT_BUILD_EXAMPLES=OFF
+)
+
 hunter_config(libp2p
-    URL https://github.com/soramitsu/libp2p/archive/dad84a03a9651c7c2bb8a8f17d0e5ea67bd10b4f.zip
-    SHA1 860742c6e3e9736d68b392513d795e09572780aa
+    URL https://github.com/soramitsu/libp2p/archive/b36fff4d01a6ea356f70025488ffc7a40b15188e.zip
+    SHA1 fca819de867f49dbc6898545d5946a4b6fdd91fa
     )

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -56,5 +56,13 @@ find_package(sr25519 REQUIRED)
 hunter_add_package(spdlog)
 find_package(spdlog CONFIG REQUIRED)
 
+# https://github.com/masterjedy/hat-trie
+hunter_add_package(tsl_hat_trie)
+find_package(tsl_hat_trie CONFIG REQUIRED)
+
+# https://github.com/masterjedy/di
+hunter_add_package(Boost.DI)
+find_package(Boost.DI CONFIG REQUIRED)
+
 hunter_add_package(libp2p)
 find_package(libp2p CONFIG REQUIRED)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -57,4 +57,4 @@ hunter_add_package(spdlog)
 find_package(spdlog CONFIG REQUIRED)
 
 hunter_add_package(libp2p)
-find_package(libp2p REQUIRED)
+find_package(libp2p CONFIG REQUIRED)

--- a/core/application/impl/local_key_storage.hpp
+++ b/core/application/impl/local_key_storage.hpp
@@ -9,7 +9,7 @@
 #include "application/key_storage.hpp"
 
 #include <boost/filesystem.hpp>
-#include <libp2p/crypto/key_generator.hpp>
+#include <libp2p/crypto/crypto_provider.hpp>
 #include <libp2p/crypto/key_validator.hpp>
 
 #include "common/buffer.hpp"
@@ -27,7 +27,7 @@ namespace kagome::application {
 
     static outcome::result<std::shared_ptr<LocalKeyStorage>> create(
         const Config &c,
-        std::shared_ptr<libp2p::crypto::KeyGenerator> generator,
+        std::shared_ptr<libp2p::crypto::CryptoProvider> crypto_provider,
         std::shared_ptr<libp2p::crypto::validator::KeyValidator> validator);
 
     ~LocalKeyStorage() override = default;
@@ -38,7 +38,7 @@ namespace kagome::application {
 
    private:
     LocalKeyStorage(
-        std::shared_ptr<libp2p::crypto::KeyGenerator> generator,
+        std::shared_ptr<libp2p::crypto::CryptoProvider> crypto_provider,
         std::shared_ptr<libp2p::crypto::validator::KeyValidator> validator);
 
     /**
@@ -62,7 +62,7 @@ namespace kagome::application {
     outcome::result<libp2p::crypto::KeyPair> loadRSA(
         const boost::filesystem::path &file) const;
 
-    std::shared_ptr<libp2p::crypto::KeyGenerator> generator_;
+    std::shared_ptr<libp2p::crypto::CryptoProvider> crypto_provider_;
     std::shared_ptr<libp2p::crypto::validator::KeyValidator> validator_;
     crypto::SR25519Keypair sr_25519_keypair_;
     crypto::ED25519Keypair ed_25519_keypair_;

--- a/test/core/application/CMakeLists.txt
+++ b/test/core/application/CMakeLists.txt
@@ -33,6 +33,6 @@ target_link_libraries(local_key_storage_test
     key_storage
     Boost::filesystem
     Boost::random
-    p2p::p2p_key_generator
+    p2p::p2p_crypto_provider
     p2p::p2p_key_validator
     )

--- a/test/core/application/local_key_storage_test.cpp
+++ b/test/core/application/local_key_storage_test.cpp
@@ -6,23 +6,31 @@
 #include "application/impl/local_key_storage.hpp"
 
 #include <gtest/gtest.h>
-#include <libp2p/crypto/key_generator/key_generator_impl.hpp>
+
+#include <libp2p/crypto/crypto_provider/crypto_provider_impl.hpp>
+#include <libp2p/crypto/ed25519_provider/ed25519_provider_impl.hpp>
 #include <libp2p/crypto/key_validator/key_validator_impl.hpp>
 #include <libp2p/crypto/random_generator/boost_generator.hpp>
 #include <testutil/outcome.hpp>
+
 #include "application/impl/key_storage_error.hpp"
 
 using kagome::application::KeyStorageError;
 using kagome::application::LocalKeyStorage;
-using libp2p::crypto::KeyGeneratorImpl;
+using libp2p::crypto::CryptoProviderImpl;
+using libp2p::crypto::ed25519::Ed25519ProviderImpl;
 using libp2p::crypto::random::BoostRandomGenerator;
 using libp2p::crypto::validator::KeyValidatorImpl;
 
 class LocalKeyStorageTest : public testing::Test {
  public:
   void SetUp() {
-    generator = std::make_shared<KeyGeneratorImpl>(random_generator);
-    validator = std::make_shared<KeyValidatorImpl>(generator);
+    auto random_generator = std::make_shared<BoostRandomGenerator>();
+    auto ed25519_provider = std::make_shared<Ed25519ProviderImpl>();
+
+    crypto_provider = std::make_shared<CryptoProviderImpl>(
+        std::move(random_generator), std::move(ed25519_provider));
+    validator = std::make_shared<KeyValidatorImpl>(crypto_provider);
     auto path = boost::filesystem::path(__FILE__).parent_path().string();
     config.ed25519_keypair_location = path + "/ed25519key.pem";
     config.sr25519_keypair_location = path + "/sr25519key.txt";
@@ -31,26 +39,25 @@ class LocalKeyStorageTest : public testing::Test {
   }
 
   LocalKeyStorage::Config config;
-  BoostRandomGenerator random_generator;
-  std::shared_ptr<KeyGeneratorImpl> generator;
+  std::shared_ptr<CryptoProviderImpl> crypto_provider;
   std::shared_ptr<KeyValidatorImpl> validator;
 };
 
 TEST_F(LocalKeyStorageTest, CreateWithEd25519) {
-  auto s = LocalKeyStorage::create(config, generator, validator);
+  auto s = LocalKeyStorage::create(config, crypto_provider, validator);
   EXPECT_OUTCOME_TRUE_1(s);
 }
 
 TEST_F(LocalKeyStorageTest, FileNotFound) {
   config.p2p_keypair_location = "aaa";
-  auto s = LocalKeyStorage::create(config, generator, validator);
+  auto s = LocalKeyStorage::create(config, crypto_provider, validator);
   EXPECT_OUTCOME_FALSE(e, s);
   ASSERT_EQ(e, KeyStorageError::FILE_READ_ERROR);
 }
 
 TEST_F(LocalKeyStorageTest, UnsupportedKeyType) {
   config.p2p_keypair_type = libp2p::crypto::Key::Type::UNSPECIFIED;
-  auto s = LocalKeyStorage::create(config, generator, validator);
+  auto s = LocalKeyStorage::create(config, crypto_provider, validator);
   EXPECT_OUTCOME_FALSE(e, s);
   ASSERT_EQ(e, KeyStorageError::UNSUPPORTED_KEY_TYPE);
 }
@@ -59,7 +66,7 @@ TEST_F(LocalKeyStorageTest, InvalidKey) {
   config.ed25519_keypair_location =
       boost::filesystem::path(__FILE__).parent_path().string()
       + "/wrong_ed25519key.pem";
-  auto s = LocalKeyStorage::create(config, generator, validator);
+  auto s = LocalKeyStorage::create(config, crypto_provider, validator);
   EXPECT_OUTCOME_FALSE(e, s);
   ASSERT_EQ(e, KeyStorageError::PRIVATE_KEY_READ_ERROR);
 }


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
I need new libp2p version for application injector, so this PR makes Kagome use latest libp2p version.
KeyGenerator doesn't exist anymore, it is replaced by CryptoProvider, so I applied CryptoProvider everywhere where KeyGenerator was used and fixed mistakes which occurred after I plugged in latest libp2p version.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Kagome is about to use newest version of libp2p, including CryptoProvider replacement for KeyGenerator, which is better, since it doesn't use references.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
