### PR TITLE
cmake: fix kagome_LIBRARIES variable

### DIFF
--- a/cmake/kagomeConfig.cmake.in
+++ b/cmake/kagomeConfig.cmake.in
@@ -46,7 +46,7 @@ set(kagome_LIBRARIES
         kagome::leveldb
         kagome::logger
         kagome::in_memory_storage
-        kagome::extensions
+        kagome::host_api
         kagome::ordered_trie_hash
         kagome::crypto_store
         kagome::crypto_store_key_type
@@ -63,7 +63,7 @@ set(kagome_LIBRARIES
         kagome::pbkdf2_provider
         kagome::secp256k1_provider
         kagome::bip39_provider
-        kagome::extension_factory
+        kagome::host_api_factory
         kagome::binaryen_core_api
         kagome::binaryen_runtime_api
         kagome::binaryen_runtime_external_interface


### PR DESCRIPTION
### Referenced issues

In #677 `extensions` and `extensions_factory` was renamed to `host_api` and `host_api_factory`, however this was not changed in this exported variable.

### Description of the Change

Updates the target  to correct names.

### Benefits

`${kagome_LIBRARIES}` can actually be used without causing errors.

### Alternate Designs

It would be great if this variable could just be generated automatically.
