### PR TITLE
Remove trace log level for rpc_transport group

### DIFF
--- a/core/log/configurator.cpp
+++ b/core/log/configurator.cpp
@@ -7,8 +7,6 @@
 
 namespace kagome::log {
 
-  // TODO remove rpc_transport level trace
-
   namespace {
     std::string embedded_config(R"(
 # ----------------
@@ -32,7 +30,6 @@ groups:
           - name: rpc
             children:
             - name: rpc_transport
-              level: trace
             - name: api
               children:
                 - name: author_api


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

Resolves https://github.com/soramitsu/kagome/issues/835

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change

Since there are no more issues with websocket connections, then we can reset the log level to default for the `rpc_transport` group.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Log levels are as intended.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

None

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
