### PR TITLE
Fix Kagome install directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,8 @@ add_subdirectory(core)
 kagome_install_setup(
     HEADER_DIRS
     core/common
+    core/clock
+    core/consensus
     core/log
     core/blockchain
     core/primitives


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

A correct set of install-include directories. Allows using Kagome as a dependency in projects.