### PR TITLE
Fix memory

### DIFF
--- a/core/runtime/binaryen/runtime_api/runtime_api.hpp
+++ b/core/runtime/binaryen/runtime_api/runtime_api.hpp
@@ -65,7 +65,7 @@ namespace kagome::runtime::binaryen {
       wasm::Name wasm_name = std::string(name);
 
       OUTCOME_TRY(res, executor_.call(*module, wasm_name, ll));
-
+      memory->reset();
       if constexpr (!std::is_same_v<void, R>) {
         WasmResult r{res.geti64()};
         auto buffer = memory->loadN(r.address, r.length);

--- a/core/runtime/binaryen/wasm_memory_impl.cpp
+++ b/core/runtime/binaryen/wasm_memory_impl.cpp
@@ -17,6 +17,12 @@ namespace kagome::runtime::binaryen {
     WasmMemoryImpl::resize(size_);
   }
 
+  void WasmMemoryImpl::reset() {
+    offset_ = 1;
+    allocated_.clear();
+    deallocated_.clear();
+  }
+
   SizeType WasmMemoryImpl::size() const {
     return size_;
   }

--- a/core/runtime/binaryen/wasm_memory_impl.hpp
+++ b/core/runtime/binaryen/wasm_memory_impl.hpp
@@ -37,6 +37,8 @@ namespace kagome::runtime::binaryen {
     WasmMemoryImpl &operator=(WasmMemoryImpl &&move) = delete;
     ~WasmMemoryImpl() override = default;
 
+    void reset() override;
+
     SizeType size() const override;
     void resize(SizeType newSize) override;
 

--- a/core/runtime/wasm_memory.hpp
+++ b/core/runtime/wasm_memory.hpp
@@ -7,8 +7,8 @@
 #define KAGOME_MEMORY_HPP
 
 #include <array>
-
 #include <boost/optional.hpp>
+
 #include "common/buffer.hpp"
 #include "runtime/types.hpp"
 
@@ -27,6 +27,11 @@ namespace kagome::runtime {
 
     constexpr static uint32_t kMaxMemorySize =
         std::numeric_limits<uint32_t>::max();
+
+    /**
+     * Resets allocated and deallocated memory information
+     */
+    virtual void reset() = 0;
 
     /**
      * @brief Return the size of the memory

--- a/test/core/runtime/mock_memory.hpp
+++ b/test/core/runtime/mock_memory.hpp
@@ -16,6 +16,7 @@ namespace kagome::runtime {
    public:
     MOCK_CONST_METHOD0(size, SizeType());
     MOCK_METHOD1(resize, void(SizeType));
+    MOCK_METHOD0(reset, void());
     MOCK_METHOD1(allocate, WasmPointer(SizeType));
     MOCK_METHOD1(deallocate, boost::optional<SizeType>(WasmPointer));
 

--- a/test/core/runtime/wasm_memory_test.cpp
+++ b/test/core/runtime/wasm_memory_test.cpp
@@ -177,3 +177,15 @@ TEST_F(MemoryHeapTest, LoadNTest) {
   auto res_b = memory_.loadN(ptr, N);
   ASSERT_EQ(b, res_b);
 }
+
+/**
+ * @given Some memory is allocated
+ * @when Memory is reset
+ * @then Allocated memory's offset is 1
+ */
+TEST_F(MemoryHeapTest, ResetTest) {
+  const size_t N = 42;
+  ASSERT_EQ(memory_.allocate(N), 1);
+  memory_.reset();
+  ASSERT_EQ(memory_.allocate(N), 1);
+}


### PR DESCRIPTION
Signed-off-by: kamilsa <kamilsa16@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

WasmMemory has problem. When memory is deallocated, contiguous memory chunks are not merged into a single chunk. That results into the situation when memory is over and we try to allocate memory we can not find big enough chunk.

Quick fix is to reset memory. I.e. we clean all information about allocated/deallocated memory chunks which in fact returns memory to initial state from the runtime point of view. 

### Benefits

Bug is fixed

### Possible Drawbacks 

None