### PR TITLE
storage: return correct ephemeral root

### DIFF
--- a/core/runtime/common/trie_storage_provider_impl.cpp
+++ b/core/runtime/common/trie_storage_provider_impl.cpp
@@ -69,7 +69,7 @@ namespace kagome::runtime {
     if (persistent_batch_ != nullptr) {
       return persistent_batch_->commit();
     }
-    return common::Buffer{};
+    return trie_storage_->getRootHash();
   }
 
   outcome::result<void> TrieStorageProviderImpl::startTransaction() {


### PR DESCRIPTION
### Referenced issues

As previously mentioned on Riot and in implementers calls, we would like `ext_storage_root_version_1` to return a valid storage root hash even in an ephemeral environment.

### Description of the Change

Instead of returning an empty buffer in ephemeral environments, this change now returns the current storage root hash.

### Benefits

A correct hash is always returned.

### Possible Drawbacks 

The code was already a bit messy, calling `forceCommit` in ephemeral environments, even though this does not necessarily make sense. This patch does not resolve this but just returns a more reasonable value. This might however not always be a sensible behavior when a forced commit is expected. 

Fixing the underlying issue therefore would be better handled in a more general refactor.