### PR TITLE
[DOPS-1047]  Make kagome CI faster

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
       runs-on: ubuntu-latest
       container: soramitsu/kagome-dev:10  # Change to ${{ env.INDOCKER_IMAGE }} https://github.community/t/how-to-set-and-access-a-workflow-variable/17335/6
       steps:
-        - uses: actions/checkout@v1
+        - uses: actions/checkout@v2
         - uses: actions/cache@v2
           with:
             path: ${{ env.CACHE_PATHS }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
       runs-on: ubuntu-latest
       container: soramitsu/kagome-dev:9  # Change to ${{ env.INDOCKER_IMAGE }} https://github.community/t/how-to-set-and-access-a-workflow-variable/17335/6
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v1
         - uses: actions/cache@v2
           with:
             path: ${{ env.CACHE_PATHS }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
         # The imported target "sr25519::sr25519" references the file
         #     "/github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a"
         #  but this file does not exist.  Possible reasons include:
-        - name:
+        - name: Kludge
           run: |
             mkdir -p /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib && \
             ln -s /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib64/libsr25519crust.a \
@@ -151,7 +151,7 @@ jobs:
         # The imported target "sr25519::sr25519" references the file
         #     "/github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a"
         #  but this file does not exist.  Possible reasons include:
-        - name:
+        - name: Kludge
           run: |
             mkdir -p /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib && \
             ln -s /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib64/libsr25519crust.a \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,7 @@ env:
   INDOCKER_IMAGE: soramitsu/kagome-dev:9
   CACHE_VERSION: v01
   CACHE_PATHS: |
-    ~/Library/Caches
-    ~/.cache
+    ~/Library/Caches/pip
     ~/.cargo
     ~/.ccache
     ~/.hunter

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,8 +137,8 @@ jobs:
           run: "${{ matrix.options.run }}"
 
   push:
-      #if: ${{ github.ref == 'refs/heads/master' || startsWith( github.ref, 'refs/tags/' ) }}
-      #needs: [clang-tidy, Linux, MacOS, Alpine]
+      if: ${{ github.ref == 'refs/heads/master' || startsWith( github.ref, 'refs/tags/' ) }}
+      needs: [clang-tidy, Linux, MacOS, Alpine]
       name: "Push"
       runs-on: ubuntu-latest
       container: soramitsu/kagome-dev:10-alpine # Change to '${{ env.INDOCKER_IMAGE }}-alpine' https://github.community/t/how-to-set-and-access-a-workflow-variable/17335/6
@@ -167,5 +167,5 @@ jobs:
             password: ${{ secrets.DOCKER_TOKEN }}
         - name: docker pack and push
           env:
-            VERSION: test-ci #${{ github.ref }}
+            VERSION: ${{ github.ref }}
           run: ./housekeeping/docker/release/build_and_push.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: ${{ env.CACHE_PATHS }}
-        key: ${{ runner.os }}-${{ env.CACHE_VERSION }}
+        key: ${{ github.job }}-${{ env.CACHE_VERSION }}
     - name: install
       run: ./housekeeping/macos/dependency.sh
     - name: build
@@ -55,7 +55,7 @@ jobs:
         - uses: actions/cache@v2
           with:
             path: ${{ env.CACHE_PATHS }}
-            key: ${{ runner.os }}-${{ env.CACHE_VERSION }}
+            key: ${{ github.job }}-${{ matrix.options.name }}-${{ env.CACHE_VERSION }}
         - name: "${{ matrix.options.name }}"
           run: "${{ matrix.options.run }}"
 
@@ -68,7 +68,7 @@ jobs:
         - uses: actions/cache@v2
           with:
             path: ${{ env.CACHE_PATHS }}
-            key: ${{ runner.os }}-${{ env.CACHE_VERSION }}
+            key: ${{ github.job }}-${{ env.CACHE_VERSION }}
         - name: clang-tidy
           env:
             # build only generated files, so clang-tidy will work correctl
@@ -86,7 +86,7 @@ jobs:
         - uses: actions/cache@v2
           with:
             path: ${{ env.CACHE_PATHS }}
-            key: ${{ runner.os }}-${{ env.CACHE_VERSION }}
+            key: ${{ github.job }}-${{ env.CACHE_VERSION }}
         - name: makeBuild
           env:
             BUILD_FINAL_TARGET: ctest_coverage
@@ -114,7 +114,7 @@ jobs:
         - uses: actions/cache@v2
           with:
             path: ${{ env.CACHE_PATHS }}
-            key: ${{ runner.os }}-${{ env.CACHE_VERSION }}
+            key: ${{ github.job }}-${{ env.CACHE_VERSION }}
         - name: build
           run: ./housekeeping/docker/release/makeRelease.sh
         - uses: azure/docker-login@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ env:
   GITHUB_HUNTER_USERNAME: ${{ secrets.HUNTER_USERNAME }}
   GITHUB_HUNTER_TOKEN: ${{ secrets.HUNTER_TOKEN }}
   INDOCKER_IMAGE: soramitsu/kagome-dev:10
-  CACHE_VERSION: v01
+  CACHE_VERSION: v02
   CACHE_PATHS: |
     ~/Library/Caches/pip
     ~/.cargo
@@ -108,9 +108,9 @@ jobs:
       strategy:
         matrix:
           options:
-            - name: "Build Test"
+            - name: "Alpine: Build Test"
               run: ./housekeeping/makeBuild.sh
-            - name: "Build Release"
+            - name: "Alpine: Build Release"
               run: ./housekeeping/docker/release/makeRelease.sh
       name: "${{ matrix.options.name }}"
       runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,7 @@ jobs:
           with:
             path: ${{ env.CACHE_PATHS }}
             key: ${{ github.job }}-${{ matrix.options.name }}-${{ env.CACHE_VERSION }}
+        # https://github.com/soramitsu/kagome/issues/453
         # ToDo should be fixed in library repo, this fix is work only for github action, you should change home dir
         # The imported target "sr25519::sr25519" references the file
         #     "/github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a"
@@ -147,6 +148,7 @@ jobs:
           with:
             path: ${{ env.CACHE_PATHS }}
             key: ${{ github.job }}-${{ env.CACHE_VERSION }}
+        # https://github.com/soramitsu/kagome/issues/453
         # ToDo should be fixed in library repo, this fix is work only for github action, you should change home dir
         # The imported target "sr25519::sr25519" references the file
         #     "/github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,3 +125,4 @@ jobs:
           env:
             VERSION: ${{ github.ref }}
           run: ./housekeeping/docker/release/build_and_push.sh
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,4 +125,3 @@ jobs:
           env:
             VERSION: ${{ github.ref }}
           run: ./housekeeping/docker/release/build_and_push.sh
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,8 +137,8 @@ jobs:
           run: "${{ matrix.options.run }}"
 
   push:
-      if: ${{ github.ref == 'refs/heads/master' || startsWith( github.ref, 'refs/tags/' ) }}
-      needs: [clang-tidy, Linux, MacOS, Alpine]
+      #if: ${{ github.ref == 'refs/heads/master' || startsWith( github.ref, 'refs/tags/' ) }}
+      #needs: [clang-tidy, Linux, MacOS, Alpine]
       name: "Push"
       runs-on: ubuntu-latest
       container: soramitsu/kagome-dev:10-alpine # Change to '${{ env.INDOCKER_IMAGE }}-alpine' https://github.community/t/how-to-set-and-access-a-workflow-variable/17335/6
@@ -167,5 +167,5 @@ jobs:
             password: ${{ secrets.DOCKER_TOKEN }}
         - name: docker pack and push
           env:
-            VERSION: ${{ github.ref }}
+            VERSION: test-ci #${{ github.ref }}
           run: ./housekeeping/docker/release/build_and_push.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
           run: |
             mkdir -p /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib && \
             ln -s /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib64/libsr25519crust.a \
-                  /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a
+                  /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a || true
         - name: "${{ matrix.options.name }}"
           run: "${{ matrix.options.run }}"
 
@@ -155,7 +155,7 @@ jobs:
           run: |
             mkdir -p /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib && \
             ln -s /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib64/libsr25519crust.a \
-                  /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a
+                  /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a || true
         - name: build
           run: ./housekeeping/docker/release/makeRelease.sh
         - uses: azure/docker-login@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
 
   Linux:
       strategy:
+        fail-fast: false
         matrix:
           options:
            - name: "Linux: gcc-9 ASAN No Toolchain"
@@ -106,6 +107,7 @@ jobs:
 
   Alpine:
       strategy:
+        fail-fast: false
         matrix:
           options:
             - name: "Alpine: Build Test"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,15 @@ jobs:
           with:
             path: ${{ env.CACHE_PATHS }}
             key: ${{ github.job }}-${{ matrix.options.name }}-${{ env.CACHE_VERSION }}
+        # ToDo should be fixed in library repo, this fix is work only for github action, you should change home dir
+        # The imported target "sr25519::sr25519" references the file
+        #     "/github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a"
+        #  but this file does not exist.  Possible reasons include:
+        - name:
+          run: |
+            mkdir -p /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib && \
+            ln -s /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib64/libsr25519crust.a \
+                  /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a
         - name: "${{ matrix.options.name }}"
           run: "${{ matrix.options.run }}"
 
@@ -138,6 +147,15 @@ jobs:
           with:
             path: ${{ env.CACHE_PATHS }}
             key: ${{ github.job }}-${{ env.CACHE_VERSION }}
+        # ToDo should be fixed in library repo, this fix is work only for github action, you should change home dir
+        # The imported target "sr25519::sr25519" references the file
+        #     "/github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a"
+        #  but this file does not exist.  Possible reasons include:
+        - name:
+          run: |
+            mkdir -p /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib && \
+            ln -s /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib64/libsr25519crust.a \
+                  /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a
         - name: build
           run: ./housekeeping/docker/release/makeRelease.sh
         - uses: azure/docker-login@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ env:
   CTEST_OUTPUT_ON_FAILURE: 1
   GITHUB_HUNTER_USERNAME: ${{ secrets.HUNTER_USERNAME }}
   GITHUB_HUNTER_TOKEN: ${{ secrets.HUNTER_TOKEN }}
-  INDOCKER_IMAGE: soramitsu/kagome-dev:9
+  INDOCKER_IMAGE: soramitsu/kagome-dev:10
   CACHE_VERSION: v01
   CACHE_PATHS: |
     ~/Library/Caches/pip
@@ -48,7 +48,7 @@ jobs:
              run: ./housekeeping/makeBuild.sh -DCMAKE_TOOLCHAIN_FILE=cmake/san/clang-8_cxx17_ubsan.cmake
       name: "${{ matrix.options.name }}"
       runs-on: ubuntu-latest
-      container: soramitsu/kagome-dev:9 # Change to ${{ env.INDOCKER_IMAGE }} https://github.community/t/how-to-set-and-access-a-workflow-variable/17335/6
+      container: soramitsu/kagome-dev:10 # Change to ${{ env.INDOCKER_IMAGE }} https://github.community/t/how-to-set-and-access-a-workflow-variable/17335/6
       steps:
         - uses: actions/checkout@v2
         - uses: actions/cache@v2
@@ -61,7 +61,7 @@ jobs:
   clang-tidy:
       name: "Linux: clang-tidy"
       runs-on: ubuntu-latest
-      container: soramitsu/kagome-dev:9
+      container: soramitsu/kagome-dev:10
       steps:
         - uses: actions/checkout@v2
         - uses: actions/cache@v2
@@ -79,7 +79,7 @@ jobs:
   coverage:
       name: "Linux: gcc-8 coverage/sonar"
       runs-on: ubuntu-latest
-      container: soramitsu/kagome-dev:9  # Change to ${{ env.INDOCKER_IMAGE }} https://github.community/t/how-to-set-and-access-a-workflow-variable/17335/6
+      container: soramitsu/kagome-dev:10  # Change to ${{ env.INDOCKER_IMAGE }} https://github.community/t/how-to-set-and-access-a-workflow-variable/17335/6
       steps:
         - uses: actions/checkout@v1
         - uses: actions/cache@v2
@@ -90,11 +90,13 @@ jobs:
           env:
             BUILD_FINAL_TARGET: ctest_coverage
           run: ./housekeeping/makeBuild.sh -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain/gcc-8_cxx17.cmake -DCOVERAGE=ON
-        - name: Submit Coverage
+        - if: github.repository == 'soramitsu/kagome'
+          name: Submit Coverage
           env:
             CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           run: ./housekeeping/codecov.sh
-        - name: Sonar
+        - if: github.repository == 'soramitsu/kagome'
+          name: Sonar
           env:
             SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
             GITHUB_USERNAME: ${{ secrets.GITHUB_USERNAME }}
@@ -102,12 +104,32 @@ jobs:
             BRANCH_NAME: ${{ github.ref }}
           run: ./housekeeping/sonar.sh
 
+  Alpine:
+      strategy:
+        matrix:
+          options:
+            - name: "Build Test"
+              run: ./housekeeping/makeBuild.sh
+            - name: "Build Release"
+              run: ./housekeeping/docker/release/makeRelease.sh
+      name: "${{ matrix.options.name }}"
+      runs-on: ubuntu-latest
+      container: soramitsu/kagome-dev:10-alpine # Change to '${{ env.INDOCKER_IMAGE }}-alpine' https://github.community/t/how-to-set-and-access-a-workflow-variable/17335/6
+      steps:
+        - uses: actions/checkout@v2
+        - uses: actions/cache@v2
+          with:
+            path: ${{ env.CACHE_PATHS }}
+            key: ${{ github.job }}-${{ matrix.options.name }}-${{ env.CACHE_VERSION }}
+        - name: "${{ matrix.options.name }}"
+          run: "${{ matrix.options.run }}"
+
   push:
       if: ${{ github.ref == 'refs/heads/master' || startsWith( github.ref, 'refs/tags/' ) }}
-      needs: [clang-tidy, Linux, MacOS]
+      needs: [clang-tidy, Linux, MacOS, Alpine]
       name: "Push"
       runs-on: ubuntu-latest
-      container: soramitsu/kagome-dev:9 # Change to ${{ env.INDOCKER_IMAGE }} https://github.community/t/how-to-set-and-access-a-workflow-variable/17335/6
+      container: soramitsu/kagome-dev:10-alpine # Change to '${{ env.INDOCKER_IMAGE }}-alpine' https://github.community/t/how-to-set-and-access-a-workflow-variable/17335/6
       steps:
         - uses: actions/checkout@v2
         - uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,24 @@ env:
   GITHUB_HUNTER_USERNAME: ${{ secrets.HUNTER_USERNAME }}
   GITHUB_HUNTER_TOKEN: ${{ secrets.HUNTER_TOKEN }}
   INDOCKER_IMAGE: soramitsu/kagome-dev:9
+  CACHE_VERSION: v01
+  CACHE_PATHS: |
+    ~/Library/Caches
+    ~/.cache
+    ~/.cargo
+    ~/.ccache
+    ~/.hunter
+    ~/.rustup
 
 jobs:
   MacOS:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: ${{ env.CACHE_PATHS }}
+        key: ${{ runner.os }}-${{ env.CACHE_VERSION }}
     - name: install
       run: ./housekeeping/macos/dependency.sh
     - name: build
@@ -40,6 +52,10 @@ jobs:
       container: soramitsu/kagome-dev:9 # Change to ${{ env.INDOCKER_IMAGE }} https://github.community/t/how-to-set-and-access-a-workflow-variable/17335/6
       steps:
         - uses: actions/checkout@v2
+        - uses: actions/cache@v2
+          with:
+            path: ${{ env.CACHE_PATHS }}
+            key: ${{ runner.os }}-${{ env.CACHE_VERSION }}
         - name: "${{ matrix.options.name }}"
           run: "${{ matrix.options.run }}"
 
@@ -49,6 +65,10 @@ jobs:
       container: soramitsu/kagome-dev:9
       steps:
         - uses: actions/checkout@v2
+        - uses: actions/cache@v2
+          with:
+            path: ${{ env.CACHE_PATHS }}
+            key: ${{ runner.os }}-${{ env.CACHE_VERSION }}
         - name: clang-tidy
           env:
             # build only generated files, so clang-tidy will work correctl
@@ -62,6 +82,10 @@ jobs:
       container: soramitsu/kagome-dev:9  # Change to ${{ env.INDOCKER_IMAGE }} https://github.community/t/how-to-set-and-access-a-workflow-variable/17335/6
       steps:
         - uses: actions/checkout@v2
+        - uses: actions/cache@v2
+          with:
+            path: ${{ env.CACHE_PATHS }}
+            key: ${{ runner.os }}-${{ env.CACHE_VERSION }}
         - name: makeBuild
           env:
             BUILD_FINAL_TARGET: ctest_coverage
@@ -86,6 +110,10 @@ jobs:
       container: soramitsu/kagome-dev:9 # Change to ${{ env.INDOCKER_IMAGE }} https://github.community/t/how-to-set-and-access-a-workflow-variable/17335/6
       steps:
         - uses: actions/checkout@v2
+        - uses: actions/cache@v2
+          with:
+            path: ${{ env.CACHE_PATHS }}
+            key: ${{ runner.os }}-${{ env.CACHE_VERSION }}
         - name: build
           run: ./housekeeping/docker/release/makeRelease.sh
         - uses: azure/docker-login@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   BUILD_DIR: build
-  BUILD_TREADS: 2
   CTEST_OUTPUT_ON_FAILURE: 1
   GITHUB_HUNTER_USERNAME: ${{ secrets.HUNTER_USERNAME }}
   GITHUB_HUNTER_TOKEN: ${{ secrets.HUNTER_TOKEN }}
@@ -23,7 +22,6 @@ jobs:
       run: ./housekeeping/macos/dependency.sh
     - name: build
       env:
-        BUILD_TREADS: 4
         DEVELOPER_DIR: /Applications/Xcode_11.app/Contents/Developer
       run: ./housekeeping/makeBuild.sh  -DCOVERAGE=OFF -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain/cxx17.cmake
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ env:
   GITHUB_HUNTER_USERNAME: ${{ secrets.HUNTER_USERNAME }}
   GITHUB_HUNTER_TOKEN: ${{ secrets.HUNTER_TOKEN }}
   INDOCKER_IMAGE: soramitsu/kagome-dev:10
-  CACHE_VERSION: v02
+  CACHE_VERSION: v03
   CACHE_PATHS: |
     ~/Library/Caches/pip
     ~/.cargo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,7 @@ jobs:
           run: |
             ./housekeeping/makeBuild.sh
             ./housekeeping/clang-tidy.sh
+
   coverage:
       name: "Linux: gcc-8 coverage/sonar"
       runs-on: ubuntu-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ jobs:
         - brew cleanup
       env:
         - BUILD_DIR=build
-        - BUILD_TREADS=2
       script:
         - ./housekeeping/makeBuild.sh  -DCOVERAGE=${COVERAGE:-OFF} -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN:-cmake/toolchain/cxx17.cmake}
 
@@ -56,7 +55,6 @@ jobs:
       env:
         - BUILD_FINAL_TARGET=generated
         - BUILD_DIR=build
-        - BUILD_TREADS=2
         - INDOCKER_IMAGE=soramitsu/kagome-dev:9
       script:
         - ./housekeeping/indocker.sh ./housekeeping/makeBuild.sh

--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ git clone https://github.com/soramitsu/kagome
 cd kagome
 
 # build and run tests
-INDOCKER_IMAGE=soramitsu/kagome-dev:9 BUILD_DIR=build BUILD_TREADS=9 ./housekeeping/indocker.sh ./housekeeping/makeBuild.sh
+INDOCKER_IMAGE=soramitsu/kagome-dev:10 BUILD_DIR=build BUILD_TREADS=9 ./housekeeping/indocker.sh ./housekeeping/makeBuild.sh
 
 # You can use indocker.sh to run any script or command inside docker
 # It mounts project dir and copy important env variable inside the container.
-INDOCKER_IMAGE=soramitsu/kagome-dev:9 ./housekeeping/indocker.sh gcc --version
+INDOCKER_IMAGE=soramitsu/kagome-dev:10 ./housekeeping/indocker.sh gcc --version
 
 ## Build Release 
 # Build Kagome
-INDOCKER_IMAGE=soramitsu/kagome-dev:9 BUILD_DIR=build ./housekeeping/indocker.sh ./housekeeping/docker/release/makeRelease.sh
+INDOCKER_IMAGE=soramitsu/kagome-dev:10 BUILD_DIR=build ./housekeeping/indocker.sh ./housekeeping/docker/release/makeRelease.sh
 # Create docker image and push 
 VERSION=0.0.1 BUILD_DIR=build ./housekeeping/docker/release/build_and_push.sh
 # or just build docker image 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ version: '3'
 
 services:
   dev:
-    image: soramitsu/kagome-dev:9
+    image: soramitsu/kagome-dev:10
     tty: true
     stdin_open: true
     working_dir: /app

--- a/housekeeping/docker/develop/Dockerfile
+++ b/housekeeping/docker/develop/Dockerfile
@@ -24,7 +24,9 @@ RUN pip3 install --no-cache-dir scikit-build cmake requests gitpython gcovr pyya
 
 # install rustc
 ENV RUST_VERSION=nightly-2019-07-07
-ENV PATH="/root/.cargo/bin:${PATH}"
+ENV RUSTUP_HOME=/root/.rustup
+ENV CARGO_HOME=/root/.cargo
+ENV PATH="${CARGO_HOME}/bin:${PATH}"
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_VERSION} && \
     rustup default ${RUST_VERSION}
 

