### PR TITLE
Fix empty enumerated root handling

### DIFF
--- a/core/extensions/impl/storage_extension.cpp
+++ b/core/extensions/impl/storage_extension.cpp
@@ -144,9 +144,6 @@ namespace kagome::extensions {
       runtime::WasmPointer lengths_data,
       runtime::SizeType values_num,
       runtime::WasmPointer result) {
-    if (values_num == 0) {
-      return;
-    }
     std::vector<uint32_t> lengths(values_num);
     for (size_t i = 0; i < values_num; i++) {
       lengths.at(i) = memory_->load32u(lengths_data + i * 4);

--- a/core/storage/trie/impl/ordered_trie_hash.hpp
+++ b/core/storage/trie/impl/ordered_trie_hash.hpp
@@ -27,8 +27,10 @@ namespace kagome::storage::trie {
     PolkadotTrie trie;
     PolkadotCodec codec;
     // empty root
-    if (begin == end) return common::Buffer{}.put(codec.hash256({0}));
-
+    if (begin == end) {
+      static const auto empty_root = common::Buffer{}.put(codec.hash256({0}));
+      return empty_root;
+    }
     // clang-format off
     static_assert(
         std::is_same_v<std::decay_t<decltype(*begin)>, common::Buffer>);

--- a/core/storage/trie/impl/polkadot_trie_db.cpp
+++ b/core/storage/trie/impl/polkadot_trie_db.cpp
@@ -190,8 +190,7 @@ namespace kagome::storage::trie {
   }
 
   common::Buffer PolkadotTrieDb::getEmptyRoot() const {
-    static const auto empty_root = Buffer{}.put(codec_.hash256({0}));
-    return empty_root;
+    return Buffer(codec_.hash256({0}));
   }
 
   bool PolkadotTrieDb::empty() const {

--- a/core/storage/trie/impl/polkadot_trie_db.cpp
+++ b/core/storage/trie/impl/polkadot_trie_db.cpp
@@ -36,8 +36,7 @@ namespace kagome::storage::trie {
                                  boost::optional<common::Buffer> root_hash)
       : db_{std::move(db)},
         codec_{},
-        root_{root_hash ? std::move(root_hash.value()) : getEmptyRoot()} {
-  }
+        root_{root_hash ? std::move(root_hash.value()) : getEmptyRoot()} {}
 
   outcome::result<void> PolkadotTrieDb::put(const Buffer &key,
                                             const Buffer &value) {
@@ -191,7 +190,8 @@ namespace kagome::storage::trie {
   }
 
   common::Buffer PolkadotTrieDb::getEmptyRoot() const {
-    return Buffer{}.put(codec_.hash256({0}));
+    static const auto empty_root = Buffer{}.put(codec_.hash256({0}));
+    return empty_root;
   }
 
   bool PolkadotTrieDb::empty() const {

--- a/core/storage/trie/impl/polkadot_trie_db.hpp
+++ b/core/storage/trie/impl/polkadot_trie_db.hpp
@@ -78,7 +78,7 @@ namespace kagome::storage::trie {
     /**
      * @return the root hash of empty Trie
      */
-    common::Buffer getEmptyRoot() const;
+    common::Buffer getEmptyRoot() const override;
 
     bool empty() const override;
 

--- a/core/storage/trie/trie_db.hpp
+++ b/core/storage/trie/trie_db.hpp
@@ -28,6 +28,8 @@ namespace kagome::storage::trie {
      */
     virtual outcome::result<void> clearPrefix(const common::Buffer &buf) = 0;
 
+    virtual common::Buffer getEmptyRoot() const = 0;
+
     /**
      * @returns true if the trie is empty, false otherwise
      */

--- a/test/core/storage/trie/mock_trie_db.hpp
+++ b/test/core/storage/trie/mock_trie_db.hpp
@@ -33,6 +33,7 @@ namespace kagome::storage::trie {
     MOCK_CONST_METHOD1(contains, bool(const common::Buffer &));
 
     MOCK_CONST_METHOD0(empty, bool(void));
+    MOCK_CONST_METHOD0(getEmptyRoot, common::Buffer());
 
     MOCK_METHOD0(cursor, std::unique_ptr<BufferMapCursor>());
     MOCK_METHOD0(batch, std::unique_ptr<BufferBatch>());


### PR DESCRIPTION
Signed-off-by: kamilsa <kamilsa16@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Before when we invoked ext_blake2_256_enumerated_trie_root with empty values, we obtained zero-filled array, which is wrong. Instead root of empty trie should be returned
### Benefits

Mentioned bug is fixed

### Possible Drawbacks 

None

### Usage Examples or Tests 

StorageExtensionTest was updated with vectors from substrate