### PR TITLE
Fix some bugs in peer manager 

### DIFF
--- a/core/network/impl/peer_manager_impl.cpp
+++ b/core/network/impl/peer_manager_impl.cpp
@@ -305,9 +305,6 @@ namespace kagome::network {
     log_->debug("New peer_id={} enqueued. In queue: {}",
                 (*it).toBase58(),
                 queue_to_connect_.size());
-    //
-    //    // Force aligning
-    //    align();
   }
 
   void PeerManagerImpl::processFullyConnectedPeer(const PeerId &peer_id) {

--- a/core/network/impl/router_libp2p.hpp
+++ b/core/network/impl/router_libp2p.hpp
@@ -8,8 +8,8 @@
 
 #include <memory>
 
-#include "application/app_state_manager.hpp"
 #include "application/app_configuration.hpp"
+#include "application/app_state_manager.hpp"
 #include "common/logger.hpp"
 #include "consensus/grandpa/grandpa.hpp"
 #include "consensus/grandpa/grandpa_observer.hpp"
@@ -47,7 +47,7 @@ namespace kagome::network {
     RouterLibp2p(
         std::shared_ptr<application::AppStateManager> app_state_manager,
         libp2p::Host &host,
-        const application::AppConfiguration& app_config,
+        const application::AppConfiguration &app_config,
         std::shared_ptr<application::ChainSpec> chain_spec,
         const OwnPeerInfo &own_info,
         std::shared_ptr<StreamEngine> stream_engine,
@@ -71,8 +71,7 @@ namespace kagome::network {
     /** @see AppStateManager::takeControl */
     void stop();
 
-    void handleSyncProtocol(
-        const std::shared_ptr<Stream> &stream) const override;
+    void handleSyncProtocol(std::shared_ptr<Stream> stream) const override;
 
     void handleGossipProtocol(std::shared_ptr<Stream> stream) const override;
 
@@ -149,6 +148,10 @@ namespace kagome::network {
       });
     }
 
+    void setProtocolHandler(
+        const libp2p::peer::Protocol& protocol,
+        void (RouterLibp2p::*method)(std::shared_ptr<Stream>) const);
+
     /**
      * Process a received gossip message
      */
@@ -157,7 +160,7 @@ namespace kagome::network {
 
     std::shared_ptr<application::AppStateManager> app_state_manager_;
     libp2p::Host &host_;
-    const application::AppConfiguration& app_config_;
+    const application::AppConfiguration &app_config_;
     std::shared_ptr<application::ChainSpec> chain_spec_;
     const OwnPeerInfo &own_info_;
     std::shared_ptr<StreamEngine> stream_engine_;

--- a/core/network/router.hpp
+++ b/core/network/router.hpp
@@ -24,8 +24,7 @@ namespace kagome::network {
      * Handle stream, which is opened over a Sync protocol
      * @param stream to be handled
      */
-    virtual void handleSyncProtocol(
-        const std::shared_ptr<Stream> &stream) const = 0;
+    virtual void handleSyncProtocol(std::shared_ptr<Stream> stream) const = 0;
 
     /**
      * Handle stream, which is opened over a Gossip protocol


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues
Resolves #609

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
Unified setting of protocol handlers in router.
Fallback way for case with empty queue in peer manager (by connect to bootstrap nodes again).
Separated handling of peer with new and existing connection.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
More case handled. It works better as result.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->
Trying to reproduce how it introduced in #609
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->