--- a/housekeeping/docker/develop/Dockerfile
+++ b/housekeeping/docker/develop/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 MAINTAINER Bohdan Vanieiev <bogdan@soramitsu.co.jp>
 
@@ -14,12 +14,13 @@ RUN apt-get update && \
         python3-pip \
         python3-setuptools \
     && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    add-apt-repository -y "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" && \
-    add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    add-apt-repository -y "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main" && \
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && rm -rf /var/lib/apt/lists/*
 
 # install cmake and dev dependencies
-RUN python3 -m pip install --upgrade pip
-RUN pip3 install scikit-build cmake requests gitpython gcovr pyyaml
+RUN python3 -m pip install --no-cache-dir --upgrade pip
+RUN pip3 install --no-cache-dir scikit-build cmake requests gitpython gcovr pyyaml
 
 # install rustc
 ENV RUST_VERSION=nightly-2019-07-07
@@ -36,6 +37,8 @@ RUN apt-get update && apt-get upgrade -y && \
         g++-8 \
         gcc-9 \
         g++-9 \
+        gcc-10 \
+        g++-10 \
         llvm-8 \
         clang-8 \
         clang-tidy-8 \
@@ -46,6 +49,7 @@ RUN apt-get update && apt-get upgrade -y && \
         ninja-build \
         vim \
         unzip\
+        docker.io \
     && rm -rf /var/lib/apt/lists/*
 
 # install sonar cli
@@ -73,11 +77,3 @@ RUN update-alternatives --install /usr/bin/gcov         gcov         /usr/bin/gc
     update-alternatives --install /usr/bin/clang-tidy   clang-tidy   /usr/bin/clang-tidy-8         90 && \
     update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-8       90 && \
     update-alternatives --install /usr/bin/python       python       /usr/bin/python3              90
-
-# soramitsu/kagome-dev:8 is used as cache,
-# if you build fresh image kagome build will fail: 'hunter ERROR: sr25519'
-# TODO change image to alpine and move this block up.
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y \
-      docker.io \
-    && rm -rf /var/lib/apt/lists/*

--- a/housekeeping/docker/develop/Dockerfile-alpine
+++ b/housekeeping/docker/develop/Dockerfile-alpine
@@ -14,7 +14,8 @@ RUN apk add --no-cache \
         g++ \
         ccache \
         linux-headers \
-        docker-cli
+        docker-cli \
+        tar
 
 # Setup python
 RUN \

--- a/housekeeping/docker/develop/Dockerfile-alpine
+++ b/housekeeping/docker/develop/Dockerfile-alpine
@@ -1,0 +1,35 @@
+FROM alpine:3
+
+# Install dependesciee
+RUN apk add --no-cache \
+        bash \
+        openssh-client \
+        python3 \
+        perl \
+        rust \
+        cargo \
+        git \
+        cmake \
+        make \
+        g++ \
+        ccache \
+        linux-headers \
+        docker-cli
+
+# Setup python
+RUN \
+    if [[ ! -e /usr/bin/pip ]]; then ln -s /usr/bin/pip3 /usr/bin/pip; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+	python -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip install --upgrade pip setuptools && \
+	pip install requests && \
+	pip install gitpython && \
+    rm -r /root/.cache
+
+# ToDo should be fixed in library repo
+# The imported target "sr25519::sr25519" references the file
+#     "/root/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a"
+#  but this file does not exist.  Possible reasons include:
+RUN mkdir -p /root/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib && \
+ 	ln -s /root/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib64/libsr25519crust.a /root/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a

--- a/housekeeping/docker/develop/Dockerfile-alpine
+++ b/housekeeping/docker/develop/Dockerfile-alpine
@@ -27,9 +27,9 @@ RUN \
 	pip install gitpython && \
     rm -r /root/.cache
 
-# ToDo should be fixed in library repo
+# ToDo should be fixed in library repo, this fix is work only for github action, you should change home dir
 # The imported target "sr25519::sr25519" references the file
-#     "/root/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a"
+#     "/github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a"
 #  but this file does not exist.  Possible reasons include:
-RUN mkdir -p /root/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib && \
- 	ln -s /root/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib64/libsr25519crust.a /root/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a
+RUN mkdir -p /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib && \
+ 	ln -s /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib64/libsr25519crust.a /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a

--- a/housekeeping/docker/develop/Dockerfile-alpine
+++ b/housekeeping/docker/develop/Dockerfile-alpine
@@ -26,10 +26,3 @@ RUN \
 	pip install requests && \
 	pip install gitpython && \
     rm -r /root/.cache
-
-# ToDo should be fixed in library repo, this fix is work only for github action, you should change home dir
-# The imported target "sr25519::sr25519" references the file
-#     "/github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a"
-#  but this file does not exist.  Possible reasons include:
-RUN mkdir -p /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib && \
- 	ln -s /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib64/libsr25519crust.a /github/home/.hunter/_Base/7819e7d/473f5cb/ee8f669/Install/lib/libsr25519crust.a

--- a/housekeeping/docker/develop/build_and_push.sh
+++ b/housekeeping/docker/develop/build_and_push.sh
@@ -2,8 +2,11 @@
 
 cd $(dirname $0)
 
-VERSION=9
+VERSION=10
 TAG=soramitsu/kagome-dev:$VERSION
 
 docker build -t $TAG .
 docker push $TAG
+
+docker build -t ${TAG}-alpine -f Dockerfile-alpine .
+docker push ${TAG}-alpine

--- a/housekeeping/docker/release/Dockerfile
+++ b/housekeeping/docker/release/Dockerfile
@@ -1,9 +1,6 @@
-FROM ubuntu:18.04
+FROM alpine:3
 
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y \
-        libasan5 \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache libgcc libstdc++
 
 WORKDIR /kagome
 ENV PATH $PATH:/kagome

--- a/housekeeping/docker/release/makeRelease.sh
+++ b/housekeeping/docker/release/makeRelease.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 
 BUILD_DIR=build
-BUILD_TREADS="${BUILD_TREADS:-4}"
+BUILD_TREADS="${BUILD_TREADS:-$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))}"
 
 cd "$(dirname $0)/../../.."
 

--- a/housekeeping/makeBuild.sh
+++ b/housekeeping/makeBuild.sh
@@ -2,7 +2,7 @@
 
 BUILD_DIR="${BUILD_DIR:?BUILD_DIR variable is not defined}"
 BUILD_FINAL_TARGET="${BUILD_FINAL_TARGET:-test}"
-BUILD_TREADS="${BUILD_TREADS:-4}"
+BUILD_TREADS="${BUILD_TREADS:-$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))}"
 
 which git
 

--- a/housekeeping/makeBuild.sh
+++ b/housekeeping/makeBuild.sh
@@ -9,5 +9,7 @@ which git
 cd "$(dirname $0)/.."
 
 cmake . -B${BUILD_DIR} "$@"
-cmake --build "${BUILD_DIR}" -- -j${BUILD_TREADS}
+if [ "$BUILD_FINAL_TARGET" == "test" ] ; then
+  cmake --build "${BUILD_DIR}" -- -j${BUILD_TREADS}
+fi
 cmake --build "${BUILD_DIR}" --target "${BUILD_FINAL_TARGET}"

--- a/housekeeping/makeBuild.sh
+++ b/housekeeping/makeBuild.sh
@@ -9,7 +9,7 @@ which git
 cd "$(dirname $0)/.."
 
 cmake . -B${BUILD_DIR} "$@"
-if [ "$BUILD_FINAL_TARGET" == "test" ] ; then
+if [ "$BUILD_FINAL_TARGET" != "generated" ] ; then
   cmake --build "${BUILD_DIR}" -- -j${BUILD_TREADS}
 fi
 cmake --build "${BUILD_DIR}" --target "${BUILD_FINAL_TARGET}"


### PR DESCRIPTION
Signed-off-by: Bulat Saifullin <bulat@saifullin.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Jira task id

[DOPS-1047](https://soramitsu.atlassian.net/browse/DOPS-1047)  Make kagome CI faster

### Related Issue

Resolves #452 

### Description of the Change

- [x] Add build cache (ccache  hunter)
- [x] clang-tidy-need only generator build, no full run.
- [ ] delete travis
- [x] add cpu count to script 
- [x] switch to alpine images,  add gcc 10
- [x] Clang-tidy failed only in Travis should fail in both
___
1. We had the plan to delete Travis job,  but I suggest moving it to separate task because we found the Clang-tidy problem with the help of Travis (Clang-tidy failed only in Travis should fail in both). 
The problem was what we used [git command](https://github.com/soramitsu/kagome/blob/master/housekeeping/clang-tidy.sh#L15)  to define changed files, but `actions/checkout@v2` do not support old git what was installed inside the container, so it used GitHub api to download files.  (fixed now)
![Screenshot from 2020-07-14 17-02-21](https://user-images.githubusercontent.com/24387396/87435015-d933d900-c5f3-11ea-9838-3b2f6e29848c.png)

2. I had planned to completely migrate to alpine, but it is not trivial to install all versions of gcc to alpine, you have to compile them first. So for build and push docker image we have a alpine container and for testing of different compiler we have Ubuntu. 


### Benefits
1. faster build time 10 min vs 30 min:
![Screenshot from 2020-07-02 11-59-01](https://user-images.githubusercontent.com/24387396/87436129-4ac05700-c5f5-11ea-99c9-366efa49b550.png)
2. optimal use of cpu cores (n+1).
3. Smaller finial docker image ~50%: 
![Screenshot from 2020-07-14 16-45-58](https://user-images.githubusercontent.com/24387396/87436280-82c79a00-c5f5-11ea-9a90-9607da784b8f.png)
4. Security: alpine uses Musl it  written with more security in mind

### Possible Drawbacks 

1. Now we have two docker images (ubuntu, alpine), both should be supported.
2. Git hub action have limit the cache size (5 GB per repo ), the old cache will be deleted very fast. some build may not see benefits.  

### Usage Examples or Tests <!-- Optional -->
you can test lite-weight kagome container:
`docker pull soramitsu/kagome:test-ci`

### Alternate Designs <!-- Optional -->

<!-- Explain what other alternates were considered and why the proposed version was selected -->
