### PR TITLE
Use 2/3 of slot time for txs collecting

### DIFF
--- a/core/consensus/babe/impl/babe_impl.cpp
+++ b/core/consensus/babe/impl/babe_impl.cpp
@@ -130,19 +130,11 @@ namespace kagome::consensus::babe {
       }
     });
     auto slot_start_delay = babe_util_->slotStartsIn(current_slot_);
-    auto delay_shift = babe_util_->slotDuration() / 2;
+    auto delay_shift = babe_util_->slotDuration() / 3 * 2;
     /*
-     * The delay lets us start slot processing when half of the time of the slot
+     * The delay lets us start slot processing when 2/3 of the time of the slot
      * duration passed, thus more transactions could have been arrived to be
      * baked into the block.
-     *
-     * That approach moves us closer to substrate's implementation where pushing
-     * extrinsics into the block starts when 2/3 of slot time is passed.
-     *
-     * Having a whole slot processing started 1/2 of slot time, pushing
-     * extrinsics to the block will approximately happen at the same time at a
-     * point of 2/3 of the whole slot time as it has done in rust
-     * implementation.
      */
     auto shifted_slot_start_delay = slot_start_delay + delay_shift;
     auto msec = std::chrono::duration_cast<std::chrono::milliseconds>(


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

Resolves #667

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change

Fine grained tuning of #857 

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs <!-- Optional -->

<!-- Explain what other alternates were considered and why the proposed version was selected -->
