### PR TITLE
Add --name node launch parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docker build -t soramitsu/kagome:0.0.1 -f ./housekeeping/docker/release/Dockerfi
 
 # Check docker image 
 docker run -it --rm soramitsu/kagome:0.0.1 kagome_full_syncing
-[2020-06-03 16:26:14][error] the option '--genesis' is required but missing
+[2020-06-03 16:26:14][error] the option '--chain' is required but missing
 
 ```
 
@@ -111,7 +111,7 @@ To launch kagome syncing node execute:
 ```
 cd examples/polkadot/
 PATH=$PATH:../../build/node/kagome_full_syncing/
-kagome_full_syncing --chain polkadot.json --base-path syncing_chain --port 50541 --rpc-port 50542 --ws-port 50543 --unix_slots
+kagome_full_syncing --chain polkadot.json --base-path syncing_chain --port 50541 --rpc-port 50542 --ws-port 50543 --unix-slots
 ```
 
 After this command syncing node will connect with the full node and start importing blocks.

--- a/core/application/app_configuration.hpp
+++ b/core/application/app_configuration.hpp
@@ -27,6 +27,7 @@ namespace kagome::application {
    public:
     static constexpr uint32_t kAbsolutMinBlocksInResponse = 10;
     static constexpr uint32_t kAbsolutMaxBlocksInResponse = 128;
+    static constexpr uint32_t kNodeNameMaxLength = 64;
 
     static_assert(kAbsolutMinBlocksInResponse <= kAbsolutMaxBlocksInResponse,
                   "Check max and min page bounding values!");
@@ -36,7 +37,6 @@ namespace kagome::application {
       kFullSyncing,
     };
 
-   public:
     virtual ~AppConfiguration() = default;
 
     /**
@@ -133,6 +133,12 @@ namespace kagome::application {
      * @return true if node allowed to run in development mode
      */
     virtual bool isRunInDevMode() const = 0;
+
+    /**
+     * @return string representation of human-readable node name.
+     * The name of node is going to be used in telemetry, etc.
+     */
+    virtual const std::string &nodeName() const = 0;
   };
 
 }  // namespace kagome::application

--- a/core/application/impl/app_configuration_impl.cpp
+++ b/core/application/impl/app_configuration_impl.cpp
@@ -200,10 +200,10 @@ namespace kagome::application {
   }
 
   void AppConfigurationImpl::parse_additional_segment(rapidjson::Value &val) {
-    load_bool(val, "single_finalizing_node", is_only_finalizing_);
-    load_bool(val, "already_synchronized", is_already_synchronized_);
-    load_u32(val, "max_blocks_in_response", max_blocks_in_response_);
-    load_bool(val, "is_unix_slots_strategy", is_unix_slots_strategy_);
+    load_bool(val, "single-finalizing-node", is_only_finalizing_);
+    load_bool(val, "already-synchronized", is_already_synchronized_);
+    load_u32(val, "max-blocks-in-response", max_blocks_in_response_);
+    load_bool(val, "is-unix-slots-strategy", is_unix_slots_strategy_);
     load_bool(val, "dev", dev_mode_);
   }
 
@@ -344,15 +344,15 @@ namespace kagome::application {
         ("rpc-port", po::value<uint16_t>(), "port for RPC over HTTP")
         ("ws-host", po::value<std::string>(), "address for RPC over Websocket protocol")
         ("ws-port", po::value<uint16_t>(), "port for RPC over Websocket protocol")
-        ("max_blocks_in_response", po::value<int>(), "max block per response while syncing")
+        ("max-blocks-in-response", po::value<int>(), "max block per response while syncing")
         ("name", po::value<std::string>(), "the human-readable name for this node")
         ;
 
     po::options_description additional_desc("Additional options");
     additional_desc.add_options()
-        ("single_finalizing_node,f", "if this is the only finalizing node")
-        ("already_synchronized,s", "if need to consider synchronized")
-        ("unix_slots,u", "if slots are calculated from unix epoch")
+        ("single-finalizing-node,f", "if this is the only finalizing node")
+        ("already-synchronized,s", "if need to consider synchronized")
+        ("unix-slots,u", "if slots are calculated from unix epoch")
         ;
 
     po::options_description development_desc("Development options");
@@ -464,13 +464,13 @@ namespace kagome::application {
     });
 
     /// aggregate data from command line args
-    if (vm.end() != vm.find("single_finalizing_node"))
+    if (vm.end() != vm.find("single-finalizing-node"))
       is_only_finalizing_ = true;
 
-    if (vm.end() != vm.find("already_synchronized"))
+    if (vm.end() != vm.find("already-synchronized"))
       is_already_synchronized_ = true;
 
-    if (vm.end() != vm.find("unix_slots")) is_unix_slots_strategy_ = true;
+    if (vm.end() != vm.find("unix-slots")) is_unix_slots_strategy_ = true;
 
     find_argument<std::string>(
         vm, "chain", [&](const std::string &val) { chain_spec_path_ = val; });
@@ -542,7 +542,7 @@ namespace kagome::application {
       listen_addresses_.emplace_back(std::move(ma_res.value()));
     }
 
-    find_argument<uint32_t>(vm, "max_blocks_in_response", [&](uint32_t val) {
+    find_argument<uint32_t>(vm, "max-blocks-in-response", [&](uint32_t val) {
       max_blocks_in_response_ = val;
     });
 

--- a/core/application/impl/app_configuration_impl.hpp
+++ b/core/application/impl/app_configuration_impl.hpp
@@ -115,6 +115,9 @@ namespace kagome::application {
     bool isRunInDevMode() const override {
       return dev_mode_;
     }
+    const std::string& nodeName() const override {
+      return node_name_;
+    }
 
    private:
     void parse_general_segment(rapidjson::Value &val);
@@ -184,6 +187,7 @@ namespace kagome::application {
     uint16_t rpc_ws_port_;
     network::PeeringConfig peering_config_;
     bool dev_mode_;
+    std::string node_name_;
   };
 
 }  // namespace kagome::application

--- a/core/application/impl/syncing_node_application.cpp
+++ b/core/application/impl/syncing_node_application.cpp
@@ -17,7 +17,8 @@ namespace kagome::application {
   SyncingNodeApplication::SyncingNodeApplication(
       const AppConfiguration &app_config)
       : logger_(log::createLogger("SyncingNodeApplication", "application")),
-        injector_{std::make_unique<injector::SyncingNodeInjector>(app_config)} {
+        injector_{std::make_unique<injector::SyncingNodeInjector>(app_config)},
+        node_name_{app_config.nodeName()} {
     // keep important instances, the must exist when injector destroyed
     // some of them are requested by reference and hence not copied
     chain_spec_ = injector_->injectChainSpec();
@@ -33,7 +34,8 @@ namespace kagome::application {
   }
 
   void SyncingNodeApplication::run() {
-    logger_->info("Start as SyncingNode with PID {}", getpid());
+    logger_->info(
+        "Start as SyncingNode with PID {} named as {}", getpid(), node_name_);
 
     auto res = util::init_directory(chain_path_);
     if (not res) {

--- a/core/application/impl/syncing_node_application.hpp
+++ b/core/application/impl/syncing_node_application.hpp
@@ -10,14 +10,14 @@
 
 #include <boost/filesystem/path.hpp>
 
-#include "injector/application_injector.hpp"
-#include "application/app_configuration.hpp"
-#include "application/chain_spec.hpp"
-#include "application/app_state_manager.hpp"
-#include "network/router.hpp"
-#include "network/peer_manager.hpp"
 #include "api/service/api_service.hpp"
+#include "application/app_configuration.hpp"
+#include "application/app_state_manager.hpp"
+#include "application/chain_spec.hpp"
+#include "injector/application_injector.hpp"
 #include "log/logger.hpp"
+#include "network/peer_manager.hpp"
+#include "network/router.hpp"
 
 namespace kagome::application {
 
@@ -48,6 +48,7 @@ namespace kagome::application {
     sptr<api::ApiService> jrpc_api_service_;
     sptr<ChainSpec> chain_spec_;
     boost::filesystem::path chain_path_;
+    const std::string node_name_;
   };
 
 }  // namespace kagome::application

--- a/core/application/impl/validating_node_application.cpp
+++ b/core/application/impl/validating_node_application.cpp
@@ -15,7 +15,8 @@ namespace kagome::application {
       const AppConfiguration &app_config)
       : logger_(log::createLogger("ValidatingNodeApplication", "application")),
         injector_{
-            std::make_unique<injector::ValidatingNodeInjector>(app_config)} {
+            std::make_unique<injector::ValidatingNodeInjector>(app_config)},
+        node_name_{app_config.nodeName()} {
     if (app_config.isAlreadySynchronized()) {
       babe_execution_strategy_ =
           consensus::babe::Babe::ExecutionStrategy::START;
@@ -43,7 +44,9 @@ namespace kagome::application {
   }
 
   void ValidatingNodeApplication::run() {
-    logger_->info("Start as ValidatingNode with PID {}", getpid());
+    logger_->info("Start as ValidatingNode with PID {} named as {}",
+                  getpid(),
+                  node_name_);
 
     auto res = util::init_directory(chain_path_);
     if (not res) {

--- a/core/application/impl/validating_node_application.hpp
+++ b/core/application/impl/validating_node_application.hpp
@@ -65,6 +65,7 @@ namespace kagome::application {
     Babe::ExecutionStrategy babe_execution_strategy_;
 
     boost::filesystem::path chain_path_;
+    const std::string node_name_;
   };
 
 }  // namespace kagome::application

--- a/docs/source/tutorials/first_kagome_chain.md
+++ b/docs/source/tutorials/first_kagome_chain.md
@@ -73,8 +73,8 @@ kagome_validating \
     --port 30363 \
     --rpc-port 9933 \
     --ws-port 9944 \
-    --single_finalizing_node \
-    --already_synchronized
+    --single-finalizing-node \
+    --already-synchronized
 ```
 
 Let's look at this flags in detail:
