### PR TITLE
Complete round if no estimate

### DIFF
--- a/core/consensus/babe/impl/babe_synchronizer_impl.cpp
+++ b/core/consensus/babe/impl/babe_synchronizer_impl.cpp
@@ -119,7 +119,12 @@ namespace kagome::consensus {
                 return requested_blocks_handler(blocks_opt.value());
               }
             }
-            self->logger_->warn("Could not sync");
+            else if (not response_res) {
+              self->logger_->error("Could not sync. Error: {}", response_res.error().message());
+            }
+            else {
+              self->logger_->error("Could not sync. Empty response");
+            }
           }
         });
   }

--- a/core/consensus/grandpa/impl/voting_round_error.cpp
+++ b/core/consensus/grandpa/impl/voting_round_error.cpp
@@ -15,5 +15,9 @@ OUTCOME_CPP_DEFINE_CATEGORY(kagome::consensus::grandpa, VotingRoundError, e) {
              "last round estimate or is descendant of it";
     case E::NEW_STATE_EQUAL_TO_OLD:
       return "New state is equal to the new one";
+    case E::NO_ESTIMATE_FOR_PREVIOUS_ROUND:
+      return "if last round didn't have an estimate then it didn't have a "
+             "ghost then it didn't have an upperbound then we cannot start a "
+             "round";
   }
 }

--- a/core/consensus/grandpa/impl/voting_round_error.hpp
+++ b/core/consensus/grandpa/impl/voting_round_error.hpp
@@ -13,7 +13,8 @@ namespace kagome::consensus::grandpa {
   enum class VotingRoundError {
     FIN_VALIDATION_FAILED = 1,
     LAST_ESTIMATE_BETTER_THAN_PREVOTE,
-    NEW_STATE_EQUAL_TO_OLD
+    NEW_STATE_EQUAL_TO_OLD,
+    NO_ESTIMATE_FOR_PREVIOUS_ROUND
   };
 
 }

--- a/core/consensus/grandpa/impl/voting_round_impl.cpp
+++ b/core/consensus/grandpa/impl/voting_round_impl.cpp
@@ -332,6 +332,7 @@ namespace kagome::consensus::grandpa {
               "hint during round {}",
               round_number_);
           env_->onCompleted(VotingRoundError::NO_ESTIMATE_FOR_PREVIOUS_ROUND);
+          break;
         }
 
         const auto &maybe_finalized = last_round_state.finalized;
@@ -381,6 +382,10 @@ namespace kagome::consensus::grandpa {
       }
       switch (state_) {
         case State::START:
+          // if we are primary and in the start state during prevote, then error happened during precommit. Should stop
+          if (isPrimary()) {
+            break;
+          }
         case State::PROPOSED: {
           auto prevote = constructPrevote(last_round_state);
           if (prevote) {

--- a/core/consensus/grandpa/impl/voting_round_impl.cpp
+++ b/core/consensus/grandpa/impl/voting_round_impl.cpp
@@ -386,6 +386,7 @@ namespace kagome::consensus::grandpa {
           if (isPrimary()) {
             break;
           }
+        [[fallthrough]]  
         case State::PROPOSED: {
           auto prevote = constructPrevote(last_round_state);
           if (prevote) {

--- a/core/consensus/grandpa/impl/voting_round_impl.cpp
+++ b/core/consensus/grandpa/impl/voting_round_impl.cpp
@@ -331,7 +331,7 @@ namespace kagome::consensus::grandpa {
               "Last round estimate does not exist, not sending primary block "
               "hint during round {}",
               round_number_);
-          break;
+          env_->onCompleted(VotingRoundError::NO_ESTIMATE_FOR_PREVIOUS_ROUND);
         }
 
         const auto &maybe_finalized = last_round_state.finalized;


### PR DESCRIPTION
Signed-off-by: kamilsa <kamilsa16@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Jira task id

[PRE-443](https://soramitsu.atlassian.net/browse/PRE-443)

### Description of the Change

We should stop the round if there were no estimate for the previous one. We have such handling, but we didn't stop round when that happened.

### Benefits

Proper missing estimate handling

### Possible Drawbacks 

None
<!-- If no drawbacks, explicitly mention this (write None) -->
