### PR TITLE
Add toString method to Buffer and fix buffer overrun in logging

### DIFF
--- a/core/common/buffer.cpp
+++ b/core/common/buffer.cpp
@@ -39,6 +39,10 @@ namespace kagome::common {
     return hex_lower(data_);
   }
 
+  const std::string_view Buffer::toString() const {
+    return std::string_view(reinterpret_cast<const char*>(data_.data()), data_.size()); // NOLINT
+  }
+
   bool Buffer::empty() const {
     return data_.empty();
   }

--- a/core/common/buffer.hpp
+++ b/core/common/buffer.hpp
@@ -215,6 +215,13 @@ namespace kagome::common {
      */
     static outcome::result<Buffer> fromHex(std::string_view hex);
 
+    /**
+     * @brief return content of bytearray as string
+     * @note Does not ensure correct encoding
+     * @return string
+     */
+     const std::string_view toString() const;
+
    private:
     std::vector<uint8_t> data_;
 

--- a/core/extensions/impl/storage_extension.cpp
+++ b/core/extensions/impl/storage_extension.cpp
@@ -149,14 +149,14 @@ namespace kagome::extensions {
     if (value.toHex().size() < 500) {
       logger_->trace(
           "Set storage. Key: {}, Key hex: {} Value: {}, Value hex {}",
-          key.data(),
+          key.toString(),
           key.toHex(),
-          value.data(),
+          value.toString(),
           value.toHex());
     } else {
       logger_->trace(
           "Set storage. Key: {}, Key hex: {} Value is too big to display",
-          key.data(),
+          key.toString(),
           key.toHex());
     }
 


### PR DESCRIPTION
### Description of the Change

This change adds the `toString` method to `common::Buffer` and fixes a buffer overrun in trace logging.

### Benefits

 - Easily convert buffers to std::string
 - No more confusing log messages with buffer overruns.

### Possible Drawbacks 

None