### PR TITLE
Add support for --ws-max-connections CLI argument

### DIFF
--- a/core/api/transport/impl/ws/ws_listener_impl.hpp
+++ b/core/api/transport/impl/ws/ws_listener_impl.hpp
@@ -58,6 +58,7 @@ namespace kagome::api {
 
     std::atomic<Session::SessionId> next_session_id_;
     std::shared_ptr<SessionImpl> new_session_;
+    std::atomic<uint32_t> active_connections_;
 
     log::Logger logger_;
   };

--- a/core/api/transport/listener.hpp
+++ b/core/api/transport/listener.hpp
@@ -29,7 +29,12 @@ namespace kagome::api {
     using Context = RpcContext;
 
     struct Configuration {
-      Endpoint endpoint{};  ///< listning endpoint
+      /// listening endpoint
+      Endpoint endpoint{};
+
+      /// max allowed simultaneous connections through websocket
+      uint32_t ws_max_connections;
+
       Configuration() {
         endpoint.address(boost::asio::ip::address_v4::any());
         endpoint.port(0);

--- a/core/application/app_configuration.hpp
+++ b/core/application/app_configuration.hpp
@@ -103,6 +103,11 @@ namespace kagome::application {
     virtual const boost::asio::ip::tcp::endpoint &rpcWsEndpoint() const = 0;
 
     /**
+     * @return maximum number of WS RPC connections
+     */
+    virtual uint32_t maxWsConnections() const = 0;
+
+    /**
      * @return log level (0-trace, 5-only critical, 6-no logs).
      */
     virtual log::Level verbosity() const = 0;

--- a/core/application/impl/app_configuration_impl.cpp
+++ b/core/application/impl/app_configuration_impl.cpp
@@ -36,12 +36,13 @@ namespace {
   const std::string def_rpc_ws_host = "0.0.0.0";
   const uint16_t def_rpc_http_port = 9933;
   const uint16_t def_rpc_ws_port = 9944;
+  const uint32_t def_ws_max_connections = 100;
   const uint16_t def_p2p_port = 30363;
   const int def_verbosity = static_cast<int>(kagome::log::Level::INFO);
   const bool def_is_already_synchronized = false;
   const bool def_is_unix_slots_strategy = false;
   const bool def_dev_mode = false;
-  const kagome::network::Roles def_roles = []{
+  const kagome::network::Roles def_roles = [] {
     kagome::network::Roles roles;
     roles.flags.full = 1;
     return roles;
@@ -80,7 +81,8 @@ namespace kagome::application {
         rpc_http_port_(def_rpc_http_port),
         rpc_ws_port_(def_rpc_ws_port),
         dev_mode_(def_dev_mode),
-        node_name_(randomNodeName()) {}
+        node_name_(randomNodeName()),
+        max_ws_connections_(def_ws_max_connections) {}
 
   fs::path AppConfigurationImpl::chainSpecPath() const {
     return chain_spec_path_.native();
@@ -174,7 +176,7 @@ namespace kagome::application {
   void AppConfigurationImpl::parse_general_segment(rapidjson::Value &val) {
     bool validator_mode = false;
     load_bool(val, "validator", validator_mode);
-    if (validator_mode){
+    if (validator_mode) {
       roles_.flags.authority = 1;
     }
 
@@ -209,6 +211,7 @@ namespace kagome::application {
     load_u16(val, "rpc-port", rpc_http_port_);
     load_str(val, "ws-host", rpc_ws_host_);
     load_u16(val, "ws-port", rpc_ws_port_);
+    load_u32(val, "ws-max-connections", max_ws_connections_);
     load_str(val, "name", node_name_);
   }
 
@@ -360,6 +363,7 @@ namespace kagome::application {
         ("rpc-port", po::value<uint16_t>(), "port for RPC over HTTP")
         ("ws-host", po::value<std::string>(), "address for RPC over Websocket protocol")
         ("ws-port", po::value<uint16_t>(), "port for RPC over Websocket protocol")
+        ("ws-max-connections", po::value<uint32_t>(), "maximum number of WS RPC server connections")
         ("max-blocks-in-response", po::value<int>(), "max block per response while syncing")
         ("name", po::value<std::string>(), "the human-readable name for this node")
         ;
@@ -648,6 +652,10 @@ namespace kagome::application {
 
     find_argument<uint16_t>(
         vm, "ws-port", [&](uint16_t val) { rpc_ws_port_ = val; });
+
+    find_argument<uint32_t>(vm, "ws-max-connections", [&](uint32_t val) {
+      max_ws_connections_ = val;
+    });
 
     rpc_http_endpoint_ = get_endpoint_from(rpc_http_host_, rpc_http_port_);
     rpc_ws_endpoint_ = get_endpoint_from(rpc_ws_host_, rpc_ws_port_);

--- a/core/application/impl/app_configuration_impl.hpp
+++ b/core/application/impl/app_configuration_impl.hpp
@@ -100,6 +100,9 @@ namespace kagome::application {
     const boost::asio::ip::tcp::endpoint &rpcWsEndpoint() const override {
       return rpc_ws_endpoint_;
     }
+    uint32_t maxWsConnections() const override {
+      return max_ws_connections_;
+    }
     log::Level verbosity() const override {
       return verbosity_;
     }
@@ -192,6 +195,7 @@ namespace kagome::application {
     network::PeeringConfig peering_config_;
     bool dev_mode_;
     std::string node_name_;
+    uint32_t max_ws_connections_;
   };
 
 }  // namespace kagome::application

--- a/test/core/api/transport/listener_test.hpp
+++ b/test/core/api/transport/listener_test.hpp
@@ -86,6 +86,7 @@ struct ListenerTest : public ::testing::Test {
     typename ListenerImpl::Configuration config{};
     config.endpoint.address(boost::asio::ip::address::from_string("127.0.0.1"));
     config.endpoint.port(4321);
+    config.ws_max_connections = 100;
     return config;
   }();
 

--- a/test/mock/core/application/app_configuration_mock.hpp
+++ b/test/mock/core/application/app_configuration_mock.hpp
@@ -46,6 +46,8 @@ namespace kagome::application {
 
     MOCK_CONST_METHOD0(rpcWsEndpoint, const boost::asio::ip::tcp::endpoint &());
 
+    MOCK_CONST_METHOD0(maxWsConnections, uint32_t());
+
     MOCK_CONST_METHOD0(verbosity, log::Level());
 
     MOCK_CONST_METHOD0(isAlreadySynchronized, bool());


### PR DESCRIPTION
Limits the number of simultaneous WS RPC connections

Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

https://github.com/soramitsu/kagome/issues/690

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change

Add support for `--ws-max-connections` CLI argument that limits the number of simultaneous WS RPC connections.

The default value is taken from [substrate implementation](https://github.com/paritytech/substrate/blob/c93ef27486e5f14696e5b6d36edafea7936edbc8/client/rpc-servers/src/lib.rs#L34) and equals 100.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

🎉 

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

➖ 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->

```bash
# here you can play around with the command using different values for the argument
kagome --dev --ws-port 9944 --ws-max-connections 2
```
Try to connect to instance from [Polkadot Explorer JS app](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/explorer) from several browser tabs
or any WS terminal like [this](https://chrome.google.com/webstore/detail/dark-websocket-terminal/dmogdjmcpfaibncngoolgljgocdabhke?hl=en) to the addr `ws://127.0.0.1:9944`.

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

<!-- ### Alternate Designs  Optional -->

<!-- Explain what other alternates were considered and why the proposed version was selected -->
