### PR TITLE
Disable clang-tidy on master 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,7 @@ jobs:
           run: "${{ matrix.options.run }}"
 
   clang-tidy:
+      if: ${{ github.ref != 'refs/heads/master'}} 
       name: "Linux: clang-tidy"
       runs-on: ubuntu-latest
       container: soramitsu/kagome-dev:10
@@ -138,7 +139,7 @@ jobs:
 
   push:
       if: ${{ github.ref == 'refs/heads/master' || startsWith( github.ref, 'refs/tags/' ) }}
-      needs: [clang-tidy, Linux, MacOS, Alpine]
+      needs: [Linux, MacOS, Alpine]
       name: "Push"
       runs-on: ubuntu-latest
       container: soramitsu/kagome-dev:10-alpine # Change to '${{ env.INDOCKER_IMAGE }}-alpine' https://github.community/t/how-to-set-and-access-a-workflow-variable/17335/6


### PR DESCRIPTION
Signed-off-by: Bulat Saifullin bulat@saifullin.ru

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

Master branch start failing on clang-tidy step.  Clang-tidy  should be performed only for PR 

### Description of the Change

disable   Clang-tidy  for master 

### Benefits

Green ci on master 

### Possible Drawbacks 
none

