### PR TITLE
Fix executing latest genesis from substrate

### DIFF
--- a/core/extensions/impl/storage_extension.cpp
+++ b/core/extensions/impl/storage_extension.cpp
@@ -368,10 +368,13 @@ namespace kagome::extensions {
     std::copy_n(parent_hash_bytes.begin(),
                 common::Hash256::size(),
                 parent_hash.begin());
-    if (auto result = calcStorageChangesRoot(parent_hash); result.has_value()) {
-      return memory_->storeBuffer(result.value());
-    }
-    return 0;
+
+    auto &&result = calcStorageChangesRoot(parent_hash);
+    auto &&res = result.has_value()
+                     ? boost::make_optional(std::move(result.value()))
+                     : boost::none;
+    return memory_->storeBuffer(
+        common::Buffer{scale::encode(std::move(res)).value()});
   }
 
   runtime::WasmSpan StorageExtension::ext_storage_next_key_version_1(

--- a/core/extensions/impl/storage_extension.cpp
+++ b/core/extensions/impl/storage_extension.cpp
@@ -373,8 +373,7 @@ namespace kagome::extensions {
     auto &&res = result.has_value()
                      ? boost::make_optional(std::move(result.value()))
                      : boost::none;
-    return memory_->storeBuffer(
-        common::Buffer{scale::encode(std::move(res)).value()});
+    return memory_->storeBuffer(scale::encode(std::move(res)).value());
   }
 
   runtime::WasmSpan StorageExtension::ext_storage_next_key_version_1(

--- a/core/runtime/binaryen/wasm_memory_impl.cpp
+++ b/core/runtime/binaryen/wasm_memory_impl.cpp
@@ -44,7 +44,7 @@ namespace kagome::runtime::binaryen {
       return 0;
     }
     const auto ptr = offset_;
-    const auto new_offset = roundUp<4>(ptr + size);  // allign
+    const auto new_offset = roundUp<4>(ptr + size);  // align
 
     BOOST_ASSERT(allocated_.find(ptr) == allocated_.end());
     if (new_offset < static_cast<const uint32_t>(ptr)) {  // overflow

--- a/core/runtime/binaryen/wasm_memory_impl.cpp
+++ b/core/runtime/binaryen/wasm_memory_impl.cpp
@@ -39,12 +39,20 @@ namespace kagome::runtime::binaryen {
     }
   }
 
+  /**
+   * Obtain closest multiple of 4 that is greater or equal to given number
+   */
+  template <typename T>
+  T roundUp4(T num_to_round) {
+      return ((num_to_round + 3) & (-4));
+  }
+
   WasmPointer WasmMemoryImpl::allocate(WasmSize size) {
     if (size == 0) {
       return 0;
     }
     const auto ptr = offset_;
-    const auto new_offset = ptr + size;
+    const auto new_offset = roundUp4(ptr + size);  // allign
 
     BOOST_ASSERT(allocated_.find(ptr) == allocated_.end());
     if (new_offset < static_cast<const uint32_t>(ptr)) {  // overflow

--- a/core/runtime/binaryen/wasm_memory_impl.cpp
+++ b/core/runtime/binaryen/wasm_memory_impl.cpp
@@ -39,20 +39,12 @@ namespace kagome::runtime::binaryen {
     }
   }
 
-  /**
-   * Obtain closest multiple of 4 that is greater or equal to given number
-   */
-  template <typename T>
-  T roundUp4(T num_to_round) {
-      return ((num_to_round + 3) & (-4));
-  }
-
   WasmPointer WasmMemoryImpl::allocate(WasmSize size) {
     if (size == 0) {
       return 0;
     }
     const auto ptr = offset_;
-    const auto new_offset = roundUp4(ptr + size);  // allign
+    const auto new_offset = roundUp<4>(ptr + size);  // allign
 
     BOOST_ASSERT(allocated_.find(ptr) == allocated_.end());
     if (new_offset < static_cast<const uint32_t>(ptr)) {  // overflow

--- a/core/runtime/binaryen/wasm_memory_impl.hpp
+++ b/core/runtime/binaryen/wasm_memory_impl.hpp
@@ -129,6 +129,7 @@ namespace kagome::runtime::binaryen {
   template <size_t X, typename T>
   inline T roundUp(T t) {
     static_assert((X & (X - 1)) == 0, "Must be POW 2!");
+    static_assert(X != 0, "Must not be 0!");
     return (t + (X - 1)) & ~(X - 1);
   }
 

--- a/core/runtime/binaryen/wasm_memory_impl.hpp
+++ b/core/runtime/binaryen/wasm_memory_impl.hpp
@@ -58,7 +58,7 @@ namespace kagome::runtime::binaryen {
     common::Buffer loadN(kagome::runtime::WasmPointer addr,
                          kagome::runtime::WasmSize n) const override;
     std::string loadStr(kagome::runtime::WasmPointer addr,
-                         kagome::runtime::WasmSize n) const override;
+                        kagome::runtime::WasmSize n) const override;
 
     void store8(WasmPointer addr, int8_t value) override;
     void store16(WasmPointer addr, int16_t value) override;
@@ -118,6 +118,19 @@ namespace kagome::runtime::binaryen {
 
     void resizeInternal(WasmSize newSize);
   };
+
+  /**
+     * Obtain closest multiple of X that is greater or equal to given number
+     * @tparam X multiple that is POW of 2
+     * @tparam T type of number
+     * @param t given number
+     * @return closest multiple
+     */
+  template <size_t X, typename T>
+  inline T roundUp(T t) {
+    static_assert((X & (X - 1)) == 0, "Must be POW 2!");
+    return (t + (X - 1)) & ~(X - 1);
+  }
 
 }  // namespace kagome::runtime::binaryen
 

--- a/test/core/runtime/wasm_memory_test.cpp
+++ b/test/core/runtime/wasm_memory_test.cpp
@@ -156,7 +156,7 @@ TEST_F(MemoryHeapTest, AllocateTooBigMemoryAfterDeallocate) {
   // memory
   auto ptr3 = memory_.allocate(size1 + 1);
 
-  // memory is allocated on mem offset (alligned by 4)
+  // memory is allocated on mem offset (aligned by 4)
   ASSERT_EQ(ptr3, kagome::runtime::binaryen::roundUp<4>(mem_offset));
 }
 

--- a/test/core/runtime/wasm_memory_test.cpp
+++ b/test/core/runtime/wasm_memory_test.cpp
@@ -72,8 +72,8 @@ TEST_F(MemoryHeapTest, ReturnOffsetWhenAllocated) {
 
   // allocated second memory chunk
   auto ptr2 = memory_.allocate(size2);
-  // second memory chunk is placed right after the first one
-  ASSERT_EQ(ptr2, size1 + ptr1);
+  // second memory chunk is placed right after the first one (alligned by 4)
+  ASSERT_EQ(ptr2, kagome::runtime::binaryen::roundUp<4>(size1 + ptr1));
 }
 
 /**
@@ -116,7 +116,7 @@ TEST_F(MemoryHeapTest, DeallocateNonexistingMemoryChunk) {
 TEST_F(MemoryHeapTest, AllocateAfterDeallocate) {
   // two memory sizes totalling to the total memory size
   const size_t size1 = 2045;
-  const size_t size2 = 2049;
+  const size_t size2 = 2047;
 
   // allocate two memory chunks with total size equal to the memory size
   auto ptr1 = memory_.allocate(size1);
@@ -156,8 +156,8 @@ TEST_F(MemoryHeapTest, AllocateTooBigMemoryAfterDeallocate) {
   // memory
   auto ptr3 = memory_.allocate(size1 + 1);
 
-  // memory is allocated on mem offset
-  ASSERT_EQ(ptr3, mem_offset);
+  // memory is allocated on mem offset (alligned by 4)
+  ASSERT_EQ(ptr3, kagome::runtime::binaryen::roundUp<4>(mem_offset));
 }
 
 /**


### PR DESCRIPTION
Signed-off-by: kamilsa <kamilsa16@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

Fixes #514 
### Description of the Change

Before Kagome was failing when executed together with genesis containing the latest runtime generated using latest substrate.

Turns out we need WasmMemory to allign all pointers. This PR fixes that.

Also it was noticed that ext_storage_changes_root's return value should be wrapped by optional

### Benefits

Kagome can execute using new runtime

### Possible Drawbacks 

None
### Usage Examples or Tests <!-- Optional -->

```
cd examples/sub2
kagome_validating --genesis mychain.json --keystore localkeystore.json -l sub_ldb1 --p2p_port 30333 --rpc_http_port 9933 --rpc_ws_port 9944 -f -s -v 2
```

