### PR TITLE
Feature/move genesis init to triedb

### DIFF
--- a/core/application/configuration_storage.hpp
+++ b/core/application/configuration_storage.hpp
@@ -7,9 +7,9 @@
 #define KAGOME_CONFIGURATION_STORAGE_HPP
 
 #include <libp2p/peer/peer_info.hpp>
-#include "blockchain/genesis_raw_config.hpp"
 #include "crypto/ed25519_types.hpp"
 #include "crypto/sr25519_types.hpp"
+#include "genesis_raw_config.hpp"
 #include "primitives/block.hpp"
 
 namespace kagome::application {
@@ -25,7 +25,7 @@ namespace kagome::application {
     /**
      * @return genesis block of the chain
      */
-    virtual blockchain::GenesisRawConfig getGenesis() const = 0;
+    virtual application::GenesisRawConfig getGenesis() const = 0;
 
     /**
      * Return ids of peer nodes of the current node

--- a/core/application/configuration_storage.hpp
+++ b/core/application/configuration_storage.hpp
@@ -7,9 +7,9 @@
 #define KAGOME_CONFIGURATION_STORAGE_HPP
 
 #include <libp2p/peer/peer_info.hpp>
+#include "application/genesis_raw_config.hpp"
 #include "crypto/ed25519_types.hpp"
 #include "crypto/sr25519_types.hpp"
-#include "genesis_raw_config.hpp"
 #include "primitives/block.hpp"
 
 namespace kagome::application {
@@ -25,7 +25,7 @@ namespace kagome::application {
     /**
      * @return genesis block of the chain
      */
-    virtual application::GenesisRawConfig getGenesis() const = 0;
+    virtual GenesisRawConfig getGenesis() const = 0;
 
     /**
      * Return ids of peer nodes of the current node

--- a/core/application/genesis_raw_config.hpp
+++ b/core/application/genesis_raw_config.hpp
@@ -8,7 +8,7 @@
 
 #include "common/buffer.hpp"
 
-namespace kagome::blockchain {
+namespace kagome::application {
 
   // configurations from genesis.json lying under "genesis"->"raw" key
   using GenesisRawConfig = std::vector<std::pair<common::Buffer, common::Buffer>>;

--- a/core/application/impl/configuration_storage_impl.cpp
+++ b/core/application/impl/configuration_storage_impl.cpp
@@ -13,7 +13,7 @@
 
 namespace kagome::application {
 
-  blockchain::GenesisRawConfig ConfigurationStorageImpl::getGenesis() const {
+  application::GenesisRawConfig ConfigurationStorageImpl::getGenesis() const {
     return config_.genesis;
   }
 

--- a/core/application/impl/configuration_storage_impl.cpp
+++ b/core/application/impl/configuration_storage_impl.cpp
@@ -13,7 +13,7 @@
 
 namespace kagome::application {
 
-  application::GenesisRawConfig ConfigurationStorageImpl::getGenesis() const {
+  GenesisRawConfig ConfigurationStorageImpl::getGenesis() const {
     return config_.genesis;
   }
 

--- a/core/application/impl/configuration_storage_impl.hpp
+++ b/core/application/impl/configuration_storage_impl.hpp
@@ -20,7 +20,7 @@ namespace kagome::application {
 
     ~ConfigurationStorageImpl() override = default;
 
-    blockchain::GenesisRawConfig getGenesis() const override;
+    application::GenesisRawConfig getGenesis() const override;
     std::vector<libp2p::peer::PeerInfo> getBootNodes() const override;
     std::vector<crypto::SR25519PublicKey> getSessionKeys() const override;
 

--- a/core/application/impl/configuration_storage_impl.hpp
+++ b/core/application/impl/configuration_storage_impl.hpp
@@ -20,7 +20,7 @@ namespace kagome::application {
 
     ~ConfigurationStorageImpl() override = default;
 
-    application::GenesisRawConfig getGenesis() const override;
+    GenesisRawConfig getGenesis() const override;
     std::vector<libp2p::peer::PeerInfo> getBootNodes() const override;
     std::vector<crypto::SR25519PublicKey> getSessionKeys() const override;
 

--- a/core/application/impl/kagome_config.hpp
+++ b/core/application/impl/kagome_config.hpp
@@ -7,7 +7,7 @@
 #define KAGOME_KAGOME_CONFIG_HPP
 
 #include <libp2p/peer/peer_info.hpp>
-#include "blockchain/genesis_raw_config.hpp"
+#include "application/genesis_raw_config.hpp"
 #include "crypto/ed25519_types.hpp"
 #include "crypto/sr25519_types.hpp"
 #include "primitives/block.hpp"
@@ -26,7 +26,7 @@ namespace kagome::application {
                      == rhs.api_ports.extrinsic_api_port;
     }
 
-    blockchain::GenesisRawConfig genesis;
+    application::GenesisRawConfig genesis;
     std::vector<libp2p::peer::PeerInfo> boot_nodes;
     std::vector<crypto::SR25519PublicKey> session_keys;
     struct ApiPorts {

--- a/core/application/impl/kagome_config.hpp
+++ b/core/application/impl/kagome_config.hpp
@@ -26,7 +26,7 @@ namespace kagome::application {
                      == rhs.api_ports.extrinsic_api_port;
     }
 
-    application::GenesisRawConfig genesis;
+    GenesisRawConfig genesis;
     std::vector<libp2p::peer::PeerInfo> boot_nodes;
     std::vector<crypto::SR25519PublicKey> session_keys;
     struct ApiPorts {

--- a/core/blockchain/impl/key_value_block_storage.cpp
+++ b/core/blockchain/impl/key_value_block_storage.cpp
@@ -36,15 +36,11 @@ namespace kagome::blockchain {
 
   outcome::result<std::shared_ptr<KeyValueBlockStorage>>
   KeyValueBlockStorage::createWithGenesis(
-      const GenesisRawConfig &genesis,
       const std::shared_ptr<storage::trie::TrieDb> &storage,
       std::shared_ptr<crypto::Hasher> hasher) {
     KeyValueBlockStorage kv_storage(storage, std::move(hasher));
     // TODO(Harrm) check that storage is actually empty
-    for (const auto &[key, val] : genesis) {
-      kv_storage.logger_->debug("Key: {} \nVal: {}", key.toHex(), val.toHex());
-      OUTCOME_TRY(storage->put(key, val));
-    }
+
     // state root type is Hash256, however for consistency with spec root hash
     // returns buffer. So we need this conversion
     OUTCOME_TRY(state_root,

--- a/core/blockchain/impl/key_value_block_storage.hpp
+++ b/core/blockchain/impl/key_value_block_storage.hpp
@@ -22,8 +22,8 @@ namespace kagome::blockchain {
     ~KeyValueBlockStorage() override = default;
 
     /**
-     * Initialise block storage with a genesis block
-     * @param genesis the genesis block
+     * Initialise block storage with a genesis block which is created inside
+     * from merkle trie root
      * @param storage underlying storage (must be empty)
      * @param hasher a hasher instance
      */

--- a/core/blockchain/impl/key_value_block_storage.hpp
+++ b/core/blockchain/impl/key_value_block_storage.hpp
@@ -8,7 +8,6 @@
 
 #include "blockchain/block_storage.hpp"
 
-#include "blockchain/genesis_raw_config.hpp"
 #include "blockchain/impl/common.hpp"
 #include "common/logger.hpp"
 #include "crypto/hasher.hpp"
@@ -29,8 +28,7 @@ namespace kagome::blockchain {
      * @param hasher a hasher instance
      */
     static outcome::result<std::shared_ptr<KeyValueBlockStorage>>
-    createWithGenesis(const GenesisRawConfig &genesis,
-                      const std::shared_ptr<storage::trie::TrieDb> &storage,
+    createWithGenesis(const std::shared_ptr<storage::trie::TrieDb> &storage,
                       std::shared_ptr<crypto::Hasher> hasher);
 
     outcome::result<primitives::BlockHeader> getBlockHeader(

--- a/core/common/buffer.cpp
+++ b/core/common/buffer.cpp
@@ -36,7 +36,7 @@ namespace kagome::common {
   }
 
   std::string Buffer::toHex() const {
-    return hex_upper(data_);
+    return hex_lower(data_);
   }
 
   bool Buffer::empty() const {

--- a/core/injector/application_injector.hpp
+++ b/core/injector/application_injector.hpp
@@ -304,7 +304,6 @@ namespace kagome::injector {
           auto persistent_storage = injector.template create<sptr<storage::PersistentBufferMap>>();
           auto trie_db = std::make_shared<storage::trie::PolkadotTrieDb>(persistent_storage);
           for (const auto &[key, val] : genesis_raw_configs) {
-            spdlog::debug("Key: {}", key.toHex());
             if (auto res = trie_db->put(key, val); not res) {
               common::raise(res.error());
             }

--- a/core/injector/application_injector.hpp
+++ b/core/injector/application_injector.hpp
@@ -225,21 +225,15 @@ namespace kagome::injector {
         di::bind<blockchain::BlockStorage>.to(
             [&](const auto &injector)
                 -> std::shared_ptr<blockchain::BlockStorage> {
-              auto configuration_storage = injector.template create<
-                  std::shared_ptr<application::ConfigurationStorage>>();
-
               auto &&hasher =
                   injector.template create<std::shared_ptr<crypto::Hasher>>();
 
               const auto &db = injector.template create<
                   std::shared_ptr<storage::trie::TrieDb>>();
 
-              const auto &genesis_raw_configs =
-                  configuration_storage->getGenesis();
-
               auto storage =
-                  blockchain::KeyValueBlockStorage::createWithGenesis(
-                      genesis_raw_configs, db, hasher);
+                  blockchain::KeyValueBlockStorage::createWithGenesis(db,
+                                                                      hasher);
               if (storage.has_error()) {
                 common::raise(storage.error());
               }
@@ -301,7 +295,22 @@ namespace kagome::injector {
         di::bind<runtime::BlockBuilderApi>.template to<runtime::BlockBuilderApiImpl>(),
         di::bind<transaction_pool::TransactionPool>.template to<transaction_pool::TransactionPoolImpl>(),
         di::bind<transaction_pool::PoolModerator>.template to<transaction_pool::PoolModeratorImpl>(),
-        di::bind<storage::trie::TrieDb>.template to<storage::trie::PolkadotTrieDb>(),
+        di::bind<storage::trie::TrieDb>.template to([&](const auto& injector){
+          auto configuration_storage = injector.template create<
+              std::shared_ptr<application::ConfigurationStorage>>();
+          const auto &genesis_raw_configs =
+              configuration_storage->getGenesis();
+
+          auto persistent_storage = injector.template create<sptr<storage::PersistentBufferMap>>();
+          auto trie_db = std::make_shared<storage::trie::PolkadotTrieDb>(persistent_storage);
+          for (const auto &[key, val] : genesis_raw_configs) {
+            spdlog::debug("Key: {}", key.toHex());
+            if (auto res = trie_db->put(key, val); not res) {
+              common::raise(res.error());
+            }
+          }
+          return trie_db;
+        }),
         di::bind<storage::trie::Codec>.template to<storage::trie::PolkadotCodec>(),
         di::bind<runtime::WasmProvider>.template to<runtime::StorageWasmProvider>().in(
             di::extension::shared),

--- a/examples/kagome_full/main.cpp
+++ b/examples/kagome_full/main.cpp
@@ -28,20 +28,20 @@ int main(int argc, char **argv) {
   auto &&keys_config = options_parser.getKeysConfig();
   auto &&level_db_config = options_parser.getLevelDbPath();
 
-//  try {
+  try {
     auto &&app = std::make_shared<kagome::application::KagomeApplicationImpl>(
         kagome_config, keys_config, level_db_config);
     app->run();
-//  } catch (std::system_error &err) {
-//    logger->error(err.what());
-//    return 1;
-//  } catch (std::exception &e) {
-//    logger->error(e.what());
-//    return 1;
-//  } catch (...) {
-//    logger->error("unknown error");
-//    return 1;
-//  }
+  } catch (std::system_error &err) {
+    logger->error(err.what());
+    return 1;
+  } catch (std::exception &e) {
+    logger->error(e.what());
+    return 1;
+  } catch (...) {
+    logger->error("unknown error");
+    return 1;
+  }
 
   return 0;
 }

--- a/examples/kagome_full/main.cpp
+++ b/examples/kagome_full/main.cpp
@@ -28,20 +28,20 @@ int main(int argc, char **argv) {
   auto &&keys_config = options_parser.getKeysConfig();
   auto &&level_db_config = options_parser.getLevelDbPath();
 
-  try {
+//  try {
     auto &&app = std::make_shared<kagome::application::KagomeApplicationImpl>(
         kagome_config, keys_config, level_db_config);
     app->run();
-  } catch (std::system_error &err) {
-    logger->error(err.what());
-    return 1;
-  } catch (std::exception &e) {
-    logger->error(e.what());
-    return 1;
-  } catch (...) {
-    logger->error("unknown error");
-    return 1;
-  }
+//  } catch (std::system_error &err) {
+//    logger->error(err.what());
+//    return 1;
+//  } catch (std::exception &e) {
+//    logger->error(e.what());
+//    return 1;
+//  } catch (...) {
+//    logger->error("unknown error");
+//    return 1;
+//  }
 
   return 0;
 }

--- a/test/core/application/configuration_storage_test.cpp
+++ b/test/core/application/configuration_storage_test.cpp
@@ -10,7 +10,7 @@
 #include "testutil/outcome.hpp"
 
 using kagome::application::ConfigurationStorageImpl;
-using kagome::blockchain::GenesisRawConfig;
+using kagome::application::GenesisRawConfig;
 using kagome::common::Buffer;
 using kagome::crypto::SR25519PublicKey;
 using libp2p::multi::Multiaddress;

--- a/test/core/blockchain/block_storage_test.cpp
+++ b/test/core/blockchain/block_storage_test.cpp
@@ -12,7 +12,6 @@
 #include "storage/leveldb/leveldb_error.hpp"
 #include "testutil/outcome.hpp"
 
-using kagome::blockchain::GenesisRawConfig;
 using kagome::blockchain::KeyValueBlockStorage;
 using kagome::common::Buffer;
 using kagome::crypto::HasherMock;
@@ -33,15 +32,13 @@ class BlockStorageTest : public testing::Test {
     root_hash.put(std::vector<uint8_t>(32ul, 1));
     EXPECT_CALL(*storage, getRootHash()).WillOnce(Return(root_hash));
     EXPECT_CALL(*storage, put(_, _)).WillRepeatedly(Return(outcome::success()));
-    block_storage = KeyValueBlockStorage::createWithGenesis(
-                        genesis_raw_config_, storage, hasher)
-                        .value();
+    block_storage =
+        KeyValueBlockStorage::createWithGenesis(storage, hasher).value();
   }
   std::shared_ptr<KeyValueBlockStorage> block_storage;
   std::shared_ptr<HasherMock> hasher = std::make_shared<HasherMock>();
   std::shared_ptr<TrieDbMock> storage = std::make_shared<TrieDbMock>();
   Block genesis;
-  GenesisRawConfig genesis_raw_config_{{Buffer(10ul, 0), Buffer(10ul, 9)}};
   BlockHash genesis_hash{{1, 2, 3, 4}};
   Buffer root_hash;
 };
@@ -59,9 +56,8 @@ TEST_F(BlockStorageTest, CreateWithExistingGenesis) {
       .WillOnce(Return(Buffer{1, 1, 1, 1}))
       .WillOnce(Return(Buffer{1, 1, 1, 1}));
   EXPECT_CALL(*storage, getRootHash()).WillOnce(Return(root_hash));
-  EXPECT_OUTCOME_FALSE(res,
-                       KeyValueBlockStorage::createWithGenesis(
-                           genesis_raw_config_, storage, hasher));
+  EXPECT_OUTCOME_FALSE(
+      res, KeyValueBlockStorage::createWithGenesis(storage, hasher));
   ASSERT_EQ(res, KeyValueBlockStorage::Error::BLOCK_EXISTS);
 }
 
@@ -77,9 +73,8 @@ TEST_F(BlockStorageTest, CreateWithStorageError) {
       .WillOnce(Return(Buffer{1, 1, 1, 1}))
       .WillOnce(Return(kagome::storage::LevelDBError::IO_ERROR));
   EXPECT_CALL(*storage, getRootHash()).WillOnce(Return(root_hash));
-  EXPECT_OUTCOME_FALSE(res,
-                       KeyValueBlockStorage::createWithGenesis(
-                           genesis_raw_config_, storage, hasher));
+  EXPECT_OUTCOME_FALSE(
+      res, KeyValueBlockStorage::createWithGenesis(storage, hasher));
   ASSERT_EQ(res, kagome::storage::LevelDBError::IO_ERROR);
 }
 

--- a/test/core/common/buffer_test.cpp
+++ b/test/core/common/buffer_test.cpp
@@ -48,7 +48,7 @@ TEST(Common, BufferPut) {
   }
   ASSERT_EQ(i, b.size());
 
-  ASSERT_EQ(b.toHex(), "68656C6C6F010000000100000000000000010102030405");
+  ASSERT_EQ(b.toHex(), "68656c6c6f010000000100000000000000010102030405");
 }
 
 /**
@@ -57,11 +57,11 @@ TEST(Common, BufferPut) {
  * @then content of current buffer changes to {1,2,3,4,5,6}
  */
 TEST(Common, putBuffer) {
-  Buffer current_buffer = {1,2,3};
-  Buffer another_buffer = {4,5,6};
-  auto & buffer = current_buffer.putBuffer(another_buffer);
-  ASSERT_EQ(&buffer, &current_buffer); // line to the same buffer is returned
-  Buffer result = {1,2,3,4,5,6};
+  Buffer current_buffer = {1, 2, 3};
+  Buffer another_buffer = {4, 5, 6};
+  auto &buffer = current_buffer.putBuffer(another_buffer);
+  ASSERT_EQ(&buffer, &current_buffer);  // line to the same buffer is returned
+  Buffer result = {1, 2, 3, 4, 5, 6};
   ASSERT_EQ(buffer, result);
 }
 
@@ -79,7 +79,7 @@ TEST(Common, BufferInit) {
   ASSERT_EQ(a.size(), b.size());
 
   ASSERT_NO_THROW({
-    Buffer c {"0102030405"_unhex};
+    Buffer c{"0102030405"_unhex};
     ASSERT_EQ(c, a);
 
     Buffer d = c;


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Before initialization the logic of putting genesis raw config information was in block store. Because of that it was possible to have troubles when StorageWasmProvider is initialized sooner than BlockStorage, because StorageWasmProvider depends on information that was put into key-value storage in BLockStorage's initialization. To fix that the logic of putting genesis raw configs into storage was moved to injector, where KeyValue storage (TrieDb) was initialized

### Benefits

Fixed issue with StorageWasmInitialization

### Possible Drawbacks 

Still issue in injector of initializing LevelDb several times
