### PR TITLE
Return changes trie, now it's opitonal

### DIFF
--- a/core/api/service/base_request.hpp
+++ b/core/api/service/base_request.hpp
@@ -83,11 +83,16 @@ namespace kagome::api::details {
       if (not src.IsInteger32() and not src.IsInteger64()) {
         throw jsonrpc::InvalidParametersFault("invalid argument type");
       }
-
       auto num = src.AsInteger64();
-      if (num < std::numeric_limits<T>::min()
-          or num > std::numeric_limits<T>::max()) {
-        throw jsonrpc::InvalidParametersFault("invalid argument value");
+      if constexpr (std::is_signed_v<T>) {
+        if (num < std::numeric_limits<T>::min()
+            or num > std::numeric_limits<T>::max()) {
+          throw jsonrpc::InvalidParametersFault("invalid argument value");
+        }
+      } else {
+        if (num < 0 or static_cast<T>(num) > std::numeric_limits<T>::max()) {
+          throw jsonrpc::InvalidParametersFault("invalid argument value");
+        }
       }
       dst = num;
     }

--- a/core/api/service/base_request.hpp
+++ b/core/api/service/base_request.hpp
@@ -90,7 +90,7 @@ namespace kagome::api::details {
           throw jsonrpc::InvalidParametersFault("invalid argument value");
         }
       } else {
-        if (num < 0 or static_cast<T>(num) > std::numeric_limits<T>::max()) {
+        if (num < 0 or static_cast<uint64_t>(num) > std::numeric_limits<T>::max()) {
           throw jsonrpc::InvalidParametersFault("invalid argument value");
         }
       }

--- a/core/consensus/babe/impl/block_executor.cpp
+++ b/core/consensus/babe/impl/block_executor.cpp
@@ -260,7 +260,9 @@ namespace kagome::consensus {
     // add block header if it does not exist
     OUTCOME_TRY(block_tree_->addBlock(block));
 
-    if (b.justification) block_tree_->finalize(block_hash, *b.justification);
+    if (b.justification) {
+      OUTCOME_TRY(block_tree_->finalize(block_hash, *b.justification));
+    }
 
     // observe possible changes of authorities
     for (auto &digest_item : block_without_seal_digest.header.digest) {

--- a/core/storage/trie/impl/ephemeral_trie_batch_impl.cpp
+++ b/core/storage/trie/impl/ephemeral_trie_batch_impl.cpp
@@ -34,7 +34,7 @@ namespace kagome::storage::trie {
 
   outcome::result<void> EphemeralTrieBatchImpl::clearPrefix(
       const Buffer &prefix) {
-    return trie_->clearPrefix(prefix, [](const auto &, auto &&) {});
+    return trie_->clearPrefix(prefix, [](const auto &, auto &&) { return outcome::success(); });
   }
 
   outcome::result<void> EphemeralTrieBatchImpl::put(const Buffer &key,

--- a/core/storage/trie/impl/persistent_trie_batch_impl.cpp
+++ b/core/storage/trie/impl/persistent_trie_batch_impl.cpp
@@ -117,7 +117,9 @@ namespace kagome::storage::trie {
       const Buffer &prefix) {
     if (changes_.has_value()) changes_.value()->onClearPrefix(prefix);
     return trie_->clearPrefix(prefix, [&](const auto &key, auto &&) {
-      if (changes_.has_value()) changes_.value()->onRemove(key);
+      if (changes_.has_value()) {
+        OUTCOME_TRY(changes_.value()->onRemove(key));
+      }
     });
   }
 

--- a/core/storage/trie/impl/persistent_trie_batch_impl.cpp
+++ b/core/storage/trie/impl/persistent_trie_batch_impl.cpp
@@ -116,11 +116,13 @@ namespace kagome::storage::trie {
   outcome::result<void> PersistentTrieBatchImpl::clearPrefix(
       const Buffer &prefix) {
     if (changes_.has_value()) changes_.value()->onClearPrefix(prefix);
-    return trie_->clearPrefix(prefix, [&](const auto &key, auto &&) {
-      if (changes_.has_value()) {
-        OUTCOME_TRY(changes_.value()->onRemove(key));
-      }
-    });
+    return trie_->clearPrefix(
+        prefix, [&](const auto &key, auto &&) -> outcome::result<void> {
+          if (changes_.has_value()) {
+            OUTCOME_TRY(changes_.value()->onRemove(key));
+          }
+          return outcome::success();
+        });
   }
 
   outcome::result<void> PersistentTrieBatchImpl::put(const Buffer &key,

--- a/core/storage/trie/polkadot_trie/polkadot_trie.hpp
+++ b/core/storage/trie/polkadot_trie/polkadot_trie.hpp
@@ -26,7 +26,7 @@ namespace kagome::storage::trie {
      * This callback is called when a node is detached from a trie. It is called
      * for each leaf from the detached node subtree
      */
-    using OnDetachCallback = std::function<void(
+    using OnDetachCallback = std::function<outcome::result<void>(
         const common::Buffer &key, boost::optional<common::Buffer> &&value)>;
 
     /**

--- a/core/storage/trie/polkadot_trie/polkadot_trie_impl.cpp
+++ b/core/storage/trie/polkadot_trie/polkadot_trie_impl.cpp
@@ -427,6 +427,7 @@ namespace kagome::storage::trie {
       auto key = PolkadotCodec::nibblesToKey(node->key_nibbles);
       OUTCOME_TRY(callback(key, std::move(node->value)));
     }
+    return outcome::success();
   }
 
   outcome::result<PolkadotTrie::NodePtr> PolkadotTrieImpl::retrieveChild(

--- a/core/storage/trie/polkadot_trie/polkadot_trie_impl.cpp
+++ b/core/storage/trie/polkadot_trie/polkadot_trie_impl.cpp
@@ -408,22 +408,24 @@ namespace kagome::storage::trie {
       auto to_detach = branch->children.at(prefix_nibbles[length]);
       branch->children.at(prefix_nibbles[length]) = n;
 
-      notifyIsDetached(to_detach, callback);
+      OUTCOME_TRY(notifyIsDetached(to_detach, callback));
       return branch;
     }
     return parent;
   }
 
-  void PolkadotTrieImpl::notifyIsDetached(const PolkadotTrie::NodePtr &node,
+  outcome::result<void> PolkadotTrieImpl::notifyIsDetached(const PolkadotTrie::NodePtr &node,
                                           const OnDetachCallback &callback) {
     if (node) {
       if (node->isBranch()) {
         auto branch = std::dynamic_pointer_cast<BranchNode>(node);
-        for (auto &child : branch->children) notifyIsDetached(child, callback);
+        for (auto &child : branch->children) {
+          OUTCOME_TRY(notifyIsDetached(child, callback));
+        }
       }
 
       auto key = PolkadotCodec::nibblesToKey(node->key_nibbles);
-      callback(key, std::move(node->value));
+      OUTCOME_TRY(callback(key, std::move(node->value)));
     }
   }
 

--- a/core/storage/trie/polkadot_trie/polkadot_trie_impl.hpp
+++ b/core/storage/trie/polkadot_trie/polkadot_trie_impl.hpp
@@ -73,8 +73,8 @@ namespace kagome::storage::trie {
     bool empty() const override;
 
    private:
-    void notifyIsDetached(const NodePtr &parent,
-                          const OnDetachCallback &callback);
+    outcome::result<void> notifyIsDetached(const NodePtr &parent,
+                                           const OnDetachCallback &callback);
 
     outcome::result<NodePtr> insert(const NodePtr &parent,
                                     const KeyNibbles &key_nibbles,

--- a/test/core/extensions/storage_extension_test.cpp
+++ b/test/core/extensions/storage_extension_test.cpp
@@ -790,7 +790,7 @@ TEST_F(StorageExtensionTest, Blake2_256_TrieRootV1) {
 TEST_F(StorageExtensionTest, ChangesRootEmpty) {
   auto parent_hash = "123456"_hash256;
   Buffer parent_hash_buf{gsl::span(parent_hash.data(), parent_hash.size())};
-  WasmResult parent_root_ptr{.address = 1, .length = Hash256::size()};
+  WasmResult parent_root_ptr{1, Hash256::size()};
   EXPECT_CALL(*memory_, loadN(parent_root_ptr.address, Hash256::size()))
       .WillOnce(Return(parent_hash_buf));
 
@@ -821,7 +821,7 @@ MATCHER_P(configsAreEqual, n, "") {
 TEST_F(StorageExtensionTest, ChangesRootNotEmpty) {
   auto parent_hash = "123456"_hash256;
   Buffer parent_hash_buf{gsl::span(parent_hash.data(), parent_hash.size())};
-  WasmResult parent_root_ptr{.address = 1, .length = Hash256::size()};
+  WasmResult parent_root_ptr{1, Hash256::size()};
   EXPECT_CALL(*memory_, loadN(parent_root_ptr.address, Hash256::size()))
       .WillOnce(Return(parent_hash_buf));
 

--- a/test/core/storage/trie/polkadot_trie/polkadot_trie_test.cpp
+++ b/test/core/storage/trie/polkadot_trie/polkadot_trie_test.cpp
@@ -309,20 +309,20 @@ TEST_F(TrieTest, ClearPrefix) {
   for (auto &entry : data) {
     EXPECT_OUTCOME_TRUE_1(trie->put(entry.first, entry.second));
   }
-  EXPECT_OUTCOME_TRUE_1(
-      trie->clearPrefix("bar"_buf, [](const auto &, auto &&) {}));
+  EXPECT_OUTCOME_TRUE_1(trie->clearPrefix(
+      "bar"_buf, [](const auto &, auto &&) { return outcome::success(); }));
   ASSERT_TRUE(trie->contains("bat"_buf));
   ASSERT_TRUE(trie->contains("batch"_buf));
   ASSERT_FALSE(trie->contains("bark"_buf));
   ASSERT_FALSE(trie->contains("barnacle"_buf));
 
-  EXPECT_OUTCOME_TRUE_1(
-      trie->clearPrefix("batc"_buf, [](const auto &, auto &&) {}));
+  EXPECT_OUTCOME_TRUE_1(trie->clearPrefix(
+      "batc"_buf, [](const auto &, auto &&) { return outcome::success(); }));
   ASSERT_TRUE(trie->contains("bat"_buf));
   ASSERT_FALSE(trie->contains("batch"_buf));
 
-  EXPECT_OUTCOME_TRUE_1(
-      trie->clearPrefix("b"_buf, [](const auto &, auto &&) {}));
+  EXPECT_OUTCOME_TRUE_1(trie->clearPrefix(
+      "b"_buf, [](const auto &, auto &&) { return outcome::success(); }));
   ASSERT_FALSE(trie->contains("bat"_buf));
   ASSERT_TRUE(trie->empty());
 }


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues
fixes #617
<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
Changes trie is not used in Polkadot currently, but may be in the future. The proposed way to detect if the changes trie is enabled is to read its config from the storage, and if it's empty, then completely disable the changes trie.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Optional presence of changes trie controlled by :changes_trie key in the storage.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
This behaviour is not well specced AFAIK.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->
Provided in the code.
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs <!-- Optional -->
* Just disable it for now
* Control with a field in the chain spec
<!-- Explain what other alternates were considered and why the proposed version was selected -->
