### PR TITLE
Fix compatibility with Polkadot JS explorer app 

### DIFF
--- a/core/api/jrpc/value_converter.hpp
+++ b/core/api/jrpc/value_converter.hpp
@@ -19,6 +19,7 @@
 #include "primitives/digest.hpp"
 #include "primitives/event_types.hpp"
 #include "primitives/extrinsic.hpp"
+#include "primitives/rpc_methods.hpp"
 #include "primitives/runtime_dispatch_info.hpp"
 #include "primitives/version.hpp"
 #include "scale/scale.hpp"
@@ -63,6 +64,7 @@ namespace kagome::api {
   inline jsonrpc::Value makeValue(const primitives::BlockHeader &);
   inline jsonrpc::Value makeValue(const primitives::Version &);
   inline jsonrpc::Value makeValue(const primitives::Justification &);
+  inline jsonrpc::Value makeValue(const primitives::RpcMethods &);
 
   inline jsonrpc::Value makeValue(const uint32_t &val) {
     return static_cast<int64_t>(val);
@@ -203,6 +205,13 @@ namespace kagome::api {
 
   inline jsonrpc::Value makeValue(const primitives::Justification &val) {
     return makeValue(val.data);
+  }
+
+  inline jsonrpc::Value makeValue(const primitives::RpcMethods &v) {
+    jStruct res;
+    res["version"] = makeValue(v.version);
+    res["methods"] = makeValue(v.methods);
+    return res;
   }
 
   inline jsonrpc::Value makeValue(const primitives::BlockData &val) {

--- a/core/api/service/chain/impl/chain_api_impl.cpp
+++ b/core/api/service/chain/impl/chain_api_impl.cpp
@@ -86,9 +86,11 @@ namespace kagome::api {
 
   outcome::result<void> ChainApiImpl::unsubscribeFinalizedHeads(
       uint32_t subscription_id) {
-    if (auto api_service = api_service_.lock())
-      return api_service->unsubscribeFinalizedHeads(subscription_id)
-          .as_failure();
+    if (auto api_service = api_service_.lock()) {
+      OUTCOME_TRY(api_service->unsubscribeFinalizedHeads(subscription_id));
+      // any non-error result is considered as success
+      return outcome::success();
+    }
 
     throw jsonrpc::InternalErrorFault(
         "Internal error. Api service not initialized.");

--- a/core/api/service/rpc/requests/methods.cpp
+++ b/core/api/service/rpc/requests/methods.cpp
@@ -18,8 +18,11 @@ namespace kagome::api::rpc::request {
     return outcome::success();
   }
 
-  outcome::result<std::vector<std::string>> Methods::execute() {
-    return api_->methods();
+  outcome::result<primitives::RpcMethods> Methods::execute() {
+    OUTCOME_TRY(methods, api_->methods());
+    primitives::RpcMethods result;
+    result.methods = std::move(methods);
+    return result;
   }
 
 }  // namespace kagome::api::rpc::request

--- a/core/api/service/rpc/requests/methods.hpp
+++ b/core/api/service/rpc/requests/methods.hpp
@@ -10,6 +10,7 @@
 #include <boost/assert.hpp>
 
 #include "outcome/outcome.hpp"
+#include "primitives/rpc_methods.hpp"
 
 namespace kagome::api {
   class RpcApi;
@@ -36,7 +37,7 @@ namespace kagome::api::rpc::request {
 
     outcome::result<void> init(const jsonrpc::Request::Parameters &params);
 
-    outcome::result<std::vector<std::string>> execute();
+    outcome::result<primitives::RpcMethods> execute();
 
    private:
     std::shared_ptr<RpcApi> api_;

--- a/core/primitives/rpc_methods.hpp
+++ b/core/primitives/rpc_methods.hpp
@@ -1,0 +1,47 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_CORE_PRIMITIVES_RPC_METHODS_HPP
+#define KAGOME_CORE_PRIMITIVES_RPC_METHODS_HPP
+
+#include <string>
+#include <vector>
+
+namespace kagome::primitives {
+
+  // The version number is just hardcoded in substrate implementation
+  // https://github.com/paritytech/substrate/blob/8060a437dc01cc247a757fb318a46f81c8e40d5c/client/rpc-servers/src/lib.rs#L59
+  static constexpr uint32_t kRpcMethodsVersion = 1;
+
+  /**
+   * A descriptor for a set of methods supported via RPC
+   */
+  struct RpcMethods {
+    using Version = uint32_t;
+    using Methods = std::vector<std::string>;
+
+    /// Descriptor version
+    Version version = kRpcMethodsVersion;
+
+    /// A set of methods names as strings
+    Methods methods;
+  };
+
+  template <typename Stream,
+            typename = std::enable_if_t<Stream::is_encoder_stream>>
+  Stream &operator<<(Stream &s, const RpcMethods &v) {
+    return s << s.version << s.methods;
+  }
+
+  template <typename Stream,
+            typename = std::enable_if_t<Stream::is_decoder_stream>>
+  Stream &operator>>(Stream &s, RpcMethods &v) {
+    s >> v.version >> v.methods;
+    return s;
+  }
+
+}  // namespace kagome::primitives
+
+#endif  // KAGOME_CORE_PRIMITIVES_RPC_METHODS_HPP


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

Addresses #713 

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change

The change updates the response format to the "rpc_methods" query. The "version" field was introduced.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Kagome gets able to be browsed via Polkadot JS explorer.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

None.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->

```bash
cd examples/polkadot 
kagome_validating --ws-port 9944 --dev
```
then go to 

https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/explorer


<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->
