### PR TITLE
Add support of --node-key-file flag

### DIFF
--- a/core/application/app_configuration.hpp
+++ b/core/application/app_configuration.hpp
@@ -70,6 +70,11 @@ namespace kagome::application {
         const = 0;
 
     /**
+     * @return the path to key used for libp2p networking
+     */
+    virtual const boost::optional<std::string> &nodeKeyFile() const = 0;
+
+    /**
      * @return port for peer to peer interactions.
      */
     virtual uint16_t p2pPort() const = 0;

--- a/core/application/impl/app_configuration_impl.cpp
+++ b/core/application/impl/app_configuration_impl.cpp
@@ -41,7 +41,7 @@ namespace {
   const bool def_is_already_synchronized = false;
   const bool def_is_unix_slots_strategy = false;
   const bool def_dev_mode = false;
-  const kagome::network::Roles def_roles = []{
+  const kagome::network::Roles def_roles = [] {
     kagome::network::Roles roles;
     roles.flags.full = 1;
     return roles;
@@ -174,7 +174,7 @@ namespace kagome::application {
   void AppConfigurationImpl::parse_general_segment(rapidjson::Value &val) {
     bool validator_mode = false;
     load_bool(val, "validator", validator_mode);
-    if (validator_mode){
+    if (validator_mode) {
       roles_.flags.authority = 1;
     }
 
@@ -354,6 +354,7 @@ namespace kagome::application {
         ("listen-addr", po::value<std::vector<std::string>>()->multitoken(), "multiaddresses the node listens for open connections on")
         ("public-addr", po::value<std::vector<std::string>>()->multitoken(), "multiaddresses that other nodes use to connect to it")
         ("node-key", po::value<std::string>(), "the secret key to use for libp2p networking")
+        ("node-key-file", po::value<std::string>(), "path to the secret key used for libp2p networking (raw binary or hex-encoded")
         ("bootnodes", po::value<std::vector<std::string>>()->multitoken(), "multiaddresses of bootstrap nodes")
         ("port,p", po::value<uint16_t>(), "port for peer to peer interactions")
         ("rpc-host", po::value<std::string>(), "address for RPC over HTTP")
@@ -545,6 +546,13 @@ namespace kagome::application {
         return false;
       }
       node_key_.emplace(std::move(key_res.value()));
+    }
+
+    if (not node_key_.has_value()) {
+      find_argument<std::string>(
+          vm, "node-key-file", [&](const std::string &val) {
+            node_key_file_ = val;
+          });
     }
 
     find_argument<uint16_t>(vm, "port", [&](uint16_t val) { p2p_port_ = val; });

--- a/core/application/impl/app_configuration_impl.hpp
+++ b/core/application/impl/app_configuration_impl.hpp
@@ -77,6 +77,10 @@ namespace kagome::application {
       return node_key_;
     }
 
+    const boost::optional<std::string> &nodeKeyFile() const override {
+      return node_key_file_;
+    };
+
     const std::vector<libp2p::multi::Multiaddress> &listenAddresses()
         const override {
       return listen_addresses_;
@@ -173,6 +177,7 @@ namespace kagome::application {
 
     network::Roles roles_;
     boost::optional<crypto::Ed25519PrivateKey> node_key_;
+    boost::optional<std::string> node_key_file_;
     std::vector<libp2p::multi::Multiaddress> listen_addresses_;
     std::vector<libp2p::multi::Multiaddress> public_addresses_;
     std::vector<libp2p::multi::Multiaddress> boot_nodes_;

--- a/core/crypto/crypto_store.hpp
+++ b/core/crypto/crypto_store.hpp
@@ -107,14 +107,16 @@ namespace kagome::crypto {
      * @param key_type key type identifier to look for
      * @return vector of found public keys
      */
-    virtual outcome::result<Ed25519Keys> getEd25519PublicKeys(KeyTypeId key_type) const = 0;
+    virtual outcome::result<Ed25519Keys> getEd25519PublicKeys(
+        KeyTypeId key_type) const = 0;
 
     /**
      * @brief searches for SR25519 keys of specified type
      * @param key_type key type identifier to look for
      * @return vector of found public keys
      */
-    virtual outcome::result<Sr25519Keys> getSr25519PublicKeys(KeyTypeId key_type) const = 0;
+    virtual outcome::result<Sr25519Keys> getSr25519PublicKeys(
+        KeyTypeId key_type) const = 0;
 
     /**
      * @return current GRANDPA session key pair
@@ -129,7 +131,17 @@ namespace kagome::crypto {
     /**
      * @return current LibP2P keypair
      */
-    virtual boost::optional<libp2p::crypto::KeyPair> getLibp2pKeypair() const = 0;
+    virtual boost::optional<libp2p::crypto::KeyPair> getLibp2pKeypair()
+        const = 0;
+
+    /**
+     * Acquires the key from user-provided path or generates and saves the
+     * key under the path. Used when --node-key-file flag gets processed.
+     * @param path - path the key file (raw bytes or hex-encoded)
+     * @return LibP2P keypair
+     */
+    virtual outcome::result<libp2p::crypto::KeyPair> loadLibp2pKeypair(
+        const Path &key_path) const = 0;
   };
 }  // namespace kagome::crypto
 

--- a/core/crypto/crypto_store/crypto_store_impl.cpp
+++ b/core/crypto/crypto_store/crypto_store_impl.cpp
@@ -164,7 +164,7 @@ namespace kagome::crypto {
     }
     auto kp = findEd25519Keypair(KEY_TYPE_LP2P, keys.value().at(0));
     if (kp) {
-      return edKeyToLibp2pKeypair(kp.value());
+      return ed25519KeyToLibp2pKeypair(kp.value());
     }
     return boost::none;
   }
@@ -178,7 +178,7 @@ namespace kagome::crypto {
       getCache(ed_suite_, ed_caches_, KEY_TYPE_LP2P)
           .insert(kp.public_key, kp.secret_key);
       OUTCOME_TRY(file_storage_->saveKeyHexAtPath(kp.secret_key, key_path));
-      return edKeyToLibp2pKeypair(kp);
+      return ed25519KeyToLibp2pKeypair(kp);
     }
     // propagate any other error
     if (lookup_res.has_error()) {
@@ -205,10 +205,10 @@ namespace kagome::crypto {
     }
     getCache(ed_suite_, ed_caches_, KEY_TYPE_LP2P)
         .insert(kp.value().public_key, kp.value().secret_key);
-    return edKeyToLibp2pKeypair(kp.value());
+    return ed25519KeyToLibp2pKeypair(kp.value());
   }
 
-  inline libp2p::crypto::KeyPair CryptoStoreImpl::edKeyToLibp2pKeypair(
+  inline libp2p::crypto::KeyPair CryptoStoreImpl::ed25519KeyToLibp2pKeypair(
       const Ed25519Keypair &kp) const {
     const auto &secret_key = kp.secret_key;
     const auto &public_key = kp.public_key;

--- a/core/crypto/crypto_store/crypto_store_impl.cpp
+++ b/core/crypto/crypto_store/crypto_store_impl.cpp
@@ -164,19 +164,63 @@ namespace kagome::crypto {
     }
     auto kp = findEd25519Keypair(KEY_TYPE_LP2P, keys.value().at(0));
     if (kp) {
-      auto &secret_key = kp.value().secret_key;
-      auto &public_key = kp.value().public_key;
-      libp2p::crypto::PublicKey lp2p_public{
-          {libp2p::crypto::Key::Type::Ed25519,
-           std::vector<uint8_t>{public_key.cbegin(), public_key.cend()}}};
-      libp2p::crypto::PrivateKey lp2p_private{
-          {libp2p::crypto::Key::Type::Ed25519,
-           std::vector<uint8_t>{secret_key.cbegin(), secret_key.cend()}}};
-      return libp2p::crypto::KeyPair{
-          .publicKey = lp2p_public,
-          .privateKey = lp2p_private,
-      };
+      return edKeyToLibp2pKeypair(kp.value());
     }
     return boost::none;
+  }
+
+  outcome::result<libp2p::crypto::KeyPair> CryptoStoreImpl::loadLibp2pKeypair(
+      const CryptoStore::Path &key_path) const {
+    auto lookup_res = file_storage_->loadFileContent(key_path);
+    if (lookup_res.has_error()
+        and lookup_res.error() == KeyFileStorage::Error::FILE_DOESNT_EXIST) {
+      auto kp = ed_suite_->generateRandomKeypair();
+      getCache(ed_suite_, ed_caches_, KEY_TYPE_LP2P)
+          .insert(kp.public_key, kp.secret_key);
+      OUTCOME_TRY(file_storage_->saveKeyHexAtPath(kp.secret_key, key_path));
+      return edKeyToLibp2pKeypair(kp);
+    }
+    // propagate any other error
+    if (lookup_res.has_error()) {
+      return lookup_res.error();
+    }
+    const auto &contents = lookup_res.value();
+    BOOST_ASSERT(ED25519_SEED_LENGTH == contents.size()
+                 or 2 * ED25519_SEED_LENGTH == contents.size());  // hex
+    boost::optional<Ed25519Keypair> kp;
+    if (ED25519_SEED_LENGTH == contents.size()) {
+      OUTCOME_TRY(
+          seed,
+          Ed25519Seed::fromSpan(gsl::span(
+              reinterpret_cast<const uint8_t *>(contents.data()),  // NOLINT
+              ED25519_SEED_LENGTH)));
+      kp = ed_suite_->generateKeypair(seed);
+    } else if (2 * ED25519_SEED_LENGTH == contents.size()) {  // hex-encoded
+      OUTCOME_TRY(seed, Ed25519Seed::fromHex(contents));
+      kp = ed_suite_->generateKeypair(seed);
+    }
+
+    if (boost::none == kp) {
+      return CryptoStoreError::UNSUPPORTED_CRYPTO_TYPE;
+    }
+    getCache(ed_suite_, ed_caches_, KEY_TYPE_LP2P)
+        .insert(kp.value().public_key, kp.value().secret_key);
+    return edKeyToLibp2pKeypair(kp.value());
+  }
+
+  inline libp2p::crypto::KeyPair CryptoStoreImpl::edKeyToLibp2pKeypair(
+      const Ed25519Keypair &kp) const {
+    const auto &secret_key = kp.secret_key;
+    const auto &public_key = kp.public_key;
+    libp2p::crypto::PublicKey lp2p_public{
+        {libp2p::crypto::Key::Type::Ed25519,
+         std::vector<uint8_t>{public_key.cbegin(), public_key.cend()}}};
+    libp2p::crypto::PrivateKey lp2p_private{
+        {libp2p::crypto::Key::Type::Ed25519,
+         std::vector<uint8_t>{secret_key.cbegin(), secret_key.cend()}}};
+    return libp2p::crypto::KeyPair{
+        .publicKey = lp2p_public,
+        .privateKey = lp2p_private,
+    };
   }
 }  // namespace kagome::crypto

--- a/core/crypto/crypto_store/crypto_store_impl.cpp
+++ b/core/crypto/crypto_store/crypto_store_impl.cpp
@@ -208,7 +208,7 @@ namespace kagome::crypto {
     return ed25519KeyToLibp2pKeypair(kp.value());
   }
 
-  inline libp2p::crypto::KeyPair CryptoStoreImpl::ed25519KeyToLibp2pKeypair(
+  libp2p::crypto::KeyPair CryptoStoreImpl::ed25519KeyToLibp2pKeypair(
       const Ed25519Keypair &kp) const {
     const auto &secret_key = kp.secret_key;
     const auto &public_key = kp.public_key;

--- a/core/crypto/crypto_store/crypto_store_impl.hpp
+++ b/core/crypto/crypto_store/crypto_store_impl.hpp
@@ -77,6 +77,9 @@ namespace kagome::crypto {
 
     boost::optional<libp2p::crypto::KeyPair> getLibp2pKeypair() const override;
 
+    outcome::result<libp2p::crypto::KeyPair> loadLibp2pKeypair(
+        const Path &key_path) const override;
+
    private:
     template <typename CryptoSuite>
     outcome::result<std::vector<typename CryptoSuite::PublicKey>> getPublicKeys(
@@ -155,6 +158,9 @@ namespace kagome::crypto {
       }
       return it->second;
     }
+
+    inline libp2p::crypto::KeyPair edKeyToLibp2pKeypair(
+        const Ed25519Keypair &kp) const;
 
     mutable std::unordered_map<KeyTypeId, KeyCache<Ed25519Suite>> ed_caches_;
     mutable std::unordered_map<KeyTypeId, KeyCache<Sr25519Suite>> sr_caches_;

--- a/core/crypto/crypto_store/crypto_store_impl.hpp
+++ b/core/crypto/crypto_store/crypto_store_impl.hpp
@@ -159,7 +159,7 @@ namespace kagome::crypto {
       return it->second;
     }
 
-    inline libp2p::crypto::KeyPair edKeyToLibp2pKeypair(
+    inline libp2p::crypto::KeyPair ed25519KeyToLibp2pKeypair(
         const Ed25519Keypair &kp) const;
 
     mutable std::unordered_map<KeyTypeId, KeyCache<Ed25519Suite>> ed_caches_;

--- a/core/crypto/crypto_store/crypto_store_impl.hpp
+++ b/core/crypto/crypto_store/crypto_store_impl.hpp
@@ -159,7 +159,7 @@ namespace kagome::crypto {
       return it->second;
     }
 
-    inline libp2p::crypto::KeyPair ed25519KeyToLibp2pKeypair(
+    libp2p::crypto::KeyPair ed25519KeyToLibp2pKeypair(
         const Ed25519Keypair &kp) const;
 
     mutable std::unordered_map<KeyTypeId, KeyCache<Ed25519Suite>> ed_caches_;

--- a/core/crypto/crypto_store/key_file_storage.cpp
+++ b/core/crypto/crypto_store/key_file_storage.cpp
@@ -96,21 +96,13 @@ namespace kagome::crypto {
       KeyTypeId type,
       gsl::span<const uint8_t> public_key,
       gsl::span<const uint8_t> seed) const {
-    std::ofstream file;
-
     auto &&path = composeKeyPath(type, public_key);
-    file.open(path.native(), std::ios::out | std::ios::trunc);
-    if (!file.is_open()) {
-      return Error::FAILED_OPEN_FILE;
-    }
-    auto hex = common::hex_lower(seed);
+    OUTCOME_TRY(saveKeyHexAtPath(seed, path));
     SL_TRACE(logger_,
              "Saving keypair (public: {}, secret: {}) to {}",
              common::hex_lower(public_key),
-             hex,
+             common::hex_lower(seed),
              path.native());
-    file << hex;
-
     return outcome::success();
   }
 
@@ -152,7 +144,7 @@ namespace kagome::crypto {
 
     std::ifstream file;
 
-    file.open(file_path.string(), std::ios::in);
+    file.open(file_path.string(), std::ios::in | std::ios::binary);
     if (!file.is_open()) {
       return Error::FAILED_OPEN_FILE;
     }
@@ -161,6 +153,20 @@ namespace kagome::crypto {
     file >> content;
     SL_TRACE(logger_, "Loaded seed {} from {}", content, file_path.native());
     return content;
+  }
+
+  outcome::result<void> KeyFileStorage::saveKeyHexAtPath(
+      gsl::span<const uint8_t> private_key,
+      const KeyFileStorage::Path &path) const {
+    std::ofstream file;
+    file.open(path.native(), std::ios::out | std::ios::trunc);
+    if (!file.is_open()) {
+      return Error::FAILED_OPEN_FILE;
+    }
+    auto hex = common::hex_lower(private_key);
+    file << hex;
+    SL_TRACE(logger_, "Saving key (secret: {}) to {}", hex, path.native());
+    return outcome::success();
   }
 
   outcome::result<std::vector<Buffer>> KeyFileStorage::collectPublicKeys(

--- a/core/crypto/crypto_store/key_file_storage.cpp
+++ b/core/crypto/crypto_store/key_file_storage.cpp
@@ -99,9 +99,8 @@ namespace kagome::crypto {
     auto &&path = composeKeyPath(type, public_key);
     OUTCOME_TRY(saveKeyHexAtPath(seed, path));
     SL_TRACE(logger_,
-             "Saving keypair (public: {}, secret: {}) to {}",
+             "Saving keypair (public: {}) to {}",
              common::hex_lower(public_key),
-             common::hex_lower(seed),
              path.native());
     return outcome::success();
   }
@@ -165,7 +164,7 @@ namespace kagome::crypto {
     }
     auto hex = common::hex_lower(private_key);
     file << hex;
-    SL_TRACE(logger_, "Saving key (secret: {}) to {}", hex, path.native());
+    SL_TRACE(logger_, "Saving key to {}", path.native());
     return outcome::success();
   }
 

--- a/core/crypto/crypto_store/key_file_storage.hpp
+++ b/core/crypto/crypto_store/key_file_storage.hpp
@@ -66,6 +66,25 @@ namespace kagome::crypto {
                                       gsl::span<const uint8_t> public_key,
                                       gsl::span<const uint8_t> seed) const;
 
+    /**
+     * Load key file contents without validation. The file may not exist.
+     * Used when --node-key-file flag is specified.
+     * @param file_path - path to the key. The contents are raw-bytes or
+     * hex-encoded key
+     * @return file contents. Format interpreting is up to the caller
+     */
+    outcome::result<std::string> loadFileContent(const Path &file_path) const;
+
+    /**
+     * Save key as hex to the specific path.
+     * Used when --node-key-file flag is specified.
+     * @param key_bytes - key contents to save
+     * @param file_path - user-provided path to create the file
+     * @return an error if any
+     */
+    outcome::result<void> saveKeyHexAtPath(
+        gsl::span<const uint8_t> private_key, const Path &path) const;
+
    private:
     explicit KeyFileStorage(Path keystore_path);
 
@@ -76,8 +95,6 @@ namespace kagome::crypto {
 
     Path composeKeyPath(KeyTypeId key_type,
                         gsl::span<const uint8_t> public_key) const;
-
-    outcome::result<std::string> loadFileContent(const Path &file_path) const;
 
     Path keystore_path_;
     log::Logger logger_;

--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -465,9 +465,7 @@ namespace {
     auto log = log::createLogger("injector", "kagome");
 
     if (app_config.nodeKey()) {
-      log->info(
-          "Will use LibP2P keypair from config or args (loading from node-key "
-          "flag)");
+      log->info("Will use LibP2P keypair from config or 'node-key' CLI arg");
 
       auto provided_keypair =
           crypto_provider.generateKeypair(app_config.nodeKey().value());
@@ -490,8 +488,7 @@ namespace {
     if (app_config.nodeKeyFile()) {
       const auto &path = app_config.nodeKeyFile().value();
       log->info(
-          "Will use LibP2P keypair from config or args (loading from "
-          "node-key-file flag)");
+          "Will use LibP2P keypair from config or 'node-key-file' CLI arg");
       auto key = crypto_store.loadLibp2pKeypair(path);
       if (key.has_error()) {
         log->error("Unable to load user provided key from {}. Error: {}",

--- a/test/mock/core/application/app_configuration_mock.hpp
+++ b/test/mock/core/application/app_configuration_mock.hpp
@@ -30,6 +30,8 @@ namespace kagome::application {
     MOCK_CONST_METHOD0(nodeKey,
                        const boost::optional<crypto::Ed25519PrivateKey> &());
 
+    MOCK_CONST_METHOD0(nodeKeyFile, const boost::optional<std::string> &());
+
     MOCK_CONST_METHOD0(listenAddresses,
                        const std::vector<libp2p::multi::Multiaddress> &());
 

--- a/test/mock/core/crypto/crypto_store_mock.hpp
+++ b/test/mock/core/crypto/crypto_store_mock.hpp
@@ -33,12 +33,17 @@ namespace kagome::crypto {
     MOCK_CONST_METHOD2(
         findSr25519Keypair,
         outcome::result<Sr25519Keypair>(KeyTypeId, const Sr25519PublicKey &));
-    MOCK_CONST_METHOD1(getEd25519PublicKeys, outcome::result<Ed25519Keys>(KeyTypeId));
-    MOCK_CONST_METHOD1(getSr25519PublicKeys, outcome::result<Sr25519Keys>(KeyTypeId));
+    MOCK_CONST_METHOD1(getEd25519PublicKeys,
+                       outcome::result<Ed25519Keys>(KeyTypeId));
+    MOCK_CONST_METHOD1(getSr25519PublicKeys,
+                       outcome::result<Sr25519Keys>(KeyTypeId));
 
     MOCK_CONST_METHOD0(getGrandpaKeypair, boost::optional<Ed25519Keypair>());
     MOCK_CONST_METHOD0(getBabeKeypair, boost::optional<Sr25519Keypair>());
-    MOCK_CONST_METHOD0(getLibp2pKeypair, boost::optional<libp2p::crypto::KeyPair>());
+    MOCK_CONST_METHOD0(getLibp2pKeypair,
+                       boost::optional<libp2p::crypto::KeyPair>());
+    MOCK_CONST_METHOD1(loadLibp2pKeypair,
+                 outcome::result<libp2p::crypto::KeyPair>(const Path &));
   };
 }  // namespace kagome::crypto
 


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

https://github.com/soramitsu/kagome/issues/686

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change

Implements flag handling the same way as substrate does.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

The flag "--node-key-type" is still ignored. That does not seem to be an issue now due to the single supported key type according to the spec is "ed25519", thus it gets assumed to be the default value when the flag is missing.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->

Lack of tests. Waiting for coverage report

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

<!-- ### Alternate Designs Optional -->

<!-- Explain what other alternates were considered and why the proposed version was selected -->
