### PR TITLE
Install missing log headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ add_subdirectory(core)
 kagome_install_setup(
     HEADER_DIRS
     core/common
+    core/log
     core/blockchain
     core/primitives
     core/macro


### PR DESCRIPTION
### Referenced issues

When soralog was integrated with kagome with #692 all logging code was moved to the log subfolder. However the headers from this folder are currently not installed.

### Description of the Change

The headers in the log subfolder are now installed.

### Benefits

Downstream targets can initialize the new logging backend which is a requirement to run most kagome code.

### Possible Drawbacks 

Slight increase of used disk space.