### PR TITLE
fix python example

### DIFF
--- a/core/api/service/chain/chain_jrpc_processor.cpp
+++ b/core/api/service/chain/chain_jrpc_processor.cpp
@@ -31,6 +31,8 @@ namespace kagome::api::chain {
   void ChainJrpcProcessor::registerHandlers() {
     server_->registerHandler("chain_getBlockHash",
                              Handler<request::GetBlockhash>(api_));
+    server_->registerHandler("chain_getHead",
+                             Handler<request::GetBlockhash>(api_));
 
     server_->registerHandler("chain_getHeader",
                              Handler<request::GetHeader>(api_));

--- a/core/consensus/babe/impl/babe_impl.cpp
+++ b/core/consensus/babe/impl/babe_impl.cpp
@@ -87,6 +87,7 @@ namespace kagome::consensus::babe {
     }
 
     EpochDescriptor last_epoch_descriptor;
+    const auto now = clock_->now();
     if (auto res = babe_util_->getLastEpoch(); res.has_value()) {
       last_epoch_descriptor = res.value();
     } else {
@@ -95,18 +96,19 @@ namespace kagome::consensus::babe {
           last_epoch_descriptor.start_slot = 0;
           break;
         case SlotsStrategy::FromUnixEpoch:
-          const auto now = clock_->now();
           auto time_since_epoch = now.time_since_epoch();
 
           auto ticks_since_epoch = time_since_epoch.count();
           last_epoch_descriptor.start_slot = static_cast<BabeSlotNumber>(
-              ticks_since_epoch / babe_configuration_->slot_duration.count());
+              ticks_since_epoch / babe_configuration_->slot_duration.count()) + 1;
           break;
       }
 
       last_epoch_descriptor.epoch_number = 0;
+
       last_epoch_descriptor.starting_slot_finish_time = closestNextTimeMultiple(
-          std::chrono::system_clock::now(), babe_configuration_->slot_duration);
+          now, babe_configuration_->slot_duration);
+
     }
 
     auto [number, hash] = block_tree_->deepestLeaf();

--- a/core/crypto/hasher.hpp
+++ b/core/crypto/hasher.hpp
@@ -15,6 +15,7 @@ namespace kagome::crypto {
     using Hash64 = common::Hash64;
     using Hash128 = common::Hash128;
     using Hash256 = common::Hash256;
+    using Hash512 = common::Hash512;
 
    public:
     virtual ~Hasher() = default;
@@ -74,6 +75,13 @@ namespace kagome::crypto {
      * @return 256-bit hash value
      */
     virtual Hash256 sha2_256(gsl::span<const uint8_t> buffer) const = 0;
+
+    /**
+     * @brief blake2b_512 function calculates 64-byte blake2b hash
+     * @param buffer source value
+     * @return 512-bit hash value
+     */
+    virtual Hash512 blake2b_512(gsl::span<const uint8_t> buffer) const = 0;
   };
 }  // namespace kagome::crypto
 

--- a/core/crypto/hasher.hpp
+++ b/core/crypto/hasher.hpp
@@ -56,6 +56,13 @@ namespace kagome::crypto {
     virtual Hash256 blake2b_256(gsl::span<const uint8_t> buffer) const = 0;
 
     /**
+     * @brief blake2b_512 function calculates 64-byte blake2b hash
+     * @param buffer source value
+     * @return 512-bit hash value
+     */
+    virtual Hash512 blake2b_512(gsl::span<const uint8_t> buffer) const = 0;
+
+    /**
      * @brief keccak_256 function calculates 32-byte keccak hash
      * @param buffer source value
      * @return 256-bit hash value
@@ -75,13 +82,6 @@ namespace kagome::crypto {
      * @return 256-bit hash value
      */
     virtual Hash256 sha2_256(gsl::span<const uint8_t> buffer) const = 0;
-
-    /**
-     * @brief blake2b_512 function calculates 64-byte blake2b hash
-     * @param buffer source value
-     * @return 512-bit hash value
-     */
-    virtual Hash512 blake2b_512(gsl::span<const uint8_t> buffer) const = 0;
   };
 }  // namespace kagome::crypto
 

