### PR TITLE
Send sync request only to announcer

### DIFF
--- a/core/blockchain/impl/block_tree_impl.cpp
+++ b/core/blockchain/impl/block_tree_impl.cpp
@@ -204,6 +204,10 @@ namespace kagome::blockchain {
     if (!node) {
       return BlockTreeError::NO_SUCH_BLOCK;
     }
+    if (storage_->getJustification(block)){
+      // block was already finalized, fine
+      return outcome::success();
+    }
 
     // insert justification into the database
     OUTCOME_TRY(storage_->putJustification(justification, block, node->depth));
@@ -221,6 +225,7 @@ namespace kagome::blockchain {
 
     OUTCOME_TRY(storage_->setLastFinalizedBlockHash(node->block_hash));
 
+    log_->info("Finalized block number {} with hash {}", node->depth, block.toHex());
     return outcome::success();
   }
 

--- a/core/consensus/babe/babe_synchronizer.hpp
+++ b/core/consensus/babe/babe_synchronizer.hpp
@@ -6,6 +6,7 @@
 #ifndef KAGOME_CORE_CONSENSUS_BABE_BABE_SYNCHRONIZER_HPP
 #define KAGOME_CORE_CONSENSUS_BABE_BABE_SYNCHRONIZER_HPP
 
+#include "primitives/authority.hpp"
 #include "primitives/block.hpp"
 #include "primitives/block_id.hpp"
 
@@ -30,6 +31,7 @@ namespace kagome::consensus {
      */
     virtual void request(const primitives::BlockId &from,
                          const primitives::BlockHash &to,
+                         primitives::AuthorityIndex authority_index,
                          const BlocksHandler &block_list_handler) = 0;
   };
 

--- a/core/consensus/babe/impl/babe_synchronizer_impl.cpp
+++ b/core/consensus/babe/impl/babe_synchronizer_impl.cpp
@@ -25,6 +25,7 @@ namespace kagome::consensus {
 
   void BabeSynchronizerImpl::request(const primitives::BlockId &from,
                                      const primitives::BlockHash &to,
+                                     primitives::AuthorityIndex authority_index,
                                      const BlocksHandler &block_list_handler) {
     std::string from_str = visit_in_place(
         from,
@@ -41,7 +42,7 @@ namespace kagome::consensus {
                                    network::Direction::DESCENDING,
                                    boost::none};
 
-    return pollClients(request, {}, block_list_handler);
+    return pollClients(request, authority_index, block_list_handler);
   }
 
   std::shared_ptr<network::SyncProtocolClient>
@@ -100,16 +101,14 @@ namespace kagome::consensus {
 
   void BabeSynchronizerImpl::pollClients(
       network::BlocksRequest request,
-      std::unordered_set<std::shared_ptr<network::SyncProtocolClient>>
-          &&polled_clients,
+      primitives::AuthorityIndex authority_index,
       const BlocksHandler &requested_blocks_handler) const {
-    auto next_client = selectNextClient(polled_clients);
+    auto next_client = sync_clients_->clients[authority_index];
 
     next_client->requestBlocks(
         request,
         [self_wp{weak_from_this()},
          request{std::move(request)},
-         polled_clients{std::move(polled_clients)},
          requested_blocks_handler{requested_blocks_handler}](
             auto &&response_res) mutable {
           if (auto self = self_wp.lock()) {
@@ -120,10 +119,7 @@ namespace kagome::consensus {
                 return requested_blocks_handler(blocks_opt.value());
               }
             }
-            // proceed to the next client
-            return self->pollClients(std::move(request),
-                                     std::move(polled_clients),
-                                     requested_blocks_handler);
+            self->logger_->warn("Could not sync");
           }
         });
   }

--- a/core/consensus/babe/impl/babe_synchronizer_impl.hpp
+++ b/core/consensus/babe/impl/babe_synchronizer_impl.hpp
@@ -28,6 +28,7 @@ namespace kagome::consensus {
 
     void request(const primitives::BlockId &from,
                  const primitives::BlockHash &to,
+                 primitives::AuthorityIndex authority_index,
                  const BlocksHandler &block_list_handler) override;
 
    private:
@@ -47,8 +48,7 @@ namespace kagome::consensus {
      */
     void pollClients(
         network::BlocksRequest request,
-        std::unordered_set<std::shared_ptr<network::SyncProtocolClient>>
-            &&polled_clients,
+        primitives::AuthorityIndex authority_index,
         const BlocksHandler &requested_blocks_handler) const;
 
     std::shared_ptr<network::SyncClientsSet> sync_clients_;

--- a/core/consensus/babe/impl/block_executor.cpp
+++ b/core/consensus/babe/impl/block_executor.cpp
@@ -54,10 +54,19 @@ namespace kagome::consensus {
       logger_->info("Received block header. Number: {}, Hash: {}",
                     header.number,
                     block_hash.toHex());
-      const auto &[last_number, last_hash] = block_tree_->getLastFinalized();
 
-      // we should request blocks between last finalized one and received block
-      requestBlocks(last_hash, block_hash, [] {});
+      auto [_, babe_header] = getBabeDigests(header).value();
+
+      if (not block_tree_->getBlockHeader(header.parent_hash)) {
+        const auto &[last_number, last_hash] = block_tree_->getLastFinalized();
+        // we should request blocks between last finalized one and received
+        // block
+        requestBlocks(
+            last_hash, block_hash, babe_header.authority_index, [] {});
+      } else {
+        requestBlocks(
+            header.parent_hash, block_hash, babe_header.authority_index, [] {});
+      }
     }
   }
 
@@ -67,15 +76,21 @@ namespace kagome::consensus {
     auto new_block_hash =
         hasher_->blake2b_256(scale::encode(new_header).value());
     BOOST_ASSERT(new_header.number >= last_number);
-    return requestBlocks(last_hash, new_block_hash, std::move(next));
+    auto [_, babe_header] = getBabeDigests(new_header).value();
+    return requestBlocks(last_hash,
+                         new_block_hash,
+                         babe_header.authority_index,
+                         std::move(next));
   }
 
   void BlockExecutor::requestBlocks(const primitives::BlockId &from,
                                     const primitives::BlockHash &to,
+                                    primitives::AuthorityIndex authority_index,
                                     std::function<void()> &&next) {
     babe_synchronizer_->request(
         from,
         to,
+        authority_index,
         [self_wp{weak_from_this()},
          next(std::move(next))](const std::vector<primitives::Block> &blocks) {
           auto self = self_wp.lock();

--- a/core/consensus/babe/impl/block_executor.hpp
+++ b/core/consensus/babe/impl/block_executor.hpp
@@ -59,6 +59,7 @@ namespace kagome::consensus {
      */
     void requestBlocks(const primitives::BlockId &from,
                        const primitives::BlockHash &to,
+                       primitives::AuthorityIndex authority_index,
                        std::function<void()> &&next);
 
    private:

--- a/core/consensus/grandpa/impl/syncing_round_observer.cpp
+++ b/core/consensus/grandpa/impl/syncing_round_observer.cpp
@@ -25,9 +25,6 @@ namespace kagome::consensus::grandpa {
                      fin_res.error().message());
       return;
     }
-    logger_->info("Finalized block number {} with hash {}",
-                  f.vote.block_number,
-                  f.vote.block_hash.toHex());
   }
 
 }  // namespace kagome::consensus::grandpa

--- a/core/consensus/grandpa/impl/voting_round_impl.cpp
+++ b/core/consensus/grandpa/impl/voting_round_impl.cpp
@@ -95,9 +95,6 @@ namespace kagome::consensus::grandpa {
             finalized.error().message());
         return;
       }
-      logger_->info("Finalized block with hash: {}, number: {}",
-                    f.vote.block_hash.toHex(),
-                    f.vote.block_number);
       env_->onCompleted(CompletedRound{.round_number = round_number_,
                                        .state = cur_round_state_});
     } else {
@@ -155,12 +152,13 @@ namespace kagome::consensus::grandpa {
 
   outcome::result<void> VotingRoundImpl::notify(
       const RoundState &last_round_state) {
-    if (last_round_state == cur_round_state_) {
-      return VotingRoundError::NEW_STATE_EQUAL_TO_OLD;
-    }
+    //    if (last_round_state == cur_round_state_) {
+    //      return VotingRoundError::NEW_STATE_EQUAL_TO_OLD;
+    //    }
 
-    if (last_round_state.finalized != cur_round_state_.finalized
-        && completable_) {
+    //    if (last_round_state.finalized != cur_round_state_.finalized
+    //        && completable_) {
+    if (completable_) {
       auto finalized = cur_round_state_.finalized.value();
       const auto &opt_justification = finalizingPrecommits(finalized);
       if (not opt_justification) {

--- a/core/consensus/grandpa/impl/voting_round_impl.cpp
+++ b/core/consensus/grandpa/impl/voting_round_impl.cpp
@@ -152,12 +152,6 @@ namespace kagome::consensus::grandpa {
 
   outcome::result<void> VotingRoundImpl::notify(
       const RoundState &last_round_state) {
-    //    if (last_round_state == cur_round_state_) {
-    //      return VotingRoundError::NEW_STATE_EQUAL_TO_OLD;
-    //    }
-
-    //    if (last_round_state.finalized != cur_round_state_.finalized
-    //        && completable_) {
     if (completable_) {
       auto finalized = cur_round_state_.finalized.value();
       const auto &opt_justification = finalizingPrecommits(finalized);

--- a/core/injector/application_injector.hpp
+++ b/core/injector/application_injector.hpp
@@ -448,21 +448,24 @@ namespace kagome::injector {
         injector.template create<sptr<blockchain::BlockHeaderRepository>>();
 
     auto res = std::make_shared<network::SyncClientsSet>();
-    auto current_peer_synchronizer =
-        injector.template create<sptr<consensus::Synchronizer>>();
-    res->clients.insert(current_peer_synchronizer);
 
     auto current_peer_info = injector.template create<libp2p::peer::PeerInfo>();
     for (const auto &peer_info : peer_infos) {
+      spdlog::debug("Added peer with id: {}", peer_info.id.toBase58());
       if (peer_info.id != current_peer_info.id) {
-        res->clients.insert(std::make_shared<consensus::SynchronizerImpl>(
+        res->clients.push_back(std::make_shared<consensus::SynchronizerImpl>(
             *host,
             peer_info,
             block_tree,
             block_header_repository,
             injector.template create<consensus::SynchronizerConfig>()));
+      } else {
+        auto current_peer_synchronizer =
+            injector.template create<sptr<consensus::Synchronizer>>();
+        res->clients.push_back(current_peer_synchronizer);
       }
     }
+    std::reverse(res->clients.begin(), res->clients.end());
     initialized = res;
     return res;
   };
@@ -482,7 +485,9 @@ namespace kagome::injector {
       common::raise(configuration_res.error());
     }
     auto config = configuration_res.value();
-    config.leadership_rate = {1, 2};
+    for (const auto &authority : config.genesis_authorities) {
+      spdlog::debug("Babe authority: {}", authority.id.id.toHex());
+    }
     initialized = std::make_shared<primitives::BabeConfiguration>(config);
     return *initialized;
   };

--- a/core/network/types/sync_clients_set.hpp
+++ b/core/network/types/sync_clients_set.hpp
@@ -16,7 +16,7 @@ namespace kagome::network {
    * Keeps all known Sync clients
    */
   struct SyncClientsSet {
-    std::unordered_set<std::shared_ptr<SyncProtocolClient>> clients;
+    std::vector<std::shared_ptr<SyncProtocolClient>> clients;
   };
 }  // namespace kagome::network
 

--- a/test/core/blockchain/block_tree_test.cpp
+++ b/test/core/blockchain/block_tree_test.cpp
@@ -191,6 +191,8 @@ TEST_F(BlockTreeTest, Finalize) {
 
   Justification justification{{0x45, 0xF4}};
   auto encoded_justification = scale::encode(justification).value();
+  EXPECT_CALL(*storage_, getJustification(primitives::BlockId(hash)))
+      .WillOnce(Return(outcome::failure(boost::system::error_code{})));
   EXPECT_CALL(*storage_, putJustification(justification, hash, header.number))
       .WillRepeatedly(Return(outcome::success()));
   EXPECT_CALL(*storage_, setLastFinalizedBlockHash(hash))

--- a/test/mock/core/consensus/babe/babe_synchronizer_mock.hpp
+++ b/test/mock/core/consensus/babe/babe_synchronizer_mock.hpp
@@ -14,9 +14,10 @@ namespace kagome::consensus {
 
   class BabeSynchronizerMock : public BabeSynchronizer {
    public:
-    MOCK_METHOD3(request,
+    MOCK_METHOD4(request,
                  void(const primitives::BlockId &,
                       const primitives::BlockHash &,
+                      primitives::AuthorityIndex,
                       const BlocksHandler &));
   };
 


### PR DESCRIPTION
Signed-off-by: kamilsa <kamilsa16@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Jira task id

[PRE-440](https://soramitsu.atlassian.net/browse/PRE-440)

### Description of the Change

Optimize and stabilize interaction between the nodes. Resolves the following issues:
1. When block header announced, peer does not ask every peer to provide a block. Only asks announcer. Announcer is identified by the AuthorityIndex in the header's digest
2. When current peer receives block announce containing the header with known parent, then syncs only that announced block, instead of querying entire path from the last finalized to the received one
3. Before grandpa didn't send finalize message if current round intends to finalize already finalized block. That caused an issue that other peers could miss that message and build better blockchain on top of another block. And when that block is announced the peer that finalized the block tried to synchonize between its finalized block and new one. And since that path didn't exist liveness was broken

### Benefits

Aforementioned issues are resolved

### Possible Drawbacks 

From now on we should guarantee that the list of boot nodes in genesis has the same order with babe authorities obtained from the runtime