@@ -86,7 +86,7 @@ Let's look at this flags in detail:
 | `--port`      | port for p2p interactions                         |
 | `--rpc-port` | port for RPC over HTTP                            |
 | `--ws-port`   | port for RPC over Websocket protocol              |
-| `--single_finalizing_node`   | need to be set if this is the only finalizing node              |
+| `--single-finalizing-node`   | need to be set if this is the only finalizing node              |
 | `--already_synchronized`   | need to be set if need to be considered synchronized              |
 
 More flags info available by running `kagome_validating --help`.

--- a/docs/source/tutorials/first_kagome_chain.md
+++ b/docs/source/tutorials/first_kagome_chain.md
@@ -87,7 +87,7 @@ Let's look at this flags in detail:
 | `--rpc-port` | port for RPC over HTTP                            |
 | `--ws-port`   | port for RPC over Websocket protocol              |
 | `--single-finalizing-node`   | need to be set if this is the only finalizing node              |
-| `--already_synchronized`   | need to be set if need to be considered synchronized              |
+| `--already-synchronized`   | need to be set if need to be considered synchronized              |
 
 More flags info available by running `kagome_validating --help`.
 

--- a/docs/source/tutorials/private_network.md
+++ b/docs/source/tutorials/private_network.md
@@ -21,8 +21,8 @@ kagome_validating \
     --port 11122 \
     --rpc-port 11133 \
     --ws-port 11144 \
