### PR TITLE
Block size limit

### DIFF
--- a/core/authorship/CMakeLists.txt
+++ b/core/authorship/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(block_builder
     outcome
     buffer
     logger
+    scale
     )
 
 add_library(block_builder_factory
@@ -33,4 +34,5 @@ add_library(proposer
     )
 target_link_libraries(proposer
     block_builder_factory
+    scale
     )

--- a/core/authorship/block_builder.hpp
+++ b/core/authorship/block_builder.hpp
@@ -30,6 +30,12 @@ namespace kagome::authorship {
      * Create a block from extrinsics and header
      */
     virtual outcome::result<primitives::Block> bake() const = 0;
+
+    /**
+     * Estimate size of encoded block representation
+     * @return size in bytes
+     */
+    virtual size_t estimateBlockSize() const = 0;
   };
 
 }  // namespace kagome::authorship

--- a/core/authorship/impl/block_builder_impl.cpp
+++ b/core/authorship/impl/block_builder_impl.cpp
@@ -91,4 +91,21 @@ namespace kagome::authorship {
     return primitives::Block{finalised_header, extrinsics_};
   }
 
+  size_t BlockBuilderImpl::estimateBlockSize() const {
+    scale::ScaleEncoderStream s(true);
+    for (const auto &xt : extrinsics_) {
+      s << xt;
+    }
+    return estimatedBlockHeaderSize() + s.size();
+  }
+
+  size_t BlockBuilderImpl::estimatedBlockHeaderSize() const {
+    static boost::optional<size_t> size = boost::none;
+    if (not size) {
+      scale::ScaleEncoderStream s(true);
+      s << block_header_;
+      size = s.size();
+    }
+    return size.value();
+  }
 }  // namespace kagome::authorship

