### PR TITLE
CMake: Allow build system to provide protobuf compiler

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -47,8 +47,13 @@ function(add_flag flag)
 endfunction()
 
 function(compile_proto_to_cpp PROTO_LIBRARY_NAME PB_H PB_CC PROTO)
-  get_target_property(Protobuf_INCLUDE_DIR protobuf::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)
-  get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc IMPORTED_LOCATION_RELEASE)
+  if (NOT Protobuf_INCLUDE_DIR)
+    get_target_property(Protobuf_INCLUDE_DIR protobuf::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)
+  endif()
+  if (NOT Protobuf_PROTOC_EXECUTABLE)
+    get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc IMPORTED_LOCATION_RELEASE)
+    set(PROTOBUF_DEPENDS protobuf::protoc)
+  endif()
 
   if (NOT Protobuf_PROTOC_EXECUTABLE)
     message(FATAL_ERROR "Protobuf_PROTOC_EXECUTABLE is empty")
@@ -80,7 +85,7 @@ function(compile_proto_to_cpp PROTO_LIBRARY_NAME PB_H PB_CC PROTO)
       COMMAND ${GEN_COMMAND}
       ARGS -I${PROJECT_SOURCE_DIR}/core -I${GEN_ARGS} --cpp_out=${SCHEMA_OUT_DIR} ${PROTO_ABS}
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-      DEPENDS protobuf::protoc
+      DEPENDS ${PROTOBUF_DEPENDS}
       VERBATIM
   )
 


### PR DESCRIPTION
### Referenced issues

This ports the relevant CMake patches from libp2p/cpp-libp2p#59 over to kagome,

Not sure if the license is compatible and it might be required that @eigendude signs the CLA as this is his patch, just applied to a different code base.

### Description of the Change

When building without Hunter, it is desirable to pass the path to protoc and
the protobuf include directory from the build system. Allow these variables
to be overridden.

Fixes the error:

| CMake Error at cmake/functions.cmake:52 (message):
|   Protobuf_PROTOC_EXECUTABLE is empty
| Call Stack (most recent call first):
|   cmake/functions.cmake:96 (compile_proto_to_cpp)
|   src/crypto/protobuf/CMakeLists.txt:6 (add_proto_library)

### Benefits

Support building kagome without hunter.

### Possible Drawbacks 

None

### Alternate Designs <!-- Optional -->

The alternative would be to not use custom functions at all but to use the functions provided by CMake or the protobuffer CMake pacakge config to compile any `.proto` files. I have [a patch](https://gitlab.w3f.tech/florian/w3fpkgs/-/blob/master/hosts/kagome/protobuf_path.patch) for this as well, but it is far more intrusive.