### PR TITLE
Fix recognition of genesis slot number

### DIFF
--- a/core/consensus/babe/impl/babe_util_impl.hpp
+++ b/core/consensus/babe/impl/babe_util_impl.hpp
@@ -33,11 +33,14 @@ namespace kagome::consensus {
     outcome::result<EpochDescriptor> getLastEpoch() const override;
 
    private:
+    BabeSlotNumber getGenesisSlotNumber();
+
     std::shared_ptr<primitives::BabeConfiguration> babe_configuration_;
     std::shared_ptr<kagome::storage::BufferStorage> storage_;
+    const SlotsStrategy strategy_;
+    const BabeClock &clock_;
 
-    BabeSlotNumber genesis_slot_number_;
-    BabeSlotNumber epoch_length_;
+    boost::optional<BabeSlotNumber> genesis_slot_number_;
 
     // optimization for storing in memory last epoch
     boost::optional<EpochDescriptor> last_epoch_;

--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -191,7 +191,7 @@ namespace {
         db,
         hasher,
         [&](const primitives::Block &genesis_block) {
-          auto log = log::createLogger("Injector", "kagome");
+          auto log = log::createLogger("Injector", "injector");
 
           auto res = db->get(authority::AuthorityManagerImpl::SCHEDULER_TREE);
           if (not res.has_value()
@@ -330,7 +330,7 @@ namespace {
       common::raise(batch.error());
     }
 
-    auto log = log::createLogger("Injector", "kagome");
+    auto log = log::createLogger("Injector", "injector");
 
     const auto &genesis_raw_configs = configuration_storage->getGenesis();
 
@@ -364,7 +364,7 @@ namespace {
     auto db_res = storage::LevelDB::create(
         app_config.databasePath(chain_spec->id()), options);
     if (!db_res) {
-      auto log = log::createLogger("Injector", "kagome");
+      auto log = log::createLogger("Injector", "injector");
       log->critical("Can't create LevelDB in {}: {}",
                     fs::absolute(app_config.databasePath(chain_spec->id()),
                                  fs::current_path())
@@ -390,7 +390,7 @@ namespace {
     auto chain_spec_res =
         application::ChainSpecImpl::loadFrom(chainspec_path.native());
     if (not chain_spec_res.has_value()) {
-      auto log = log::createLogger("Injector", "kagome");
+      auto log = log::createLogger("Injector", "injector");
       log->critical(
           "Can't load chain spec from {}: {}",
           fs::absolute(chainspec_path.native(), fs::current_path()).native(),
@@ -419,7 +419,7 @@ namespace {
     auto configuration = std::make_shared<primitives::BabeConfiguration>(
         std::move(configuration_res.value()));
 
-    auto log = log::createLogger("Injector", "kagome");
+    auto log = log::createLogger("Injector", "injector");
     for (const auto &authority : configuration->genesis_authorities) {
       SL_DEBUG(log, "Babe authority: {}", authority.id.id.toHex());
     }
@@ -475,7 +475,7 @@ namespace {
       return initialized.value();
     }
 
-    auto log = log::createLogger("Injector", "kagome");
+    auto log = log::createLogger("Injector", "injector");
 
     if (app_config.nodeKey()) {
       log->info("Will use LibP2P keypair from config or 'node-key' CLI arg");
@@ -1067,7 +1067,7 @@ namespace {
         injector.template create<const crypto::CryptoStore &>();
     auto &&sr25519_kp = crypto_store.getBabeKeypair();
     if (not sr25519_kp) {
-      auto log = log::createLogger("Injector", "kagome");
+      auto log = log::createLogger("Injector", "injector");
       log->error("Failed to get BABE keypair");
       return {};
     }
@@ -1094,7 +1094,7 @@ namespace {
         injector.template create<const crypto::CryptoStore &>();
     auto &&ed25519_kp = crypto_store.getGrandpaKeypair();
     if (not ed25519_kp) {
-      auto log = log::createLogger("Injector", "kagome");
+      auto log = log::createLogger("Injector", "injector");
       log->error("Failed to get GRANDPA keypair");
       return {};
     }
@@ -1143,7 +1143,7 @@ namespace {
     std::vector<libp2p::multi::Multiaddress> public_addrs =
         config.publicAddresses();
 
-    auto log = log::createLogger("Injector", "kagome");
+    auto log = log::createLogger("Injector", "injector");
     for (auto &addr : listen_addrs) {
       SL_DEBUG(log, "Peer listening on multiaddr: {}", addr.getStringAddress());
     }

--- a/core/log/configurator.cpp
+++ b/core/log/configurator.cpp
@@ -26,6 +26,7 @@ groups:
         level: off
       - name: kagome
         children:
+          - name: injector
           - name: application
           - name: rpc
             children:


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues
Resolves #750

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
Previously genesis slot number was calculating with assumption as it is prodused right now. Next runnings gets thet from saved epoch digest, which updated in block #1 usually.
Now genesis slot number is predicted and renew a when the next digest of epoch received.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Error is fixed

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None