--- a/core/authorship/impl/block_builder_impl.hpp
+++ b/core/authorship/impl/block_builder_impl.hpp
@@ -28,7 +28,11 @@ namespace kagome::authorship {
 
     outcome::result<primitives::Block> bake() const override;
 
+    size_t estimateBlockSize() const override;
+
    private:
+    size_t estimatedBlockHeaderSize() const;
+
     primitives::BlockHeader block_header_;
     std::shared_ptr<runtime::BlockBuilder> block_builder_api_;
     log::Logger logger_;

--- a/core/authorship/impl/proposer_impl.hpp
+++ b/core/authorship/impl/proposer_impl.hpp
@@ -18,6 +18,13 @@ namespace kagome::authorship {
 
   class ProposerImpl : public Proposer {
    public:
+    /// Maximum transactions quantity to try to push into the block before
+    /// finalization when resources are exhausted (block size limit reached)
+    static constexpr auto kMaxSkippedTransactions = 8;
+
+    /// Default block size limit in bytes
+    static constexpr size_t kBlockSizeLimit = 4 * 1024 * 1024 + 512;
+
     ~ProposerImpl() override = default;
 
     ProposerImpl(

--- a/core/scale/scale_encoder_stream.cpp
+++ b/core/scale/scale_encoder_stream.cpp
@@ -106,6 +106,12 @@ namespace kagome::scale {
     }
   }  // namespace
 
+  ScaleEncoderStream::ScaleEncoderStream()
+      : drop_data_{false}, bytes_written_{0} {}
+
+  ScaleEncoderStream::ScaleEncoderStream(bool drop_data)
+      : drop_data_{drop_data}, bytes_written_{0} {}
+
   ByteArray ScaleEncoderStream::data() const {
     ByteArray buffer(stream_.size(), 0u);
     for (auto &&[it, dest] = std::pair(stream_.begin(), buffer.begin());
@@ -116,8 +122,15 @@ namespace kagome::scale {
     return buffer;
   }
 
+  size_t ScaleEncoderStream::size() const {
+    return bytes_written_;
+  }
+
   ScaleEncoderStream &ScaleEncoderStream::putByte(uint8_t v) {
-    stream_.push_back(v);
+    ++bytes_written_;
+    if (not drop_data_) {
+      stream_.push_back(v);
+    }
     return *this;
   }
 

--- a/core/scale/scale_encoder_stream.hpp
+++ b/core/scale/scale_encoder_stream.hpp
@@ -23,11 +23,26 @@ namespace kagome::scale {
     // special tag to differentiate encoding streams from others
     static constexpr auto is_encoder_stream = true;
 
+    ScaleEncoderStream();
+
+    /**
+     * Stream initialization
+     * @param drop_data - when true will only count encoded data size while
+     * omitting the data itself
+     */
+    explicit ScaleEncoderStream(bool drop_data);
+
     /// Getters
     /**
      * @return vector of bytes containing encoded data
      */
     std::vector<uint8_t> data() const;
+
+    /**
+     * Get amount of encoded data written to the stream
+     * @return size in bytes
+     */
+    size_t size() const;
 
     /**
      * @brief scale-encodes pair of values
@@ -275,7 +290,10 @@ namespace kagome::scale {
 
    private:
     ScaleEncoderStream &encodeOptionalBool(const boost::optional<bool> &v);
+
+    const bool drop_data_;
     std::deque<uint8_t> stream_;
+    size_t bytes_written_;
   };
 
 }  // namespace kagome::scale

--- a/test/core/authorship/proposer_test.cpp
+++ b/test/core/authorship/proposer_test.cpp
@@ -130,6 +130,8 @@ TEST_F(ProposerTest, CreateBlockSuccess) {
   EXPECT_CALL(*transaction_pool_, removeStale(BlockId(expected_number_)))
       .WillOnce(Return(outcome::success()));
 
+  EXPECT_CALL(*block_builder_, estimateBlockSize()).WillOnce(Return(1));
+
   EXPECT_CALL(*block_builder_, bake()).WillOnce(Return(expected_block));
 
   // when
@@ -179,6 +181,7 @@ TEST_F(ProposerTest, PushFailed) {
       .WillOnce(Return(outcome::failure(
           boost::system::error_code{})));  // for xt from tx pool, will emit
                                            // Error: Success though
+  EXPECT_CALL(*block_builder_, estimateBlockSize()).WillOnce(Return(1));
   EXPECT_CALL(*block_builder_, bake()).WillOnce(Return(expected_block));
 
   std::map<Transaction::Hash, std::shared_ptr<Transaction>> ready_transactions{

--- a/test/core/scale/CMakeLists.txt
+++ b/test/core/scale/CMakeLists.txt
@@ -101,3 +101,10 @@ addtest(scale_array_test
 target_link_libraries(scale_array_test
     scale
     )
+
+addtest(scale_encode_counter_test
+    scale_encode_counter_test.cpp
+    )
+target_link_libraries(scale_encode_counter_test
+    scale
+    )

--- a/test/core/scale/scale_encode_counter_test.cpp
+++ b/test/core/scale/scale_encode_counter_test.cpp
@@ -1,0 +1,88 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <boost/optional.hpp>
+#include "scale/scale_encoder_stream.hpp"
+
+using kagome::scale::ScaleEncoderStream;
+
+class ScaleCounter : public ::testing::Test {
+ public:
+  ScaleCounter() : s(true) {}
+
+ protected:
+  ScaleEncoderStream s;
+};
+
+struct TestStruct {
+  uint8_t x;
+  std::string y;
+};
+
+template <class Stream, typename = std::enable_if_t<Stream::is_encoder_stream>>
+Stream &operator<<(Stream &s, const TestStruct &v) {
+  return s << v.x << v.y;
+}
+
+// helper for same kind checks
+#define SIZE(bytes) ASSERT_EQ(s.size(), bytes)
+
+/**
+ * @given a bool
+ * @when it gets scale encoded
+ * @then the resulting stream size equals to expected
+ */
+TEST_F(ScaleCounter, Bool) {
+  s << true;
+  SIZE(1);
+}
+
+/**
+ * @given a string
+ * @when it gets scale encoded
+ * @then the resulting stream size equals to expected
+ */
+TEST_F(ScaleCounter, String) {
+  std::string value = "test string";
+  s << value;
+  SIZE(value.size() + 1);
+}
+
+/**
+ * @given an empty optional
+ * @when it gets scale encoded
+ * @then the resulting stream size equals to expected
+ */
+TEST_F(ScaleCounter, EmptyOptional) {
+  boost::optional<uint32_t> var = boost::none;
+  s << var;
+  SIZE(1);
+}
+
+/**
+ * @given an optional with an uint32 value inside
+ * @when it gets scale encoded
+ * @then the resulting stream size equals to expected
+ */
+TEST_F(ScaleCounter, NonEmptyOptional) {
+  boost::optional<uint32_t> var = 10;
+  s << var;
+  SIZE(5);
+}
+
+/**
+ * @given a custom defined struct
+ * @when it gets scale encoded
+ * @then the resulting stream size equals to expected
+ */
+TEST_F(ScaleCounter, CustomStruct) {
+  TestStruct st{.x = 10, .y = "test string"};
+  s << st;
+  SIZE(1 + st.y.size() + 1);
+}

--- a/test/mock/core/authorship/block_builder_mock.hpp
+++ b/test/mock/core/authorship/block_builder_mock.hpp
@@ -18,6 +18,8 @@ namespace kagome::authorship {
                   outcome::result<primitives::ExtrinsicIndex>(
                       const primitives::Extrinsic &extrinsic));
     MOCK_CONST_METHOD0(bake, outcome::result<primitives::Block>());
+
+    MOCK_CONST_METHOD0(estimateBlockSize, size_t());
   };
 
 }  // namespace kagome::authorship


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

Resolves https://github.com/soramitsu/kagome/issues/826

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change

The change introduces proper processing of block size limit during block creation before its proposing.
Added transactions skipping mechanism to increase potential block utilization.

The same place in substrate https://github.com/paritytech/substrate/blob/d3db3c1d1011983ba7565e342910a6d2095625c8/client/basic-authorship/src/basic_authorship.rs#L339

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Improved block utilization during its production

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

None?

Proofs are not taken into account during block size estimation while in substrate this is an option BUT substrate uses the `false` value for that option during proposer instantiation.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests 

proposer_test
block_builder_test
scale_encode_counter_test

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs <!-- Optional -->

<!-- Explain what other alternates were considered and why the proposed version was selected -->
