### PR TITLE
cmake: Install "binaryen_runtime_api" and "binaryen_core_api" module

### DIFF
--- a/cmake/kagomeConfig.cmake.in
+++ b/cmake/kagomeConfig.cmake.in
@@ -61,6 +61,7 @@ set(kagome_LIBRARIES
         kagome::secp256k1_provider
         kagome::bip39_provider
         kagome::extension_factory
+        kagome::binaryen_runtime_api
         kagome::binaryen_runtime_external_interface
         kagome::binaryen_runtime_manager
         kagome::binaryen_runtime_environment

--- a/cmake/kagomeConfig.cmake.in
+++ b/cmake/kagomeConfig.cmake.in
@@ -21,6 +21,7 @@ set(kagome_LIBRARIES
         kagome::hexutil
         kagome::mp_utils
         kagome::blob
+        kagome::primitives
         kagome::database_error
         kagome::trie_error
         kagome::trie_serializer
@@ -35,6 +36,8 @@ set(kagome_LIBRARIES
         kagome::persistent_trie_batch
         kagome::topper_trie_batch
         kagome::changes_tracker
+        kagome::blockchain_common
+        kagome::block_header_repository
         kagome::blake2
         kagome::keccak
         kagome::hasher

--- a/cmake/kagomeConfig.cmake.in
+++ b/cmake/kagomeConfig.cmake.in
@@ -61,6 +61,7 @@ set(kagome_LIBRARIES
         kagome::secp256k1_provider
         kagome::bip39_provider
         kagome::extension_factory
+        kagome::binaryen_core_api
         kagome::binaryen_runtime_api
         kagome::binaryen_runtime_external_interface
         kagome::binaryen_runtime_manager

--- a/core/blockchain/CMakeLists.txt
+++ b/core/blockchain/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(block_header_repository
 target_link_libraries(block_header_repository
     blockchain_common
     )
+kagome_install(block_header_repository)
 
 add_library(block_storage
     impl/key_value_block_storage.cpp

--- a/core/blockchain/impl/CMakeLists.txt
+++ b/core/blockchain/impl/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(blockchain_common
     polkadot_codec
     primitives
     )
+kagome_install(blockchain_common)
 
 add_library(block_tree
     block_tree_impl.cpp

--- a/core/primitives/CMakeLists.txt
+++ b/core/primitives/CMakeLists.txt
@@ -25,3 +25,4 @@ target_link_libraries(primitives
     scale
     blob
     )
+kagome_install(primitives)

--- a/core/runtime/binaryen/CMakeLists.txt
+++ b/core/runtime/binaryen/CMakeLists.txt
@@ -70,6 +70,7 @@ target_link_libraries(binaryen_runtime_api INTERFACE
     binaryen_runtime_external_interface
     binaryen_wasm_module
     )
+kagome_install(binaryen_runtime_api)
 
 add_library(binaryen_core_api
     runtime_api/core_impl.cpp

--- a/core/runtime/binaryen/CMakeLists.txt
+++ b/core/runtime/binaryen/CMakeLists.txt
@@ -80,6 +80,7 @@ target_link_libraries(binaryen_core_api
     binaryen_wasm_executor
     binaryen_runtime_api
     )
+kagome_install(binaryen_core_api)
 
 add_library(binaryen_tagged_transaction_queue_api
     runtime_api/tagged_transaction_queue_impl.cpp


### PR DESCRIPTION
### Description of the Change

Have CMake install `binaryen_runtime_api` and `binaryen_core_api` module.

### Benefits

The `RuntimeApi` and `CoreFactoryImpl` class can be used externally.

### Possible Drawbacks 

None