### PR TITLE
Feature/compressed code

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -78,3 +78,6 @@ find_package(fmt CONFIG REQUIRED)
 
 hunter_add_package(yaml-cpp)
 find_package(yaml-cpp CONFIG REQUIRED)
+
+hunter_add_package(zstd)
+find_package(zstd CONFIG REQUIRED)

--- a/core/runtime/common/CMakeLists.txt
+++ b/core/runtime/common/CMakeLists.txt
@@ -3,14 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-
 add_library(storage_wasm_provider
     storage_wasm_provider.cpp
+    uncompress_code_if_needed.cpp
     )
 target_link_libraries(storage_wasm_provider
-    buffer
     blob
+    buffer
+    zstd::libzstd_static
     )
+kagome_install(storage_wasm_provider)
 
 add_library(const_wasm_provider
     const_wasm_provider.cpp

--- a/core/runtime/common/CMakeLists.txt
+++ b/core/runtime/common/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(storage_wasm_provider
 target_link_libraries(storage_wasm_provider
     blob
     buffer
+    logger
     zstd::libzstd_static
     )
 kagome_install(storage_wasm_provider)

--- a/core/runtime/common/storage_wasm_provider.hpp
+++ b/core/runtime/common/storage_wasm_provider.hpp
@@ -9,8 +9,9 @@
 #include "runtime/wasm_provider.hpp"
 
 namespace kagome::storage::trie {
+  class EphemeralTrieBatch;
   class TrieStorage;
-}
+}  // namespace kagome::storage::trie
 
 namespace kagome::runtime {
 
@@ -27,6 +28,9 @@ namespace kagome::runtime {
         const storage::trie::RootHash &at) const override;
 
    private:
+    void setStateCodeFromBatch(
+        const outcome::result<
+            std::unique_ptr<storage::trie::EphemeralTrieBatch>> &batch) const;
     std::shared_ptr<const storage::trie::TrieStorage> storage_;
     mutable common::Buffer state_code_;
     mutable storage::trie::RootHash last_state_root_;

--- a/core/runtime/common/uncompress_code_if_needed.cpp
+++ b/core/runtime/common/uncompress_code_if_needed.cpp
@@ -1,0 +1,34 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/common/uncompress_code_if_needed.hpp"
+
+#include <zstd.h>
+
+namespace kagome::runtime {
+
+  // @see
+  // https://github.com/paritytech/substrate/blob/polkadot-v0.9.8/primitives/maybe-compressed-blob/src/lib.rs#L28
+  constexpr uint8_t kZstdPrefix[8] = {
+      0x52, 0xBC, 0x53, 0x76, 0x46, 0xDB, 0x8E, 0x05};
+  // @see
+  // https://github.com/paritytech/substrate/blob/polkadot-v0.9.8/primitives/maybe-compressed-blob/src/lib.rs#L35
+  constexpr size_t kCodeBlobBombLimit = 50 * 1024 * 1024;
+
+  void uncompressCodeIfNeeded(const common::Buffer &buf, common::Buffer &res) {
+    if (std::equal(buf.begin(),
+                   buf.begin() + 8,
+                   std::begin(kZstdPrefix),
+                   std::end(kZstdPrefix))) {
+      res.resize(kCodeBlobBombLimit);
+      auto size = ZSTD_decompress(
+          res.data(), kCodeBlobBombLimit, buf.data() + 8, buf.size() - 8);
+      res.resize(size);
+    } else {
+      res = buf;
+    }
+  }
+
+}  // namespace kagome::runtime

--- a/core/runtime/common/uncompress_code_if_needed.cpp
+++ b/core/runtime/common/uncompress_code_if_needed.cpp
@@ -13,24 +13,25 @@ namespace kagome::runtime {
 
   // @see
   // https://github.com/paritytech/substrate/blob/polkadot-v0.9.8/primitives/maybe-compressed-blob/src/lib.rs#L28
-  constexpr uint8_t kZstdPrefix[8] = {
+  constexpr uint8_t kZstdPrefixSize = 8;
+  constexpr uint8_t kZstdPrefix[kZstdPrefixSize] = {
       0x52, 0xBC, 0x53, 0x76, 0x46, 0xDB, 0x8E, 0x05};
   // @see
   // https://github.com/paritytech/substrate/blob/polkadot-v0.9.8/primitives/maybe-compressed-blob/src/lib.rs#L35
   constexpr size_t kCodeBlobBombLimit = 50 * 1024 * 1024;
 
   void uncompressCodeIfNeeded(const common::Buffer &buf, common::Buffer &res) {
-    if (buf.size() > 8
+    if (buf.size() > kZstdPrefixSize
         && std::equal(buf.begin(),
-                      buf.begin() + 8,
+                      buf.begin() + kZstdPrefixSize,
                       std::begin(kZstdPrefix),
                       std::end(kZstdPrefix))) {
       auto logger = log::createLogger("UncompressCodeIfNeeded", "wasm");
       // here we can check that blob is really ZSTD compressed
       // but we don't use the result size, it's unknown for the WASM blob
       // @see ZSTD_CONTENTSIZE_UNKNOWN
-      auto check_size =
-          ZSTD_getFrameContentSize(buf.data() + 8, buf.size() - 8);
+      auto check_size = ZSTD_getFrameContentSize(buf.data() + kZstdPrefixSize,
+                                                 buf.size() - kZstdPrefixSize);
       // error here would mean an update of codebase
       // so we leave it to try the previous runtime if any
       if (check_size == ZSTD_CONTENTSIZE_ERROR) {
@@ -38,8 +39,10 @@ namespace kagome::runtime {
         return;
       }
       res.resize(kCodeBlobBombLimit);
-      auto size = ZSTD_decompress(
-          res.data(), kCodeBlobBombLimit, buf.data() + 8, buf.size() - 8);
+      auto size = ZSTD_decompress(res.data(),
+                                  kCodeBlobBombLimit,
+                                  buf.data() + kZstdPrefixSize,
+                                  buf.size() - kZstdPrefixSize);
       res.resize(size);
     } else {
       res = buf;

--- a/core/runtime/common/uncompress_code_if_needed.hpp
+++ b/core/runtime/common/uncompress_code_if_needed.hpp
@@ -1,0 +1,15 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_CORE_RUNTIME_UNCOMPRESS_IF_NEEDED_HPP
+#define KAGOME_CORE_RUNTIME_UNCOMPRESS_IF_NEEDED_HPP
+
+#include "common/buffer.hpp"
+
+namespace kagome::runtime {
+  void uncompressCodeIfNeeded(const common::Buffer &buf, common::Buffer &res);
+}  // namespace kagome::runtime
+
+#endif  // KAGOME_CORE_RUNTIME_UNCOMPRESS_IF_NEEDED_HPP

--- a/test/core/runtime/CMakeLists.txt
+++ b/test/core/runtime/CMakeLists.txt
@@ -148,3 +148,10 @@ target_link_libraries(trie_storage_provider_test
     trie_serializer
     logger_for_tests
     )
+
+addtest(uncompress_code_test
+    uncompress_code_test.cpp
+    )
+target_link_libraries(uncompress_code_test
+    storage_wasm_provider
+    )

--- a/test/core/runtime/CMakeLists.txt
+++ b/test/core/runtime/CMakeLists.txt
@@ -153,5 +153,6 @@ addtest(uncompress_code_test
     uncompress_code_test.cpp
     )
 target_link_libraries(uncompress_code_test
+    log_configurator
     storage_wasm_provider
     )

--- a/test/core/runtime/uncompress_code_test.cpp
+++ b/test/core/runtime/uncompress_code_test.cpp
@@ -1,0 +1,14 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "runtime/common/uncompress_code_if_needed.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace kagome;  // NOLINT
+using namespace runtime; // NOLINT
+
+TEST(UncompressCodeIfNeeded, GetCodeWhenNoStorageUpdates) {
+  ;
+}

--- a/test/core/runtime/uncompress_code_test.cpp
+++ b/test/core/runtime/uncompress_code_test.cpp
@@ -6,9 +6,51 @@
 
 #include <gtest/gtest.h>
 
-using namespace kagome;  // NOLINT
-using namespace runtime; // NOLINT
+#include "testutil/prepare_loggers.hpp"
 
-TEST(UncompressCodeIfNeeded, GetCodeWhenNoStorageUpdates) {
-  ;
+using namespace kagome;   // NOLINT
+using namespace runtime;  // NOLINT
+
+class UncompressCodeIfNeeded : public ::testing::Test {
+ public:
+  static void SetUpTestCase() {
+    testutil::prepareLoggers();
+  }
+};
+
+TEST_F(UncompressCodeIfNeeded, NotOkSize) {
+  common::Buffer buf(5, 'a');
+  common::Buffer res;
+  uncompressCodeIfNeeded(buf, res);
+  ASSERT_EQ(res, buf);
+}
+
+TEST_F(UncompressCodeIfNeeded, NotNeeded) {
+  common::Buffer buf(9, 'a');
+  common::Buffer res;
+  uncompressCodeIfNeeded(buf, res);
+  ASSERT_EQ(res, buf);
+}
+
+TEST_F(UncompressCodeIfNeeded, NotNeeded2) {
+  common::Buffer buf({0x52, 0xBC, 0x53, 0x76, 0x46, 0xDB, 0x8E, 0x06, 0xFF});
+  common::Buffer res({0xAA});
+  uncompressCodeIfNeeded(buf, res);
+  ASSERT_EQ(res, buf);
+}
+
+TEST_F(UncompressCodeIfNeeded, UncompressFail) {
+  common::Buffer buf({0x52, 0xBC, 0x53, 0x76, 0x46, 0xDB, 0x8E, 0x05, 0xFF});
+  common::Buffer res({0xAA});
+  uncompressCodeIfNeeded(buf, res);
+  ASSERT_EQ(res, common::Buffer({0xAA}));
+}
+
+TEST_F(UncompressCodeIfNeeded, UncompressSucceed) {
+  auto buf =
+      common::Buffer::fromHex("52BC537646DB8E0528B52FFD200421000062616265")
+          .value();
+  common::Buffer res;
+  uncompressCodeIfNeeded(buf, res);
+  ASSERT_EQ(res, common::Buffer({'b', 'a', 'b', 'e'}));
 }


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues
Resolves #797 
<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
add ZSTD uncompress function to WASM code storage provider
update first_kagome_chain with polkadot v0.9.8 dev chain spec
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Now we can use more compressed chainspecs.
Drastically increases node start speed.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Tests possibly rely on ZSTD version, thus will need update
Uncompression would break when new runtime size is greater than kCodeBlobBombLimit. It is true for substrate too.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs <!-- Optional -->

<!-- Explain what other alternates were considered and why the proposed version was selected -->