-    --single_finalizing_node \
-    --already_synchronized
+    --single-finalizing-node \
+    --already-synchronized
 ```
 
 ### Execute second validating node  

--- a/test/core/application/app_config_test.cpp
+++ b/test/core/application/app_config_test.cpp
@@ -46,7 +46,8 @@ class AppConfigurationTest : public testing::Test {
               "rpc-host" : "1.1.1.1",
               "rpc-port" : 123,
               "ws-host" : "2.2.2.2",
-              "ws-port" : 678
+              "ws-port" : 678,
+              "name" : "Bob's node"
         },
         "additional" : {
           "single_finalizing_node" : true
@@ -104,10 +105,10 @@ class AppConfigurationTest : public testing::Test {
       file << file_content;
     };
 
-    spawn_file(config_path,
-               (boost::format(file_content) % chain_path.native()
-                % base_path.native())
-                   .str());
+    spawn_file(
+        config_path,
+        (boost::format(file_content) % chain_path.native() % base_path.native())
+            .str());
     spawn_file(invalid_config_path, invalid_file_content);
     spawn_file(damaged_config_path, damaged_file_content);
     spawn_file(chain_path.native(), "");
@@ -266,6 +267,7 @@ TEST_F(AppConfigurationTest, ConfigFileTest) {
   ASSERT_EQ(app_config_->rpcWsEndpoint(), ws_endpoint);
   ASSERT_EQ(app_config_->verbosity(), kagome::log::Level::DEBUG);
   ASSERT_EQ(app_config_->isOnlyFinalizing(), true);
+  ASSERT_EQ(app_config_->nodeName(), "Bob's node");
 }
 
 /**
@@ -537,7 +539,7 @@ TEST_F(AppConfigurationTest, UnexpVerbosityCmdLineTest) {
 /**
  * @given new created AppConfigurationImpl
  * @when is_only_finalize present
- * @then we should receve true from the call
+ * @then we should receive true from the call
  */
 TEST_F(AppConfigurationTest, OnlyFinalizeTestTest) {
   char const *args[] = {"/path/",
@@ -570,4 +572,25 @@ TEST_F(AppConfigurationTest, OnlyFinalizeTestTest_2) {
       sizeof(args) / sizeof(args[0]),
       (char **)args));
   ASSERT_EQ(app_config_->isOnlyFinalizing(), true);
+}
+
+/**
+ * @given newly created AppConfigurationImpl
+ * @when node name set in command line arguments
+ * @then the name is correctly passed to configuration
+ */
+TEST_F(AppConfigurationTest, NodeNameAsCommandLineOption) {
+  char const *args[] = {"/path/",
+                        "--single_finalizing_node",
+                        "--chain",
+                        chain_path.native().c_str(),
+                        "--base-path",
+                        base_path.native().c_str(),
+                        "--name",
+                        "Alice's node"};
+  ASSERT_TRUE(app_config_->initialize_from_args(
+      AppConfiguration::LoadScheme::kValidating,
+      sizeof(args) / sizeof(args[0]),
+      (char **)args));
+  ASSERT_EQ(app_config_->nodeName(), "Alice's node");
 }

--- a/test/core/application/app_config_test.cpp
+++ b/test/core/application/app_config_test.cpp
@@ -50,7 +50,7 @@ class AppConfigurationTest : public testing::Test {
               "name" : "Bob's node"
         },
         "additional" : {
-          "single_finalizing_node" : true
+          "single-finalizing-node" : true
         }
       })";
   static constexpr char const *invalid_file_content =
@@ -72,7 +72,7 @@ class AppConfigurationTest : public testing::Test {
               "ws-port" : "AWESOME_PORT"
         },
         "additional" : {
-          "single_finalizing_node" : "order1800"
+          "single-finalizing-node" : "order1800"
         }
       })";
   static constexpr char const *damaged_file_content =
@@ -83,7 +83,7 @@ class AppConfigurationTest : public testing::Test {
         "blockchain" : {
           "chain" : 1
         },
-        "storage" : nalizing_node" : "order1800"
+        "storage" : nalizing-node" : "order1800"
         }
       })";
 
@@ -378,13 +378,13 @@ TEST_F(AppConfigurationTest, NoConfigFileTest) {
 
 /**
  * @given new created AppConfigurationImpl
- * @when --single_finalizing_node cmd line arg is provided
- * @then we must receive this value from is_single_finalizing_node() call
+ * @when --single-finalizing-node cmd line arg is provided
+ * @then we must receive this value from isOnlyFinalizing() call
  */
 TEST_F(AppConfigurationTest, OnlyFinalizeTest) {
   char const *args[] = {
       "/path/",
-      "--single_finalizing_node",
+      "--single-finalizing-node",
       "true",
       "--chain",
       chain_path.native().c_str(),
@@ -557,12 +557,12 @@ TEST_F(AppConfigurationTest, OnlyFinalizeTestTest) {
 
 /**
  * @given new created AppConfigurationImpl
- * @when is_only_finalize present
- * @then we should receve true from the call
+ * @when single-finalizing-node present
+ * @then we should receive true from the isOnlyFinalizing() call
  */
 TEST_F(AppConfigurationTest, OnlyFinalizeTestTest_2) {
   char const *args[] = {"/path/",
-                        "--single_finalizing_node",
+                        "--single-finalizing-node",
                         "--chain",
                         chain_path.native().c_str(),
                         "--base-path",
@@ -581,7 +581,7 @@ TEST_F(AppConfigurationTest, OnlyFinalizeTestTest_2) {
  */
 TEST_F(AppConfigurationTest, NodeNameAsCommandLineOption) {
   char const *args[] = {"/path/",
-                        "--single_finalizing_node",
+                        "--single-finalizing-node",
                         "--chain",
                         chain_path.native().c_str(),
                         "--base-path",

--- a/test/mock/core/application/app_configuration_mock.hpp
+++ b/test/mock/core/application/app_configuration_mock.hpp
@@ -54,6 +54,8 @@ namespace kagome::application {
     MOCK_CONST_METHOD0(peeringConfig, const network::PeeringConfig &());
 
     MOCK_CONST_METHOD0(isRunInDevMode, bool());
+
+    MOCK_CONST_METHOD0(nodeName, const std::string &());
   };
 
 }  // namespace kagome::application


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

https://github.com/soramitsu/kagome/issues/685

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change

1. Add support of a flag to set human-readable node name.
2. When the flag is not used and the config does not define the name, then the auto-generated UUID string would be used as the name.
3. Unify other flag names to use a dash instead of underscore as a word delimiter.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

The node name displays in logs at startup.
This is the supporting change for the future implementation of the telemetry feature.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

None

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->

```bash
kagome_full_syncing --name Alice --chain polkadot.json -d syncing_chain --port 50541 --rpc-port 50542 --ws-port 50543 --unix-slots -v 1
...
21.04.12 19:43:21.495324  T:1 Info SyncingNodeApplication  Start as SyncingNode with PID 64066 named as Alice
...


or 

app_config_test
```

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->
