### PR TITLE
Add logging group for protocols

### DIFF
--- a/core/log/configurator.cpp
+++ b/core/log/configurator.cpp
@@ -61,6 +61,8 @@ groups:
               - name: binatien
           - name: metrics
           - name: network
+            children:
+              - name: protocols
           - name: changes_trie
           - name: storage
           - name: pubsub

--- a/core/network/protocols/gossip_protocol.hpp
+++ b/core/network/protocols/gossip_protocol.hpp
@@ -70,7 +70,7 @@ namespace kagome::network {
     const OwnPeerInfo &own_info_;
     std::shared_ptr<StreamEngine> stream_engine_;
     const libp2p::peer::Protocol protocol_;
-    log::Logger log_ = log::createLogger("GossipProtocol");
+    log::Logger log_ = log::createLogger("GossipProtocol", "protocols");
   };
 
 }  // namespace kagome::network

--- a/core/network/protocols/grandpa_protocol.hpp
+++ b/core/network/protocols/grandpa_protocol.hpp
@@ -84,7 +84,7 @@ namespace kagome::network {
     const OwnPeerInfo &own_info_;
     std::shared_ptr<StreamEngine> stream_engine_;
     const libp2p::peer::Protocol protocol_;
-    log::Logger log_ = log::createLogger("GrandpaProtocol");
+    log::Logger log_ = log::createLogger("GrandpaProtocol", "protocols");
   };
 
 }  // namespace kagome::network

--- a/core/network/protocols/propagate_transactions_protocol.hpp
+++ b/core/network/protocols/propagate_transactions_protocol.hpp
@@ -86,7 +86,7 @@ namespace kagome::network {
     std::shared_ptr<ExtrinsicObserver> extrinsic_observer_;
     std::shared_ptr<StreamEngine> stream_engine_;
     const libp2p::peer::Protocol protocol_;
-    log::Logger log_ = log::createLogger("PropagateTransactionsProtocol");
+    log::Logger log_ = log::createLogger("PropagateTransactionsProtocol", "protocols");
   };
 
 }  // namespace kagome::network

--- a/core/network/protocols/sup_protocol.hpp
+++ b/core/network/protocols/sup_protocol.hpp
@@ -76,7 +76,7 @@ namespace kagome::network {
     std::shared_ptr<blockchain::BlockStorage> storage_;
     std::shared_ptr<PeerManager> peer_manager_;
     const libp2p::peer::Protocol protocol_;
-    log::Logger log_ = log::createLogger("SupProtocol");
+    log::Logger log_ = log::createLogger("SupProtocol", "protocols");
   };
 
 }  // namespace kagome::network

--- a/core/network/protocols/sync_protocol.hpp
+++ b/core/network/protocols/sync_protocol.hpp
@@ -72,7 +72,7 @@ namespace kagome::network {
     libp2p::Host &host_;
     std::shared_ptr<SyncProtocolObserver> sync_observer_;
     const libp2p::peer::Protocol protocol_;
-    log::Logger log_ = log::createLogger("SyncProtocol");
+    log::Logger log_ = log::createLogger("SyncProtocol", "protocols");
   };
 
 }  // namespace kagome::network


### PR DESCRIPTION
Signed-off-by: Dmitriy Khaustov aka xDimon <khaustov.dm@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues
No specified

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
Added new log group "protocols" and assign protocols' loggers to its.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
More control of protocols' logging

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs <!-- Optional -->

<!-- Explain what other alternates were considered and why the proposed version was selected -->
