### PR TITLE
Suppress useless catch-up-requests flood in GRANDPA

### DIFF
--- a/core/consensus/babe/babe.hpp
+++ b/core/consensus/babe/babe.hpp
@@ -68,6 +68,11 @@ namespace kagome::consensus {
      * @returns current state
      */
     virtual State getCurrentState() const = 0;
+
+    /**
+     * Calls @param handler when Babe will be synchronized
+     */
+    virtual void doOnSynchronized(std::function<void()> handler) = 0;
   };
 }  // namespace kagome::consensus
 

--- a/core/consensus/babe/impl/babe_impl.cpp
+++ b/core/consensus/babe/impl/babe_impl.cpp
@@ -219,11 +219,10 @@ namespace kagome::consensus {
   }
 
   void BabeImpl::doOnSynchronized(std::function<void()> handler) {
-    on_synchronized_ = std::move(handler);
     if (current_state_ == State::SYNCHRONIZED) {
-      if (auto on_synchronized = std::move(on_synchronized_)) {
-        on_synchronized();
-      }
+      handler();
+    } else {
+      on_synchronized_ = std::move(handler);
     }
   }
 

--- a/core/consensus/babe/impl/babe_impl.hpp
+++ b/core/consensus/babe/impl/babe_impl.hpp
@@ -82,6 +82,8 @@ namespace kagome::consensus {
 
     void onBlockAnnounce(const network::BlockAnnounce &announce) override;
 
+    void doOnSynchronized(std::function<void()> handler) override;
+
    private:
     /**
      * Run the next Babe slot
@@ -151,6 +153,8 @@ namespace kagome::consensus {
     BabeTimePoint next_slot_finish_time_;
 
     boost::optional<ExecutionStrategy> execution_strategy_;
+
+    std::function<void()> on_synchronized_;
 
     common::Logger log_;
   };

--- a/core/consensus/babe/impl/syncing_babe.hpp
+++ b/core/consensus/babe/impl/syncing_babe.hpp
@@ -32,6 +32,8 @@ namespace kagome::consensus {
 
     void onBlockAnnounce(const network::BlockAnnounce &announce) override;
 
+    void doOnSynchronized(std::function<void()> handler) override{};
+
    private:
     std::shared_ptr<consensus::BlockExecutor> block_executor_;
   };

--- a/core/consensus/grandpa/impl/grandpa_impl.cpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.cpp
@@ -99,7 +99,7 @@ namespace kagome::consensus::grandpa {
         boost::asio::post(*self->io_context_, [wp] {
           if (auto self = wp.lock()) {
             self->executeNextRound();
-            self->isReady_ = true;
+            self->is_ready_ = true;
           }
         });
       }
@@ -276,7 +276,7 @@ namespace kagome::consensus::grandpa {
 
   void GrandpaImpl::onCatchUpRequest(const libp2p::peer::PeerId &peer_id,
                                      const network::CatchUpRequest &msg) {
-    if (not isReady_) {
+    if (not is_ready_) {
       return;
     }
     if (previous_round_ == nullptr) {
@@ -338,7 +338,7 @@ namespace kagome::consensus::grandpa {
 
   void GrandpaImpl::onCatchUpResponse(const libp2p::peer::PeerId &peer_id,
                                       const network::CatchUpResponse &msg) {
-    if (not isReady_) {
+    if (not is_ready_) {
       return;
     }
     BOOST_ASSERT(current_round_ != nullptr);
@@ -416,7 +416,7 @@ namespace kagome::consensus::grandpa {
 
   void GrandpaImpl::onVoteMessage(const libp2p::peer::PeerId &peer_id,
                                   const VoteMessage &msg) {
-    if (not isReady_) {
+    if (not is_ready_) {
       return;
     }
 
@@ -473,7 +473,7 @@ namespace kagome::consensus::grandpa {
 
   void GrandpaImpl::onFinalize(const libp2p::peer::PeerId &peer_id,
                                const Fin &fin) {
-    if (not isReady_) {
+    if (not is_ready_) {
       return;
     }
 

--- a/core/consensus/grandpa/impl/grandpa_impl.cpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.cpp
@@ -26,7 +26,8 @@ namespace kagome::consensus::grandpa {
       const crypto::ED25519Keypair &keypair,
       std::shared_ptr<Clock> clock,
       std::shared_ptr<boost::asio::io_context> io_context,
-      std::shared_ptr<authority::AuthorityManager> authority_manager)
+      std::shared_ptr<authority::AuthorityManager> authority_manager,
+      std::shared_ptr<consensus::Babe> babe)
       : app_state_manager_(std::move(app_state_manager)),
         environment_{std::move(environment)},
         storage_{std::move(storage)},
@@ -35,7 +36,8 @@ namespace kagome::consensus::grandpa {
         keypair_{keypair},
         clock_{std::move(clock)},
         io_context_{std::move(io_context)},
-        authority_manager_(std::move(authority_manager)) {
+        authority_manager_(std::move(authority_manager)),
+        babe_(babe) {
     BOOST_ASSERT(app_state_manager_ != nullptr);
     BOOST_ASSERT(environment_ != nullptr);
     BOOST_ASSERT(storage_ != nullptr);
@@ -44,6 +46,7 @@ namespace kagome::consensus::grandpa {
     BOOST_ASSERT(clock_ != nullptr);
     BOOST_ASSERT(io_context_ != nullptr);
     BOOST_ASSERT(authority_manager_ != nullptr);
+    BOOST_ASSERT(babe_ != nullptr);
 
     app_state_manager_->takeControl(*this);
   }
@@ -88,10 +91,16 @@ namespace kagome::consensus::grandpa {
     BOOST_ASSERT(current_round_->finalizable());
     BOOST_ASSERT(current_round_->finalizedBlock() == round_state.finalized);
 
-    // Planning play next round
-    boost::asio::post(*io_context_, [wp = weak_from_this()] {
+    // Lambda which is executed when voting round is completed.
+    babe_->doOnSynchronized([wp = weak_from_this()] {
       if (auto self = wp.lock()) {
-        self->executeNextRound();
+        // Planning play next round
+        boost::asio::post(*self->io_context_, [wp] {
+          if (auto self = wp.lock()) {
+            self->executeNextRound();
+            self->isReady_ = true;
+          }
+        });
       }
     });
 
@@ -266,6 +275,9 @@ namespace kagome::consensus::grandpa {
 
   void GrandpaImpl::onCatchUpRequest(const libp2p::peer::PeerId &peer_id,
                                      const network::CatchUpRequest &msg) {
+    if (not isReady_) {
+      return;
+    }
     if (previous_round_ == nullptr) {
       logger_->debug(
           "Catch-up request (since round #{}) received from {} was rejected: "
@@ -321,6 +333,9 @@ namespace kagome::consensus::grandpa {
 
   void GrandpaImpl::onCatchUpResponse(const libp2p::peer::PeerId &peer_id,
                                       const network::CatchUpResponse &msg) {
+    if (not isReady_) {
+      return;
+    }
     BOOST_ASSERT(current_round_ != nullptr);
     if (current_round_->roundNumber() >= msg.round_number) {
       // Catching up in to the past
@@ -394,6 +409,10 @@ namespace kagome::consensus::grandpa {
 
   void GrandpaImpl::onVoteMessage(const libp2p::peer::PeerId &peer_id,
                                   const VoteMessage &msg) {
+    if (not isReady_) {
+      return;
+    }
+
     std::shared_ptr<VotingRound> target_round = selectRound(msg.round_number);
     if (not target_round) {
       if (current_round_->roundNumber() + 2 <= msg.round_number) {
@@ -443,6 +462,10 @@ namespace kagome::consensus::grandpa {
 
   void GrandpaImpl::onFinalize(const libp2p::peer::PeerId &peer_id,
                                const Fin &fin) {
+    if (not isReady_) {
+      return;
+    }
+
     std::shared_ptr<VotingRound> target_round = selectRound(fin.round_number);
     if (not target_round) {
       if (current_round_->roundNumber() < fin.round_number) {

--- a/core/consensus/grandpa/impl/grandpa_impl.hpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.hpp
@@ -103,7 +103,7 @@ namespace kagome::consensus::grandpa {
     std::shared_ptr<boost::asio::io_context> io_context_;
     std::shared_ptr<authority::AuthorityManager> authority_manager_;
 
-    bool isReady_ = false;
+    bool is_ready_ = false;
     std::shared_ptr<consensus::Babe> babe_;
 
     const Clock::Duration catch_up_request_suppression_duration_ =

--- a/core/consensus/grandpa/impl/grandpa_impl.hpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.hpp
@@ -106,6 +106,10 @@ namespace kagome::consensus::grandpa {
     bool isReady_ = false;
     std::shared_ptr<consensus::Babe> babe_;
 
+    const Clock::Duration catch_up_request_suppression_duration_ =
+        std::chrono::seconds(15);
+    Clock::TimePoint catch_up_request_suppressed_until_;
+
     common::Logger logger_ = common::createLogger("Grandpa");
   };
 

--- a/core/consensus/grandpa/impl/grandpa_impl.hpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.hpp
@@ -13,6 +13,7 @@
 #include "blockchain/block_tree.hpp"
 #include "common/logger.hpp"
 #include "consensus/authority/authority_manager.hpp"
+#include "consensus/babe/babe.hpp"
 #include "consensus/grandpa/environment.hpp"
 #include "consensus/grandpa/impl/voting_round_impl.hpp"
 #include "consensus/grandpa/movable_round_state.hpp"
@@ -39,7 +40,8 @@ namespace kagome::consensus::grandpa {
                 const crypto::ED25519Keypair &keypair,
                 std::shared_ptr<Clock> clock,
                 std::shared_ptr<boost::asio::io_context> io_context,
-                std::shared_ptr<authority::AuthorityManager> authority_manager);
+                std::shared_ptr<authority::AuthorityManager> authority_manager,
+                std::shared_ptr<consensus::Babe> babe);
 
     /** @see AppStateManager::takeControl */
     bool prepare();
@@ -100,6 +102,9 @@ namespace kagome::consensus::grandpa {
     std::shared_ptr<Clock> clock_;
     std::shared_ptr<boost::asio::io_context> io_context_;
     std::shared_ptr<authority::AuthorityManager> authority_manager_;
+
+    bool isReady_ = false;
+    std::shared_ptr<consensus::Babe> babe_;
 
     common::Logger logger_ = common::createLogger("Grandpa");
   };

--- a/core/injector/application_injector.hpp
+++ b/core/injector/application_injector.hpp
@@ -509,7 +509,7 @@ namespace kagome::injector {
       if (peer_info.id != current_peer_info.id) {
         res->clients.emplace_back(
             std::make_shared<network::RemoteSyncProtocolClient>(
-                *host, std::move(peer_info), std::move(configuration_storage)));
+                *host, std::move(peer_info), configuration_storage));
       } else {
         res->clients.emplace_back(
             std::make_shared<network::DummySyncProtocolClient>());


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues
Resolves #528 

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
Postpone GRANDPA start until BABE will be synchronized.
Suppress catch-up-requests for duration or until next response.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Network will not be flooded by unsynchronized nodes.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Perhaps some delay of grandpa synchronisation

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->
Needless

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs <!-- Optional -->
None

<!-- Explain what other alternates were considered and why the proposed version was selected -->
