### PR TITLE
Update private_network.md

### DIFF
--- a/docs/source/tutorials/private_network.md
+++ b/docs/source/tutorials/private_network.md
@@ -21,7 +21,8 @@ kagome \
     --base-path validating1 \
     --port 11122 \
     --rpc-port 11133 \
-    --ws-port 11144
+    --ws-port 11144 \
+    --prometheus-port 11155
 ```
 
 ### Execute second validating node (node with authority) 
@@ -35,7 +36,8 @@ kagome \
     --base-path validating2 \
     --port 11222 \
     --rpc-port 11233 \
-    --ws-port 11244
+    --ws-port 11244 \
+    --prometheus-port 11255
 ```
 
 Second node passes several steps before actual block production begins:
@@ -61,7 +63,8 @@ kagome \
     --base-path syncing1 \
     --port 21122 \
     --rpc-port 21133 \
-    --ws-port 21144
+    --ws-port 21144 \
+    --prometheus-port 21155
 ```
 
 Note that trie root is the same with validating nodes. When syncing node receives block announcement it first synchronizes missing blocks and then listens to the new blocks and finalization. 


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

-

### Description of the Change

Without adding prometheus port into the script, we may end up with situation when there are several nodes on the same machine are having same port and cannot be executed
### Benefits

Scripts from docs could be executed

### Possible Drawbacks 

Still nodes cannot be executed. See the following logs in 1st node:

```
21.08.05 17:37:02.344319  Info      TrieStorage  Initialize trie storage with root: 03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314
21.08.05 17:37:04.412476  Info      Injector  Will use LibP2P keypair from config or args (loading from base path)
21.08.05 17:37:04.418508  Info      Application  Start as KagomeApplicationImpl with PID 76357 named as acb2d8a4-b246-45ed-b115-312aac32a956
21.08.05 17:37:04.420127  Info      RouterLibp2p  Started with peer id: 12D3KooWEgUjBV5FJAuBSoNMRYFRHjV7PjZwRQ7b43EKX9g7D6xV
21.08.05 17:37:04.420162  Info      RouterLibp2p  Started listening on address: /ip4/0.0.0.0/tcp/11122/p2p/12D3KooWEgUjBV5FJAuBSoNMRYFRHjV7PjZwRQ7b43EKX9g7D6xV
21.08.05 17:37:04.420174  Info      RouterLibp2p  Started listening on address: /ip6/::/tcp/11122/p2p/12D3KooWEgUjBV5FJAuBSoNMRYFRHjV7PjZwRQ7b43EKX9g7D6xV
21.08.05 17:37:04.420197  Info      OpenMetrics  Started successfully on host: 0.0.0.0, port: 11155
21.08.05 17:37:04.421212  Error     PeerManager  List of last active peers cannot be obtained from storage. Error=entry not found in database
21.08.05 17:37:23.909229  Warning   PeerManager  Unable to create stream /sup/block-announces/1 with 12D3KooWKzGMnzpdQQFGvxVEBYKQuyttE3KjigvBAwXy7hZtdHqs: Stream: reset by remote peer
21.08.05 17:37:23.934386  Warning   PeerManager  Unable to create stream /sup/block-announces/1 with 12D3KooWKzGMnzpdQQFGvxVEBYKQuyttE3KjigvBAwXy7hZtdHqs: Stream: reset by remote peer
...
```

and that from 2nd node:

```
21.08.05 17:37:21.314682  Info      TrieStorage  Initialize trie storage with root: 03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314
21.08.05 17:37:23.697784  Info      Injector  Will use LibP2P keypair from config or args (loading from base path)
21.08.05 17:37:23.703187  Info      Application  Start as KagomeApplicationImpl with PID 77094 named as 63578364-ffdd-4531-aafa-dd1a59b837a1
21.08.05 17:37:23.704717  Info      RouterLibp2p  Started with peer id: 12D3KooWKzGMnzpdQQFGvxVEBYKQuyttE3KjigvBAwXy7hZtdHqs
21.08.05 17:37:23.704751  Info      RouterLibp2p  Started listening on address: /ip4/0.0.0.0/tcp/11222/p2p/12D3KooWKzGMnzpdQQFGvxVEBYKQuyttE3KjigvBAwXy7hZtdHqs
21.08.05 17:37:23.704767  Info      RouterLibp2p  Started listening on address: /ip6/::/tcp/11222/p2p/12D3KooWKzGMnzpdQQFGvxVEBYKQuyttE3KjigvBAwXy7hZtdHqs
21.08.05 17:37:23.704799  Info      OpenMetrics  Started successfully on host: 0.0.0.0, port: 11255
21.08.05 17:37:23.705915  Error     PeerManager  List of last active peers cannot be obtained from storage. Error=entry not found in database
21.08.05 17:37:23.861874  Warning   PeerManager  Unable to create stream /sup/block-announces/1 with 12D3KooWEgUjBV5FJAuBSoNMRYFRHjV7PjZwRQ7b43EKX9g7D6xV: Stream: reset by remote peer
21.08.05 17:37:23.934657  Warning   PeerManager  Unable to create stream /sup/block-announces/1 with 12D3KooWEgUjBV5FJAuBSoNMRYFRHjV7PjZwRQ7b43EKX9g7D6xV: Stream: reset by remote peer
...
```

