### PR TITLE
cmake: fix installed header dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ kagome_install_setup(
     core/crypto
     core/outcome
     core/runtime
-    core/extensions
+    core/host_api
     core/subscription
 )
 


### PR DESCRIPTION
### Referenced issues

In #677 `extensions` was renamed to `host_api`, however this was not updated in the header install directive.

### Description of the Change

CMake now install the renamed folder, namely `core/host_api` instead of `core/extensions`.

This will fix build issues like these:

```
 /home/runner/.hunter/_Base/deb079c/1720112/6249b1f/Install/include/runtime/binaryen/runtime_api/runtime_api.hpp:17:10: fatal error: host_api/host_api_factory.hpp: No such file or directory
   17 | #include "host_api/host_api_factory.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### Benefits

The correct folder is used and installed.

### Possible Drawbacks 

None
