### PR TITLE
Fix wrong order of starting RPC entities

### DIFF
--- a/core/api/service/CMakeLists.txt
+++ b/core/api/service/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(api_service
 target_link_libraries(api_service
     Boost::boost
     logger
+    app_state_manager
+    rpc_thread_pool
     )
 
 add_subdirectory(author)

--- a/core/api/service/api_service.hpp
+++ b/core/api/service/api_service.hpp
@@ -11,6 +11,8 @@
 
 #include "api/jrpc/jrpc_server_impl.hpp"
 #include "api/transport/listener.hpp"
+#include "api/transport/rpc_thread_pool.hpp"
+#include "application/app_state_manager.hpp"
 #include "common/logger.hpp"
 
 namespace kagome::api {
@@ -31,7 +33,9 @@ namespace kagome::api {
      * @param listener - a shared ptr to the endpoint listener instance
      * @param processors - shared ptrs to JSON processor instances
      */
-    ApiService(std::vector<std::shared_ptr<Listener>> listeners,
+    ApiService(std::shared_ptr<application::AppStateManager> app_state_manager,
+               std::shared_ptr<api::RpcThreadPool> thread_pool,
+               std::vector<std::shared_ptr<Listener>> listeners,
                std::shared_ptr<JRpcServer> server,
                gsl::span<std::shared_ptr<JRpcProcessor>> processors);
 
@@ -41,6 +45,10 @@ namespace kagome::api {
     void stop();
 
    private:
+    std::shared_ptr<application::AppStateManager> app_state_manager_;
+
+    std::shared_ptr<api::RpcThreadPool> thread_pool_;
+
     std::vector<sptr<Listener>> listeners_;
     std::shared_ptr<JRpcServer> server_;
     common::Logger logger_;

--- a/core/api/transport/rpc_thread_pool.cpp
+++ b/core/api/transport/rpc_thread_pool.cpp
@@ -8,17 +8,11 @@
 namespace kagome::api {
 
   RpcThreadPool::RpcThreadPool(
-      std::shared_ptr<AppStateManager> app_state_manager,
       std::shared_ptr<Context> context,
       const Configuration &configuration)
-      : app_state_manager_(std::move(app_state_manager)),
-        context_(std::move(context)),
+      : context_(std::move(context)),
         config_(configuration) {
-    BOOST_ASSERT(app_state_manager_);
     BOOST_ASSERT(context_);
-
-    app_state_manager_->atLaunch([this] { start(); });
-    app_state_manager_->atShutdown([this] { stop(); });
   }
 
   void RpcThreadPool::start() {
@@ -30,10 +24,12 @@ namespace kagome::api {
       thread->detach();
       threads_.emplace_back(std::move(thread));
     }
+	  logger_->debug("Thread pool started");
   }
 
   void RpcThreadPool::stop() {
     context_->stop();
+	  logger_->debug("Thread pool stopped");
   }
 
 }  // namespace kagome::api

--- a/core/api/transport/rpc_thread_pool.cpp
+++ b/core/api/transport/rpc_thread_pool.cpp
@@ -7,11 +7,9 @@
 
 namespace kagome::api {
 
-  RpcThreadPool::RpcThreadPool(
-      std::shared_ptr<Context> context,
-      const Configuration &configuration)
-      : context_(std::move(context)),
-        config_(configuration) {
+  RpcThreadPool::RpcThreadPool(std::shared_ptr<Context> context,
+                               const Configuration &configuration)
+      : context_(std::move(context)), config_(configuration) {
     BOOST_ASSERT(context_);
   }
 
@@ -24,12 +22,12 @@ namespace kagome::api {
       thread->detach();
       threads_.emplace_back(std::move(thread));
     }
-	  logger_->debug("Thread pool started");
+    logger_->debug("Thread pool started");
   }
 
   void RpcThreadPool::stop() {
     context_->stop();
-	  logger_->debug("Thread pool stopped");
+    logger_->debug("Thread pool stopped");
   }
 
 }  // namespace kagome::api

--- a/core/api/transport/rpc_thread_pool.hpp
+++ b/core/api/transport/rpc_thread_pool.hpp
@@ -31,8 +31,7 @@ namespace kagome::api {
       size_t max_thread_number = 10;
     };
 
-    RpcThreadPool(std::shared_ptr<AppStateManager> app_state_manager,
-                  std::shared_ptr<Context> context,
+    RpcThreadPool(std::shared_ptr<Context> context,
                   const Configuration &configuration);
 
     ~RpcThreadPool() = default;
@@ -48,8 +47,6 @@ namespace kagome::api {
     void stop();
 
    private:
-    std::shared_ptr<AppStateManager> app_state_manager_;
-
     std::shared_ptr<Context> context_;
     const Configuration config_;
 

--- a/core/application/impl/block_producing_node_application.cpp
+++ b/core/application/impl/block_producing_node_application.cpp
@@ -41,8 +41,6 @@ namespace kagome::application {
     babe_ = injector_.create<sptr<Babe>>();
     router_ = injector_.create<sptr<network::Router>>();
 
-    rpc_context_ = injector_.create<sptr<api::RpcContext>>();
-    rpc_thread_pool_ = injector_.create<sptr<api::RpcThreadPool>>();
     jrpc_api_service_ = injector_.create<sptr<api::ApiService>>();
   }
 

--- a/core/application/impl/block_producing_node_application.hpp
+++ b/core/application/impl/block_producing_node_application.hpp
@@ -74,8 +74,6 @@ namespace kagome::application {
     sptr<Babe> babe_;
     sptr<network::Router> router_;
 
-    sptr<api::RpcContext> rpc_context_;
-    sptr<api::RpcThreadPool> rpc_thread_pool_;
     sptr<api::ApiService> jrpc_api_service_;
 
     bool is_genesis_epoch_;

--- a/core/application/impl/syncing_node_application.cpp
+++ b/core/application/impl/syncing_node_application.cpp
@@ -31,8 +31,6 @@ namespace kagome::application {
     config_storage_ = injector_.create<sptr<ConfigurationStorage>>();
     router_ = injector_.create<sptr<network::Router>>();
 
-    rpc_context_ = injector_.create<sptr<api::RpcContext>>();
-    rpc_thread_pool_ = injector_.create<sptr<api::RpcThreadPool>>();
     jrpc_api_service_ = injector_.create<sptr<api::ApiService>>();
   }
 

--- a/core/application/impl/syncing_node_application.hpp
+++ b/core/application/impl/syncing_node_application.hpp
@@ -51,8 +51,6 @@ namespace kagome::application {
     sptr<ConfigurationStorage> config_storage_;
     sptr<network::Router> router_;
 
-    sptr<api::RpcContext> rpc_context_;
-    sptr<api::RpcThreadPool> rpc_thread_pool_;
     sptr<api::ApiService> jrpc_api_service_;
 
     common::Logger logger_;

--- a/core/application/impl/validating_node_application.cpp
+++ b/core/application/impl/validating_node_application.cpp
@@ -44,8 +44,6 @@ namespace kagome::application {
     grandpa_launcher_ = injector_.create<sptr<GrandpaLauncher>>();
     router_ = injector_.create<sptr<network::Router>>();
 
-    rpc_context_ = injector_.create<sptr<api::RpcContext>>();
-    rpc_thread_pool_ = injector_.create<sptr<api::RpcThreadPool>>();
     jrpc_api_service_ = injector_.create<sptr<api::ApiService>>();
   }
 

--- a/core/application/impl/validating_node_application.hpp
+++ b/core/application/impl/validating_node_application.hpp
@@ -90,8 +90,6 @@ namespace kagome::application {
     sptr<GrandpaLauncher> grandpa_launcher_;
     sptr<network::Router> router_;
 
-    sptr<api::RpcContext> rpc_context_;
-    sptr<api::RpcThreadPool> rpc_thread_pool_;
     sptr<api::ApiService> jrpc_api_service_;
 
     bool is_genesis_epoch_;

--- a/test/core/api/service/author/author_service_test.cpp
+++ b/test/core/api/service/author/author_service_test.cpp
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include "api/service/author/author_jrpc_processor.hpp"
+#include "application/impl/app_state_manager_impl.hpp"
 #include "common/blob.hpp"
 #include "mock/core/api/service/author/author_api_mock.hpp"
 #include "mock/core/api/transport/listener_mock.hpp"
@@ -66,12 +67,23 @@ class AuthorServiceTest : public ::testing::Test {
 
   sptr<AuthorApiMock> api = std::make_shared<AuthorApiMock>();
 
+  sptr<AppStateManager> app_state_manager =
+      std::make_shared<kagome::application::AppStateManagerImpl>();
+
+  std::shared_ptr<kagome::api::RpcContext> context =
+      std::make_shared<kagome::api::RpcContext>();
+
+  kagome::api::RpcThreadPool::Configuration config = {1, 1};
+
+  sptr<kagome::api::RpcThreadPool> thread_pool =
+      std::make_shared<kagome::api::RpcThreadPool>(context, config);
+
   sptr<JRpcServer> server = std::make_shared<JRpcServerImpl>();
 
   std::vector<std::shared_ptr<JRpcProcessor>> processors{
       std::make_shared<AuthorJRpcProcessor>(server, api)};
-  sptr<ApiService> service =
-      std::make_shared<ApiService>(listeners, server, processors);
+  sptr<ApiService> service = std::make_shared<ApiService>(
+      app_state_manager, thread_pool, listeners, server, processors);
 
   sptr<SessionMock> session = std::make_shared<SessionMock>();
 


### PR DESCRIPTION
Signed-off-by: Dmitriy Khaustov aka xDimon <khaustov.dm@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Jira task id
[PRE-430](https://soramitsu.atlassian.net/browse/PRE-430)

<!-- Id of the task from Jira. Example: PRE-42. If there is no corresponding task, then remove this field -->

### Description of the Change
Change exchange dependencies rpc_service and rpc_thread_pool

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Right order of starting RPC

<!-- What benefits will be realized by the code change? -->

