### PR TITLE
extension: implement print hex and num

### DIFF
--- a/core/extensions/extension.hpp
+++ b/core/extensions/extension.hpp
@@ -538,10 +538,26 @@ namespace kagome::extensions {
     virtual runtime::WasmResult ext_misc_runtime_version_version_1(
         runtime::WasmSpan data) const = 0;
 
-    virtual void ext_misc_print_utf8_version_1(
+    /**
+     * Print a hex value
+     * @param data pointer-size to an array of bytes with hex
+     */
+    virtual void ext_misc_print_hex_version_1(
         runtime::WasmSpan data) const = 0;
 
-    virtual void ext_misc_print_num_version_1(uint64_t value) const = 0;
+    /**
+     * Print a number
+     * @param value - number to be printed
+     */
+    virtual void ext_misc_print_num_version_1(
+        uint64_t value) const = 0;
+
+    /**
+     * Print a UTF-8-encoded string
+     * @param data pointer-size to an array of bytes with UTF-8
+     */
+    virtual void ext_misc_print_utf8_version_1(
+        runtime::WasmSpan data) const = 0;
 
   };
 }  // namespace kagome::extensions

--- a/core/extensions/impl/extension_impl.cpp
+++ b/core/extensions/impl/extension_impl.cpp
@@ -390,13 +390,19 @@ namespace kagome::extensions {
     return misc_ext_.ext_misc_runtime_version_version_1(data);
   }
 
