### PR TITLE
Batching of signature validation in runtime APIs

### DIFF
--- a/core/extensions/extension.hpp
+++ b/core/extensions/extension.hpp
@@ -10,8 +10,8 @@
 #include <functional>
 
 #include "runtime/types.hpp"
-#include "runtime/wasm_result.hpp"
 #include "runtime/wasm_memory.hpp"
+#include "runtime/wasm_result.hpp"
 
 namespace kagome::extensions {
   /**
@@ -324,6 +324,23 @@ namespace kagome::extensions {
     virtual void ext_keccak_256(runtime::WasmPointer data,
                                 runtime::WasmSize len,
                                 runtime::WasmPointer out) = 0;
+
+    /**
+     * @brief Starts the verification extension. The extension is a separate
+     * background process and is used to parallel-verify signatures which are
+     * pushed to the batch with ext_crypto_.._verify
+     */
+    virtual void ext_start_batch_verify() = 0;
+
+    /**
+     * @brief Finish verifying the batch of signatures since the last call to
+     * this function. Blocks until all the signatures are verified.
+     * @throws runtime_error if no verification extension is registered
+     * (ext_crypto_start_batch_verify (E.3.15) tchwas not called.)
+     * @returns an i32 integer value equal to 1 if all the signatures are valid
+     * or a value equal to 0 if one or more of the signatures are invalid.
+     */
+    virtual runtime::WasmSize ext_finish_batch_verify() = 0;
 
     /**
      * Verify the signature over the ed25519 message

--- a/core/extensions/impl/crypto_extension.hpp
+++ b/core/extensions/impl/crypto_extension.hpp
@@ -6,6 +6,10 @@
 #ifndef KAGOME_CRYPTO_EXTENSION_HPP
 #define KAGOME_CRYPTO_EXTENSION_HPP
 
+#include <future>
+#include <optional>
+#include <queue>
+
 #include "common/logger.hpp"
 #include "crypto/bip39/bip39_types.hpp"
 #include "crypto/crypto_store.hpp"
@@ -24,7 +28,7 @@ namespace kagome::extensions {
   /**
    * Implements extension functions related to cryptography
    */
-  class CryptoExtension {
+  class CryptoExtension : std::enable_shared_from_this<CryptoExtension> {
    public:
     CryptoExtension(
         std::shared_ptr<runtime::WasmMemory> memory,
@@ -55,6 +59,16 @@ namespace kagome::extensions {
     void ext_keccak_256(runtime::WasmPointer data,
                         runtime::WasmSize len,
                         runtime::WasmPointer out_ptr);
+
+    /**
+     * @see Extension::ext_start_batch_verify
+     */
+    void ext_start_batch_verify();
+
+    /**
+     * @see Extension::ext_finish_batch_verify
+     */
+    runtime::WasmSize ext_finish_batch_verify();
 
     /**
      * @see Extension::ext_ed25519_verify
@@ -206,6 +220,7 @@ namespace kagome::extensions {
     std::shared_ptr<crypto::Hasher> hasher_;
     std::shared_ptr<crypto::CryptoStore> crypto_store_;
     std::shared_ptr<crypto::Bip39Provider> bip39_provider_;
+    std::optional<std::queue<std::future<runtime::WasmSize>>> batch_verify_;
     common::Logger logger_;
   };
 }  // namespace kagome::extensions

--- a/core/extensions/impl/crypto_extension.hpp
+++ b/core/extensions/impl/crypto_extension.hpp
@@ -28,7 +28,7 @@ namespace kagome::extensions {
   /**
    * Implements extension functions related to cryptography
    */
-  class CryptoExtension : std::enable_shared_from_this<CryptoExtension> {
+  class CryptoExtension : public std::enable_shared_from_this<CryptoExtension> {
    public:
     CryptoExtension(
         std::shared_ptr<runtime::WasmMemory> memory,

--- a/core/extensions/impl/crypto_extension.hpp
+++ b/core/extensions/impl/crypto_extension.hpp
@@ -30,6 +30,13 @@ namespace kagome::extensions {
    */
   class CryptoExtension : public std::enable_shared_from_this<CryptoExtension> {
    public:
+    static constexpr uint32_t kVerifyBatchSuccess = 1;
+    static constexpr uint32_t kVerifyBatchFail = 0;
+    static constexpr uint32_t kSr25519VerifySuccess = 1;
+    static constexpr uint32_t kSr25519VerifyFail = 0;
+    static constexpr uint32_t kEd25519VerifySuccess = 1;
+    static constexpr uint32_t kEd25519VerifyFail = 0;
+
     CryptoExtension(
         std::shared_ptr<runtime::WasmMemory> memory,
         std::shared_ptr<crypto::SR25519Provider> sr25519_provider,

--- a/core/extensions/impl/extension_impl.cpp
+++ b/core/extensions/impl/extension_impl.cpp
@@ -225,6 +225,14 @@ namespace kagome::extensions {
     crypto_ext_.ext_keccak_256(data, len, out);
   }
 
+  void ExtensionImpl::ext_start_batch_verify() {
+    crypto_ext_.ext_start_batch_verify();
+  }
+
+  runtime::WasmSize ExtensionImpl::ext_finish_batch_verify() {
+    return crypto_ext_.ext_finish_batch_verify();
+  }
+
   runtime::WasmSize ExtensionImpl::ext_ed25519_verify(
       runtime::WasmPointer msg_data,
       runtime::WasmSize msg_len,
@@ -369,5 +377,4 @@ namespace kagome::extensions {
     return crypto_ext_.ext_crypto_secp256k1_ecdsa_recover_compressed_v1(sig,
                                                                         msg);
   }
-
 }  // namespace kagome::extensions

--- a/core/extensions/impl/extension_impl.hpp
+++ b/core/extensions/impl/extension_impl.hpp
@@ -147,6 +147,10 @@ namespace kagome::extensions {
                         runtime::WasmSize len,
                         runtime::WasmPointer out) override;
 
+    void ext_start_batch_verify() override;
+
+    runtime::WasmSize ext_finish_batch_verify() override;
+
     runtime::WasmSize ext_ed25519_verify(
         runtime::WasmPointer msg_data,
         runtime::WasmSize msg_len,

--- a/core/runtime/binaryen/runtime_external_interface.cpp
+++ b/core/runtime/binaryen/runtime_external_interface.cpp
@@ -44,8 +44,13 @@ namespace kagome::runtime::binaryen {
   const static wasm::Name ext_blake2_128 = "ext_blake2_128";
   const static wasm::Name ext_blake2_256 = "ext_blake2_256";
   const static wasm::Name ext_keccak_256 = "ext_keccak_256";
+
+  const static wasm::Name ext_start_batch_verify = "ext_start_batch_verify";
+  const static wasm::Name ext_finish_batch_verify = "ext_finish_batch_verify";
+
   const static wasm::Name ext_ed25519_verify = "ext_ed25519_verify";
   const static wasm::Name ext_sr25519_verify = "ext_sr25519_verify";
+
   const static wasm::Name ext_twox_64 = "ext_twox_64";
   const static wasm::Name ext_twox_128 = "ext_twox_128";
   const static wasm::Name ext_twox_256 = "ext_twox_256";
@@ -92,6 +97,11 @@ namespace kagome::runtime::binaryen {
   const static wasm::Name ext_storage_next_key_version_1 =
       "ext_storage_next_key_version_1";
 
+  const static wasm::Name ext_crypto_start_batch_verify_version_1 =
+      "ext_crypto_start_batch_verify_version_1";
+  const static wasm::Name ext_crypto_finish_batch_verify_version_1 =
+      "ext_crypto_finish_batch_verify_version_1";
+
   const static wasm::Name ext_crypto_ed25519_public_keys_version_1 =
       "ext_crypto_ed25519_public_keys_version_1";
   const static wasm::Name ext_crypto_ed25519_generate_version_1 =
@@ -135,7 +145,8 @@ namespace kagome::runtime::binaryen {
                      "storage provider is nullptr");
     auto memory_impl =
         std::make_shared<WasmMemoryImpl>(&(ShellExternalInterface::memory));
-    extension_ = extension_factory->createExtension(memory_impl, std::move(storage_provider));
+    extension_ = extension_factory->createExtension(
+        memory_impl, std::move(storage_provider));
   }
 
   wasm::Literal RuntimeExternalInterface::callImport(
@@ -298,6 +309,20 @@ namespace kagome::runtime::binaryen {
         return wasm::Literal();
       }
 
+      // ext_start_batch_verify
+      if (import->base == ext_start_batch_verify) {
+        checkArguments(import->base.c_str(), 0, arguments.size());
+        extension_->ext_start_batch_verify();
+        return wasm::Literal();
+      }
+
+      // ext_finish_batch_verify
+      if (import->base == ext_start_batch_verify) {
+        checkArguments(import->base.c_str(), 0, arguments.size());
+        auto res = extension_->ext_finish_batch_verify();
+        return wasm::Literal(res);
+      }
+
       /// ext_ed25519_verify
       if (import->base == ext_ed25519_verify) {
         checkArguments(import->base.c_str(), 4, arguments.size());
@@ -351,6 +376,22 @@ namespace kagome::runtime::binaryen {
       // ----------------------- api version 1 ---------------------------
 
       // ----------------------- crypto functions ------------------------
+
+	    // ext_crypto_start_batch_verify_version_1
+	    if (import->base == ext_crypto_start_batch_verify_version_1) {
+		    checkArguments(import->base.c_str(), 0, arguments.size());
+		    extension_->ext_start_batch_verify();
+		    return wasm::Literal();
+	    }
+
+	    // ext_crypto_start_batch_verify_version_1
+	    if (import->base == ext_crypto_start_batch_verify_version_1) {
+		    checkArguments(import->base.c_str(), 0, arguments.size());
+		    auto res = extension_->ext_finish_batch_verify();
+		    return wasm::Literal(res);
+	    }
+
+
       /// ext_crypto_ed25519_public_keys_version_1
       if (import->base == ext_crypto_ed25519_public_keys_version_1) {
         checkArguments(import->base.c_str(), 1, arguments.size());

--- a/test/core/runtime/runtime_external_interface_test.cpp
+++ b/test/core/runtime/runtime_external_interface_test.cpp
@@ -168,6 +168,8 @@ class REITest : public ::testing::Test {
       "  (import \"env\" \"ext_set_storage\" (func $ext_set_storage (type 6)))\n"
       "  (import \"env\" \"ext_clear_prefix\" (func $ext_clear_prefix (type 0)))\n"
       "  (import \"env\" \"ext_exists_storage\" (func $ext_exists_storage (type 3)))\n"
+      "  (import \"env\" \"ext_start_batch_verify\" (func $ext_start_batch_verify (type 11)))\n"
+      "  (import \"env\" \"ext_finish_batch_verify\" (func $ext_finish_batch_verify (type 35)))\n"
       "  (import \"env\" \"ext_sr25519_verify\" (func $ext_sr25519_verify (type 9)))\n"
       "  (import \"env\" \"ext_ed25519_verify\" (func $ext_ed25519_verify (type 9)))\n"
       "  (import \"env\" \"ext_storage_root\" (func $ext_storage_root (type 1)))\n"
@@ -177,6 +179,8 @@ class REITest : public ::testing::Test {
       "  (import \"env\" \"ext_chain_id\" (func $ext_chain_id (type 27)))\n"
 
       /// version 1
+      "  (import \"env\" \"ext_crypto_start_batch_verify\" (func $ext_crypto_start_batch_verify_version_1 (type 11)))\n"
+      "  (import \"env\" \"ext_crypto_finish_batch_verify\" (func $ext_crypto_finish_batch_verify_version_1 (type 35)))\n"
       "  (import \"env\" \"ext_crypto_ed25519_public_keys_version_1\" (func $ext_crypto_ed25519_public_keys_version_1 (type 29)))\n"
       "  (import \"env\" \"ext_crypto_ed25519_generate_version_1\" (func $ext_crypto_ed25519_generate_version_1 (type 30)))\n"
       "  (import \"env\" \"ext_crypto_ed25519_sign_version_1\" (func $ext_crypto_ed25519_sign_version_1 (type 31)))\n"

--- a/test/mock/core/extensions/extension_mock.hpp
+++ b/test/mock/core/extensions/extension_mock.hpp
@@ -93,6 +93,10 @@ namespace kagome::extensions {
                                    runtime::WasmSize msg_len,
                                    runtime::WasmPointer out_ptr));
 
+    MOCK_METHOD0(ext_start_batch_verify, void());
+
+    MOCK_METHOD0(ext_finish_batch_verify, runtime::WasmSize());
+
     MOCK_METHOD4(ext_ed25519_verify,
                  runtime::WasmSize(runtime::WasmPointer msg_data,
                                    runtime::WasmSize msg_len,
@@ -134,7 +138,8 @@ namespace kagome::extensions {
                       runtime::WasmSize len,
                       runtime::WasmPointer out));
     MOCK_CONST_METHOD0(ext_chain_id, uint64_t());
-    MOCK_CONST_METHOD1(ext_misc_runtime_version_version_1, runtime::WasmResult(runtime::WasmSpan));
+    MOCK_CONST_METHOD1(ext_misc_runtime_version_version_1,
+                       runtime::WasmResult(runtime::WasmSpan));
 
     // ------------------------ Storage extensions v1 ------------------------
 


### PR DESCRIPTION
### <!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues
Resolves #516

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
Add methods for start and finish verification batch.
Modify exested verification methods to support batching.
Add unit-test for batching

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
New ability in according to spec

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Nope

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->
Unit-test included

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs <!-- Optional -->
To use full asynchronous validation. Right now it just delay for demand (lazy calculation).

<!-- Explain what other alternates were considered and why the proposed version was selected -->
