### PR TITLE
Leave more time for txs collecting before block building

### DIFF
--- a/core/clock/impl/ticker_impl.cpp
+++ b/core/clock/impl/ticker_impl.cpp
@@ -15,10 +15,10 @@ namespace kagome::clock {
             *io_context}},
         interval_{interval} {}
 
-  void TickerImpl::start(clock::SystemClock::Duration duration) {
+  void TickerImpl::start(clock::SystemClock::Duration delay) {
     if (callback_) {
       started_ = true;
-      timer_.expires_from_now(duration);
+      timer_.expires_from_now(delay);
       timer_.async_wait(
           [&](const boost::system::error_code &ec) { onTick(ec); });
     }
@@ -35,7 +35,7 @@ namespace kagome::clock {
 
   void TickerImpl::asyncCallRepeatedly(
       std::function<void(const std::error_code &)> h) {
-    if(not started_) {
+    if (not started_) {
       callback_ = std::move(h);
     }
   }

--- a/core/clock/impl/ticker_impl.hpp
+++ b/core/clock/impl/ticker_impl.hpp
@@ -23,7 +23,7 @@ namespace kagome::clock {
 
     ~TickerImpl() override = default;
 
-    void start(clock::SystemClock::Duration duration) override;
+    void start(clock::SystemClock::Duration delay) override;
 
     void stop() override;
 

--- a/core/clock/ticker.hpp
+++ b/core/clock/ticker.hpp
@@ -19,9 +19,9 @@ namespace kagome::clock {
     virtual ~Ticker() = default;
 
     /**
-     * start ticker after duration
+     * start ticker after delay
      */
-    virtual void start(clock::SystemClock::Duration duration) = 0;
+    virtual void start(clock::SystemClock::Duration delay) = 0;
 
     /**
      * cancel ticker
@@ -35,9 +35,8 @@ namespace kagome::clock {
 
     /**
      * Wait for the ticker interval to last
-     * @param h - handler, which is called, when the ticker interval lasts, or error
-     * happens
-     * Start ticker only after setting callback here!
+     * @param h - handler, which is called, when the ticker interval lasts, or
+     * error happens Start ticker only after setting callback here!
      */
     virtual void asyncCallRepeatedly(
         std::function<void(const std::error_code &)> h) = 0;

--- a/core/consensus/babe/babe_util.hpp
+++ b/core/consensus/babe/babe_util.hpp
@@ -31,6 +31,11 @@ namespace kagome::consensus {
     virtual BabeDuration slotStartsIn(BabeSlotNumber slot) const = 0;
 
     /**
+     * @returns configured slot duration
+     */
+    virtual BabeDuration slotDuration() const = 0;
+
+    /**
      * @returns number of epoch by provided {@param slot_number}
      */
     virtual EpochNumber slotToEpoch(BabeSlotNumber slot_number) const = 0;

--- a/core/consensus/babe/impl/babe_impl.cpp
+++ b/core/consensus/babe/impl/babe_impl.cpp
@@ -108,7 +108,7 @@ namespace kagome::consensus::babe {
              "Starting an epoch {}. Session key: {}",
              epoch.epoch_number,
              keypair_->public_key.toHex());
-    current_epoch_ = std::move(epoch);
+    current_epoch_ = epoch;
     current_slot_ = current_epoch_.start_slot;
 
     [[maybe_unused]] auto res = babe_util_->setLastEpoch(current_epoch_);
@@ -126,14 +126,30 @@ namespace kagome::consensus::babe {
                    ec.message());
           return;
         }
-        self->finishSlot();
+        self->processSlot();
       }
     });
-    auto duration = babe_util_->slotStartsIn(current_slot_);
-    auto msec =
-        std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+    auto slot_start_delay = babe_util_->slotStartsIn(current_slot_);
+    auto delay_shift = babe_util_->slotDuration() / 2;
+    /*
+     * The delay lets us start slot processing when half of the time of the slot
+     * duration passed, thus more transactions could have been arrived to be
+     * baked into the block.
+     *
+     * That approach moves us closer to substrate's implementation where pushing
+     * extrinsics into the block starts when 2/3 of slot time is passed.
+     *
+     * Having a whole slot processing started 1/2 of slot time, pushing
+     * extrinsics to the block will approximately happen at the same time at a
+     * point of 2/3 of the whole slot time as it has done in rust
+     * implementation.
+     */
+    auto shifted_slot_start_delay = slot_start_delay + delay_shift;
+    auto msec = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    shifted_slot_start_delay)
+                    .count();
     SL_TRACE(log_, "Babe starts in {} msec", msec);
-    ticker_->start(duration);
+    ticker_->start(shifted_slot_start_delay);
   }
 
   Babe::State BabeImpl::getCurrentState() const {
@@ -213,7 +229,7 @@ namespace kagome::consensus::babe {
     }
   }
 
-  void BabeImpl::finishSlot() {
+  void BabeImpl::processSlot() {
     BOOST_ASSERT(keypair_ != nullptr);
 
     if (not slots_leadership_.has_value()) {

--- a/core/consensus/babe/impl/babe_impl.hpp
+++ b/core/consensus/babe/impl/babe_impl.hpp
@@ -90,9 +90,9 @@ namespace kagome::consensus::babe {
 
    private:
     /**
-     * Finish the current Babe slot
+     * Process the current Babe slot
      */
-    void finishSlot();
+    void processSlot();
 
     /**
      * Gather the block and broadcast it

--- a/core/consensus/babe/impl/babe_util_impl.cpp
+++ b/core/consensus/babe/impl/babe_util_impl.cpp
@@ -42,6 +42,10 @@ namespace kagome::consensus {
            - clock_.now().time_since_epoch();
   }
 
+  BabeDuration BabeUtilImpl::slotDuration() const {
+    return babe_configuration_->slot_duration;
+  }
+
   BabeSlotNumber BabeUtilImpl::getGenesisSlotNumber() {
     if (genesis_slot_number_.has_value()) {
       return genesis_slot_number_.value();

--- a/core/consensus/babe/impl/babe_util_impl.hpp
+++ b/core/consensus/babe/impl/babe_util_impl.hpp
@@ -25,6 +25,8 @@ namespace kagome::consensus {
 
     BabeDuration slotStartsIn(BabeSlotNumber slot) const override;
 
+    BabeDuration slotDuration() const override;
+
     EpochNumber slotToEpoch(BabeSlotNumber slot) const override;
 
     BabeSlotNumber slotInEpoch(BabeSlotNumber slot) const override;

--- a/test/mock/core/consensus/babe/babe_util_mock.hpp
+++ b/test/mock/core/consensus/babe/babe_util_mock.hpp
@@ -14,10 +14,11 @@ namespace kagome::consensus {
 
   class BabeUtilMock : public BabeUtil {
    public:
-
     MOCK_CONST_METHOD0(getCurrentSlot, BabeSlotNumber());
 
     MOCK_CONST_METHOD1(slotStartsIn, BabeDuration(BabeSlotNumber));
+
+    MOCK_CONST_METHOD0(slotDuration, BabeDuration());
 
     MOCK_CONST_METHOD1(slotToEpoch, EpochNumber(BabeSlotNumber));
 


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

Resolves https://github.com/soramitsu/kagome/issues/667

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change

Slot processing starts with delay (half of the slot time) which lets us step closer to substrate implementation in rust, having more time for transactions collecting before block building.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Corrected behavior.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

All the slots processing will be started with a half-slot-time delay, even for slots in which the kagome is not producing blocks.
As soon as this becomes critical, the approach is a subject of change.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs <!-- Optional -->

An alternative design could be transforming the stack of calls:
```
... getReadyTransactions
ProposerImpl::propose
BabeImpl::processSlotLeadership
BabeImpl::processSlot
BabeImpl::runEpoch
```
 ... By splitting it into two parts and having the last (starting from getReadyTransactions point at the code) as an asynchronously invoked callback starting past 2/3 of slot duration.

<!-- Explain what other alternates were considered and why the proposed version was selected -->
