### PR TITLE
Fix storage_root interface

### DIFF
--- a/core/extensions/extension.hpp
+++ b/core/extensions/extension.hpp
@@ -190,7 +190,7 @@ namespace kagome::extensions {
      * root.
      * @return memory span containing scale-encoded storage root
      */
-    virtual runtime::WasmPointer ext_storage_root_version_1() = 0;
+    virtual runtime::WasmSpan ext_storage_root_version_1() = 0;
 
     /**
      * Commits all existing operations and gets the resulting change
@@ -198,7 +198,7 @@ namespace kagome::extensions {
      * @param parent_hash wasm span containing parent hash
      * @return wasm span containing scale-encoded optional change root
      */
-    virtual runtime::WasmPointer ext_storage_changes_root_version_1(
+    virtual runtime::WasmSpan ext_storage_changes_root_version_1(
         runtime::WasmSpan parent_hash) = 0;
 
     /**

--- a/core/extensions/impl/extension_impl.cpp
+++ b/core/extensions/impl/extension_impl.cpp
@@ -145,11 +145,11 @@ namespace kagome::extensions {
     return storage_ext_.ext_storage_clear_prefix_version_1(prefix);
   }
 
-  runtime::WasmPointer ExtensionImpl::ext_storage_root_version_1() {
+  runtime::WasmSpan ExtensionImpl::ext_storage_root_version_1() {
     return storage_ext_.ext_storage_root_version_1();
   }
 
-  runtime::WasmPointer ExtensionImpl::ext_storage_changes_root_version_1(
+  runtime::WasmSpan ExtensionImpl::ext_storage_changes_root_version_1(
       runtime::WasmSpan parent_hash) {
     return storage_ext_.ext_storage_changes_root_version_1(parent_hash);
   }

--- a/core/extensions/impl/extension_impl.hpp
+++ b/core/extensions/impl/extension_impl.hpp
@@ -96,9 +96,9 @@ namespace kagome::extensions {
 
     void ext_storage_clear_prefix_version_1(runtime::WasmSpan prefix) override;
 
-    runtime::WasmPointer ext_storage_root_version_1() override;
+    runtime::WasmSpan ext_storage_root_version_1() override;
 
-    runtime::WasmPointer ext_storage_changes_root_version_1(
+    runtime::WasmSpan ext_storage_changes_root_version_1(
         runtime::WasmSpan parent_hash) override;
 
     runtime::WasmSpan ext_storage_next_key_version_1(

--- a/test/mock/core/extensions/extension_mock.hpp
+++ b/test/mock/core/extensions/extension_mock.hpp
@@ -151,10 +151,10 @@ namespace kagome::extensions {
 
     MOCK_METHOD1(ext_storage_clear_prefix_version_1, void(runtime::WasmSpan));
 
-    MOCK_METHOD0(ext_storage_root_version_1, runtime::WasmPointer());
+    MOCK_METHOD0(ext_storage_root_version_1, runtime::WasmSpan());
 
     MOCK_METHOD1(ext_storage_changes_root_version_1,
-                 runtime::WasmPointer(runtime::WasmSpan));
+                 runtime::WasmSpan(runtime::WasmSpan));
 
     MOCK_CONST_METHOD1(ext_storage_next_key_version_1,
                        runtime::WasmSpan(runtime::WasmSpan));


### PR DESCRIPTION
### Referenced issues

This is an addition to #505, which failed to also the update the return types of the storage root functions of `Extension` and `ExtensionImpl`.

### Description of the Change

This change updates the storage root functions of `Extension` and `ExtensionImpl` with the correct return type.

### Benefits

Return type according to spec, fixes bug where span is turned into a pointer.

### Possible Drawbacks 

None

### Additional Notes

It would be probably worth to have your CI check compiler warnings, as this probably could have been caught by the compiler on submission.