### PR TITLE
Fix genesis slot assignment

### DIFF
--- a/core/consensus/babe/impl/babe_impl.cpp
+++ b/core/consensus/babe/impl/babe_impl.cpp
@@ -442,8 +442,12 @@ namespace kagome::consensus {
           first_slot_times_[first_slot_times_.size() / 2];
 
       Epoch epoch;
-      epoch.epoch_index =
-          *first_production_slot / genesis_configuration_->epoch_length;
+      auto slot_duration = genesis_configuration_->slot_duration;
+      auto ticks_since_epoch = clock_->now().time_since_epoch().count();
+      auto genesis_slot = static_cast<BabeSlotNumber>(ticks_since_epoch
+                                                      / slot_duration.count());
+      epoch.epoch_index = (*first_production_slot - genesis_slot)
+                          / genesis_configuration_->epoch_length;
       epoch.start_slot = *first_production_slot;
       epoch.epoch_duration = genesis_configuration_->epoch_length;
       auto next_epoch_digest_res =

--- a/core/consensus/babe/impl/babe_impl.cpp
+++ b/core/consensus/babe/impl/babe_impl.cpp
@@ -79,7 +79,7 @@ namespace kagome::consensus {
                      "slot duration must be > 0");
     TimePoint now = clock_->now();
     Duration time_since_epoch = now.time_since_epoch();
-    TimePoint epoch_start_point = now - time_since_epoch;
+    TimePoint epoch_start_point = std::chrono::system_clock::from_time_t(0);
 
     auto ticks_since_epoch = time_since_epoch.count();
 


### PR DESCRIPTION
Signed-off-by: Yura Zarudniy <zarudniy@soramitsu.co.jp>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Slot 0 should correspond to the the beginning of Unix epoch (1970-1-1, 00-00-00). Therefore when Babe is executed genesis slot should be calculated as <time from start of unix epoch> / <slot time>

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
