### PR TITLE
Fix compilation using clang 12 and GNU GCC 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,8 +74,19 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(AppleClang|Clang|GNU)$")
   add_flag(-Wno-format-nonliteral)   # prints way too many warnings from spdlog
   add_flag(-Wno-gnu-zero-variadic-macro-arguments)   # https://stackoverflow.com/questions/21266380/is-the-gnu-zero-variadic-macro-arguments-safe-to-ignore
 
-  # clang compiler starting from version 12 wont compile when these unknown for it flags are specified
-  if (NOT (("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(AppleClang|Clang)$") AND (${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "12.0")))
+  if (
+      (("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(AppleClang|Clang)$") AND (${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "12.0"))
+      OR
+      (("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(GNU)$") AND (${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "9.0"))
+  )
+    # use new options format for clang >= 12 and gnu >= 9
+    add_flag(-Werror=unused-lambda-capture)  # error if lambda capture is unused
+    add_flag(-Werror=return-type)      # warning: control reaches end of non-void function [-Wreturn-type]
+    add_flag(-Werror=non-virtual-dtor) # warn the user if a class with virtual functions has a non-virtual destructor. This helps catch hard to track down memory errors
+    add_flag(-Werror=sign-compare)     # warn the user if they compare a signed and unsigned numbers
+    add_flag(-Werror=reorder)          # field '$1' will be initialized after field '$2'
+    add_flag(-Werror=mismatched-tags)  # warning: class '$1' was previously declared as struct
+  else()
     # promote to errors
     add_flag(-Werror-unused-lambda-capture)  # error if lambda capture is unused
     add_flag(-Werror-return-type)      # warning: control reaches end of non-void function [-Wreturn-type]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,12 +74,15 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(AppleClang|Clang|GNU)$")
   add_flag(-Wno-format-nonliteral)   # prints way too many warnings from spdlog
   add_flag(-Wno-gnu-zero-variadic-macro-arguments)   # https://stackoverflow.com/questions/21266380/is-the-gnu-zero-variadic-macro-arguments-safe-to-ignore
 
-  # promote to errors
-  add_flag(-Werror-unused-lambda-capture)  # error if lambda capture is unused
-  add_flag(-Werror-return-type)      # warning: control reaches end of non-void function [-Wreturn-type]
-  add_flag(-Werror-non-virtual-dtor) # warn the user if a class with virtual functions has a non-virtual destructor. This helps catch hard to track down memory errors
-  add_flag(-Werror-sign-compare)     # warn the user if they compare a signed and unsigned numbers
-  add_flag(-Werror-reorder)          # field '$1' will be initialized after field '$2'
+  # clang compiler starting from version 12 wont compile when these unknown for it flags are specified
+  if (NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(AppleClang|Clang)$") AND (${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "12.0"))
+    # promote to errors
+    add_flag(-Werror-unused-lambda-capture)  # error if lambda capture is unused
+    add_flag(-Werror-return-type)      # warning: control reaches end of non-void function [-Wreturn-type]
+    add_flag(-Werror-non-virtual-dtor) # warn the user if a class with virtual functions has a non-virtual destructor. This helps catch hard to track down memory errors
+    add_flag(-Werror-sign-compare)     # warn the user if they compare a signed and unsigned numbers
+    add_flag(-Werror-reorder)          # field '$1' will be initialized after field '$2'
+  endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   # using Visual Studio C++
   # TODO(warchant): add flags https://github.com/lefticus/cppbestpractices/blob/master/02-Use_the_Tools_Available.md#msvc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(AppleClang|Clang|GNU)$")
   add_flag(-Wno-gnu-zero-variadic-macro-arguments)   # https://stackoverflow.com/questions/21266380/is-the-gnu-zero-variadic-macro-arguments-safe-to-ignore
 
   # clang compiler starting from version 12 wont compile when these unknown for it flags are specified
-  if (NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(AppleClang|Clang)$") AND (${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "12.0"))
+  if (NOT (("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(AppleClang|Clang)$") AND (${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "12.0")))
     # promote to errors
     add_flag(-Werror-unused-lambda-capture)  # error if lambda capture is unused
     add_flag(-Werror-return-type)      # warning: control reaches end of non-void function [-Wreturn-type]

--- a/core/authorship/impl/block_builder_impl.cpp
+++ b/core/authorship/impl/block_builder_impl.cpp
@@ -51,6 +51,8 @@ namespace kagome::authorship {
               extrinsics_.push_back(extrinsic);
               return extrinsics_.size() - 1;
           }
+          // Not going to happen
+          throw std::runtime_error("Not all ApplyOutcome cases are checked");
         },
         [this, &extrinsic](primitives::ApplyError)
             -> outcome::result<primitives::ExtrinsicIndex> {


### PR DESCRIPTION
Clang 12 c++ compiler won't compile when unknown Werror flags were passed

Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change



<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Now the project is able to be compiled using clang 12 cpp compiler.
GNU GCC 9 will not produce warnings for obsolete flags set too.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

None

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs <!-- Optional -->

<!-- Explain what other alternates were considered and why the proposed version was selected -->
