### PR TITLE
[Duty] Fix CI failure on coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,12 +91,12 @@ jobs:
           env:
             BUILD_FINAL_TARGET: ctest_coverage
           run: ./housekeeping/makeBuild.sh -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain/gcc-8_cxx17.cmake -DCOVERAGE=ON
-        - if: ${{ github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.repository }}
+        - if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           name: Submit Coverage
           env:
             CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           run: if [ "CODECOV_TOKEN" != "null" ]; then ./housekeeping/codecov.sh; else echo "Some secret undefined. Step passed..."; fi
-        - if: ${{ github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.repository }}
+        - if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           name: Sonar
           env:
             SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,12 +91,12 @@ jobs:
           env:
             BUILD_FINAL_TARGET: ctest_coverage
           run: ./housekeeping/makeBuild.sh -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain/gcc-8_cxx17.cmake -DCOVERAGE=ON
-        - if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        - if: ${{ github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.repository }}
           name: Submit Coverage
           env:
             CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           run: if [ "CODECOV_TOKEN" != "null" ]; then ./housekeeping/codecov.sh; else echo "Some secret undefined. Step passed..."; fi
-        - if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        - if: ${{ github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.repository }}
           name: Sonar
           env:
             SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,12 +91,12 @@ jobs:
           env:
             BUILD_FINAL_TARGET: ctest_coverage
           run: ./housekeeping/makeBuild.sh -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain/gcc-8_cxx17.cmake -DCOVERAGE=ON
-        - if: ${{ github.repository == 'soramitsu/kagome' }}
+        - if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           name: Submit Coverage
           env:
             CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           run: if [ "CODECOV_TOKEN" != "null" ]; then ./housekeeping/codecov.sh; else echo "Some secret undefined. Step passed..."; fi
-        - if: ${{ github.repository == 'soramitsu/kagome' }}
+        - if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           name: Sonar
           env:
             SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Change the condition upon which the CI executes the coverage upload. 
According to the [docs](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#using-encrypted-secrets-in-a-workflow) Github Actions does not expose secrets to pull requests from forks as a security measure. 
This PR changes the condition on the steps that require secrets to skip them in case the head of the branch is not the repository itself (which happens when the PR is from a fork).   


### Benefits

CIs passe without failing like [this](https://github.com/soramitsu/kagome/runs/966947008)
 
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

PRs from forks will not see their coverage uploaded 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