--- a/core/crypto/hasher/hasher_impl.cpp
+++ b/core/crypto/hasher/hasher_impl.cpp
@@ -16,6 +16,7 @@
 namespace kagome::crypto {
   using common::Hash128;
   using common::Hash256;
+  using common::Hash512;
   using common::Hash64;
 
   Hash64 HasherImpl::twox_64(gsl::span<const uint8_t> buffer) const {
@@ -39,6 +40,12 @@ namespace kagome::crypto {
   Hash256 HasherImpl::blake2b_256(gsl::span<const uint8_t> buffer) const {
     Hash256 out;
     blake2b(out.data(), 32, nullptr, 0, buffer.data(), buffer.size());
+    return out;
+  }
+
+  Hash512 HasherImpl::blake2b_512(gsl::span<const uint8_t> buffer) const {
+    Hash512 out;
+    blake2b(out.data(), 64, nullptr, 0, buffer.data(), buffer.size());
     return out;
   }
 

--- a/core/crypto/hasher/hasher_impl.hpp
+++ b/core/crypto/hasher/hasher_impl.hpp
@@ -29,6 +29,8 @@ namespace kagome::crypto {
     Hash256 blake2s_256(gsl::span<const uint8_t> buffer) const override;
 
     Hash256 sha2_256(gsl::span<const uint8_t> buffer) const override;
+
+    Hash512 blake2b_512(gsl::span<const uint8_t> buffer) const override;
   };
 
 }  // namespace kagome::hash

--- a/core/primitives/ss58_codec.cpp
+++ b/core/primitives/ss58_codec.cpp
@@ -28,7 +28,7 @@ namespace kagome::primitives {
       const crypto::Hasher &hasher) {
     constexpr auto PREFIX = "SS58PRE";
     auto preimage = common::Buffer{}.put(PREFIX).put(ss58_address);
-    auto checksum = hasher.blake2b_256(preimage);
+    auto checksum = hasher.blake2b_512(preimage);
     return common::Buffer{
         gsl::make_span(checksum).subspan(0, kSs58ChecksumLength)};
   }

--- a/docs/source/tutorials/first_kagome_chain.md
+++ b/docs/source/tutorials/first_kagome_chain.md
@@ -74,7 +74,8 @@ kagome \
     --port 30363 \
     --rpc-port 9933 \
     --ws-port 9944 \
-    --already-synchronized
+    --already-synchronized \
+    --unix-slots
 ```
 
 Let's look at this flags in detail:
@@ -88,6 +89,7 @@ Let's look at this flags in detail:
 | `--rpc-port` | port for RPC over HTTP                            |
 | `--ws-port`   | port for RPC over Websocket protocol              |
 | `--already-synchronized`   | need to be set if need to be considered synchronized              |
+|  --unix-slots    | need to be set if slots are calculated from unix epoch |
 
 More flags info available by running `kagome --help`.
 
@@ -120,13 +122,13 @@ Let's query current balance of Alice's account.
 
 ```shell script
 python3 balance.py localhost:9933 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-# Current free balance: 999998897.549684  
+# Current free balance: 10000.0  
 ```
 
 Let's do the same for the Bob's account.
 ```shell script
 python3 balance.py localhost:9933 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
-# Current free balance: 999998901.0  
+# Current free balance: 10000.0  
 ```
 
 #### Send extrinsic
@@ -138,7 +140,7 @@ This command will create extrinsic that transfers 1000 from Alice to Bob's accou
 To send extrinsic use `transfer.py` script as follows:
 ```shell script
 python3 transfer.py localhost:9933 0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty 1
-# Extrinsic submitted. Response:  {'jsonrpc': '2.0', 'id': 1, 'result': [39, 212, 157, 212, 66, 199, 109, 255, 180, 146, 47, 243, 118, 221, 233, 172, 35, 201, 157, 96, 248, 24, 22, 14, 230, 108, 217, 211, 29, 216, 65, 255]} 
+Extrinsic '0x315060176633a3e20656bd15c6eceff63b9f8bdc45595dc8ad52a02ae38d1708' sent
 ```
 
 #### Query again the balances
@@ -149,14 +151,14 @@ Get the balance of Bob's account:
 
 ```shell script
 python3 balance.py localhost:9933 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
-# Current free balance: 999998902.0  
+# Current free balance: 10001.0  
 ```
 We can see that Bob's balance was increased by 1 as it was set on the subkey command
 
 Now let's check Alice's account:
 ```shell script
 python3 balance.py localhost:9933 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-Current free balance: 999998895.0993682  
+Current free balance: 9999.0  
 ```
 
 We can see that Alice's account was decreased by more than 1. This is caused by the commission paid for transfer

--- a/docs/source/tutorials/first_kagome_chain.md
+++ b/docs/source/tutorials/first_kagome_chain.md
@@ -135,7 +135,7 @@ python3 balance.py localhost:9933 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694
 
 We can generate extrinsic using the following command:
 
-This command will create extrinsic that transfers 1000 from Alice to Bob's account (Alice's account is defined by secret seed and Bob's account by account id). To define on which blockchain this extrinsic is going to be executed we provide subkey with genesis hash `b86008325a917cd553b122702d1346bf6f132db4ea17155a9eec733413dc9ecf` which corresponds to the hash of the genesis block of our chain.
+This command will create extrinsic that transfers 1 from Alice to Bob's account (Alice's account is defined by secret seed and Bob's account by account id).
 
 To send extrinsic use `transfer.py` script as follows:
 ```shell script
@@ -158,7 +158,7 @@ We can see that Bob's balance was increased by 1 as it was set on the subkey com
 Now let's check Alice's account:
 ```shell script
 python3 balance.py localhost:9933 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-Current free balance: 9999.0  
+Current free balance: 9998.999829217584  
 ```
 
 We can see that Alice's account was decreased by more than 1. This is caused by the commission paid for transfer

--- a/examples/transfer/transfer.py
+++ b/examples/transfer/transfer.py
@@ -1,6 +1,7 @@
 import requests
 import sys
-from substrateinterface import SubstrateInterface, SubstrateRequestException, Keypair
+from substrateinterface import SubstrateInterface, Keypair
+from substrateinterface.exceptions import SubstrateRequestException
 
 
 def main():

--- a/test/core/api/service/system/system_api_test.cpp
+++ b/test/core/api/service/system/system_api_test.cpp
@@ -82,8 +82,8 @@ TEST_F(SystemApiTest, GetNonceNoPendingTxs) {
       .WillOnce(Return(kInitialNonce));
   auto hash_preimage = Buffer{}.put("SS58PRE").putUint8(42).put(kAccountId);
   EXPECT_CALL(*hasher_mock_,
-              blake2b_256(gsl::span<const uint8_t>(hash_preimage)))
-      .WillOnce(Return(kagome::common::Hash256{{'\035', '!'}}));
+              blake2b_512(gsl::span<const uint8_t>(hash_preimage)))
+      .WillOnce(Return(kagome::common::Hash512{{'\035', '!'}}));
   EXPECT_CALL(*transaction_pool_mock_, getReadyTransactions());
 
   EXPECT_OUTCOME_TRUE(nonce, system_api_->getNonceFor(kSs58Account))
@@ -103,8 +103,8 @@ TEST_F(SystemApiTest, GetNonceWithPendingTxs) {
       .WillOnce(Return(kInitialNonce));
   auto hash_preimage = Buffer{}.put("SS58PRE").putUint8(42).put(kAccountId);
   EXPECT_CALL(*hasher_mock_,
-              blake2b_256(gsl::span<const uint8_t>(hash_preimage)))
-      .WillOnce(Return(kagome::common::Hash256{{'\035', '!'}}));
+              blake2b_512(gsl::span<const uint8_t>(hash_preimage)))
+      .WillOnce(Return(kagome::common::Hash512{{'\035', '!'}}));
 
   constexpr auto kReadyTxNum = 5;
   std::array<std::vector<uint8_t>, kReadyTxNum> encoded_nonces;

--- a/test/core/crypto/hasher/hasher_test.cpp
+++ b/test/core/crypto/hasher/hasher_test.cpp
@@ -121,6 +121,21 @@ TEST_F(HasherFixture, blake2_256) {
 
 /**
  * @given some common source value
+ * @when Hasher::blake2_512 method is applied
+ * @then expected result obtained
+ */
+TEST_F(HasherFixture, blake2_512) {
+  Buffer buffer = Buffer{}.put("SS58PRE").put(
+      "2ad43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"_unhex);
+  std::vector<uint8_t> match =
+      "1d21e05182aa937aaad71638832ee54547597e374b1bbe6560c9b2f4f738034fc6160de68c76191cc0b5208566e6bb1a3b663429fa580d0f1be7c8f79baf9b97"_unhex;
+
+  auto hash = hasher->blake2b_512(buffer);
+  ASSERT_EQ(blob2buffer<64>(hash).asVector(), match);
+}
+
+/**
+ * @given some common source value
  * @when Hasher::blake2_128 method is applied
  * @then expected result obtained
  */

--- a/test/core/metrics/metrics_test.cpp
+++ b/test/core/metrics/metrics_test.cpp
@@ -451,7 +451,7 @@ TEST_F(SummaryTest, QuantileValues) {
  */
 TEST_F(SummaryTest, MaxAge) {
   auto summary =
-      createSummary("summary7", {{0.99, 0.001}}, std::chrono::milliseconds(80), 2);
+      createSummary("summary7", {{0.99, 0.001}}, std::chrono::milliseconds(1000), 2);
   summary->observe(8.0);
 
   static const auto test_value = [&summary](double ref) {
@@ -465,8 +465,10 @@ TEST_F(SummaryTest, MaxAge) {
   };
 
   test_value(8.0);
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  // we just check that value remains after a little waiting, if summary window not expired
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
   test_value(8.0);
-  std::this_thread::sleep_for(std::chrono::milliseconds(110));
+  // check that there is no value sometime after expiration
+  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
   test_value(std::numeric_limits<double>::quiet_NaN());
 }

--- a/test/mock/core/crypto/hasher_mock.hpp
+++ b/test/mock/core/crypto/hasher_mock.hpp
@@ -30,6 +30,8 @@ namespace kagome::crypto {
     MOCK_CONST_METHOD1(keccak_256, Hash256(gsl::span<const uint8_t>));
 
     MOCK_CONST_METHOD1(sha2_256, Hash256(gsl::span<const uint8_t>));
+
+    MOCK_CONST_METHOD1(blake2b_512, Hash512(gsl::span<const uint8_t>));
   };
 }  // namespace kagome::crypto
 


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues
resolves #766, #772
<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
* update `first_kagome_example/localchain.json` from `polkadot build-spec --chain=dev`
* fix python transfer script due to updated `substrate-interface` library
* fix ss58 account addresses checksum checking (update to blake2b_512 address hashing)
* fix wasm runtime error "Current Slot must match timestamp slot" by starting from creating block the next time slot
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
babe slot time checking could be suboptimal
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->
hasher_test::blake512 task real account address, and hashes it. thus it is seen that checksum is fine in 2 bytes at the end.
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs <!-- Optional -->
babe slot time checking could be optimized by estimation slot finalization time not just by remainder, but also checking current slot according to UTC time
<!-- Explain what other alternates were considered and why the proposed version was selected -->