+  void ExtensionImpl::ext_misc_print_hex_version_1(
+      runtime::WasmSpan data) const {
+    return misc_ext_.ext_misc_print_hex_version_1(data);
+  }
+
+  void ExtensionImpl::ext_misc_print_num_version_1(
+      uint64_t value) const {
+    return misc_ext_.ext_misc_print_num_version_1(value);
+  }
+
   void ExtensionImpl::ext_misc_print_utf8_version_1(
       runtime::WasmSpan data) const {
     return misc_ext_.ext_misc_print_utf8_version_1(data);
-  }
-
-  void ExtensionImpl::ext_misc_print_num_version_1(uint64_t value) const {
-    return misc_ext_.ext_misc_print_num_version_1(value);
   }
 
   runtime::WasmSpan ExtensionImpl::ext_crypto_secp256k1_ecdsa_recover_v1(

--- a/core/extensions/impl/extension_impl.hpp
+++ b/core/extensions/impl/extension_impl.hpp
@@ -247,9 +247,11 @@ namespace kagome::extensions {
     runtime::WasmResult ext_misc_runtime_version_version_1(
         runtime::WasmSpan data) const override;
 
-    void ext_misc_print_utf8_version_1(runtime::WasmSpan data) const override;
+    void ext_misc_print_hex_version_1(runtime::WasmSpan data) const override;
 
     void ext_misc_print_num_version_1(uint64_t value) const override;
+
+    void ext_misc_print_utf8_version_1(runtime::WasmSpan data) const override;
 
     runtime::WasmSpan ext_crypto_secp256k1_ecdsa_recover_v1(
         runtime::WasmPointer sig, runtime::WasmPointer msg) override;

--- a/core/extensions/impl/misc_extension.cpp
+++ b/core/extensions/impl/misc_extension.cpp
@@ -57,15 +57,23 @@ namespace kagome::extensions {
     return runtime::WasmResult{memory_->storeBuffer(error_res)};
   }
 
+  void MiscExtension::ext_misc_print_hex_version_1(
+      runtime::WasmSpan data) const {
+    auto [ptr, len] = runtime::splitSpan(data);
+    auto buf = memory_->loadN(ptr, len);
+    logger_->info("hex: {}", buf.toHex());
+  }
+
+  void MiscExtension::ext_misc_print_num_version_1(
+      uint64_t value) const {
+    logger_->info("num: {}", value);
+  }
+
   void MiscExtension::ext_misc_print_utf8_version_1(
       runtime::WasmSpan data) const {
     auto [ptr, len] = runtime::splitSpan(data);
     auto buf = memory_->loadN(ptr, len);
-    logger_->info("{}", buf.toString());
-  }
-
-  void MiscExtension::ext_misc_print_num_version_1(uint64_t value) const {
-    logger_->info("{}", value);
+    logger_->info("utf8: {}", buf.toString());
   }
 
 }  // namespace kagome::extensions

--- a/core/extensions/impl/misc_extension.hpp
+++ b/core/extensions/impl/misc_extension.hpp
@@ -46,9 +46,11 @@ namespace kagome::extensions {
     runtime::WasmResult ext_misc_runtime_version_version_1(
         runtime::WasmSpan data) const;
 
-    void ext_misc_print_utf8_version_1(runtime::WasmSpan data) const;
+    void ext_misc_print_hex_version_1(runtime::WasmSpan data) const;
 
     void ext_misc_print_num_version_1(uint64_t value) const;
+
+    void ext_misc_print_utf8_version_1(runtime::WasmSpan data) const;
 
    private:
     CoreFactoryMethod core_factory_method_;

--- a/core/runtime/binaryen/runtime_external_interface.cpp
+++ b/core/runtime/binaryen/runtime_external_interface.cpp
@@ -57,9 +57,9 @@ namespace kagome::runtime::binaryen {
 
   const static wasm::Name ext_chain_id = "ext_chain_id";
 
-  const static wasm::Name ext_misc_print_utf8_version_1 =
-      "ext_misc_print_utf8_version_1";
+  const static wasm::Name ext_misc_print_hex_version_1 = "ext_misc_print_hex_version_1";
   const static wasm::Name ext_misc_print_num_version_1 = "ext_misc_print_num_version_1";
+  const static wasm::Name ext_misc_print_utf8_version_1 = "ext_misc_print_utf8_version_1";
 
   // version 1
   const static wasm::Name ext_hashing_keccak_256_version_1 =
@@ -673,6 +673,21 @@ namespace kagome::runtime::binaryen {
         return wasm::Literal(res);
       }
 
+      /// ext_misc_print_hex_version_1
+      if (import->base == ext_misc_print_hex_version_1) {
+        checkArguments(import->base.c_str(), 1, arguments.size());
+        extension_->ext_misc_print_hex_version_1(arguments.at(0).geti64());
+        return wasm::Literal();
+      }
+
+      /// ext_misc_print_num_version_1
+      if (import->base == ext_misc_print_num_version_1) {
+        checkArguments(import->base.c_str(), 1, arguments.size());
+        extension_->ext_misc_print_num_version_1(arguments.at(0).geti64());
+        return wasm::Literal();
+      }
+
+      /// ext_misc_print_utf8_version_1
       if (import->base == ext_misc_print_utf8_version_1) {
         checkArguments(import->base.c_str(), 1, arguments.size());
         extension_->ext_misc_print_utf8_version_1(arguments.at(0).geti64());
@@ -682,12 +697,6 @@ namespace kagome::runtime::binaryen {
       // TODO(xDimon): It is temporary suppress fails at calling of
       //  callImport(ext_offchain_index_set_version_1)
       if (import->base == "ext_offchain_index_set_version_1") {
-        return wasm::Literal();
-      }
-
-      if (import->base == ext_misc_print_num_version_1) {
-        checkArguments(import->base.c_str(), 1, arguments.size());
-        extension_->ext_misc_print_num_version_1(arguments.at(0).geti64());
         return wasm::Literal();
       }
     }

--- a/test/mock/core/extensions/extension_mock.hpp
+++ b/test/mock/core/extensions/extension_mock.hpp
@@ -142,8 +142,9 @@ namespace kagome::extensions {
     MOCK_CONST_METHOD1(ext_misc_runtime_version_version_1,
                        runtime::WasmResult(runtime::WasmSpan));
 
-    MOCK_CONST_METHOD1(ext_misc_print_utf8_version_1, void(runtime::WasmSpan));
+    MOCK_CONST_METHOD1(ext_misc_print_hex_version_1, void(runtime::WasmSpan));
     MOCK_CONST_METHOD1(ext_misc_print_num_version_1, void(uint64_t));
+    MOCK_CONST_METHOD1(ext_misc_print_utf8_version_1, void(runtime::WasmSpan));
 
     MOCK_METHOD0(ext_storage_start_transaction, void());
     MOCK_METHOD0(ext_storage_rollback_transaction, void());


### PR DESCRIPTION
### Referenced issues

While debugging our test suite I realized that `ext_misc_print_hex_version_1` and `ext_misc_print_num_version_1` are not implemented.

### Description of the Change

This implements them.

### Benefits

You can use them from the runtime.

### Usage Examples or Tests

For example, in a runtime you now can do:

```rust
sp_io::misc::print_num(42);
```
