### PR TITLE
Propagation of Grandpa messages

### DIFF
--- a/core/consensus/grandpa/impl/grandpa_impl.cpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.cpp
@@ -485,7 +485,8 @@ namespace kagome::consensus::grandpa {
   void GrandpaImpl::onVoteMessage(const libp2p::peer::PeerId &peer_id,
                                   const VoteMessage &msg) {
     SL_DEBUG(logger_,
-             "{} has received from {}: voter_set_id={} round={} #{} hash={}",
+             "{} has received from {}: "
+             "voter_set_id={} round={} for block #{} hash={}",
              msg.vote.is<Prevote>()
                  ? "Prevote"
                  : msg.vote.is<Precommit>() ? "Precommit" : "PrimaryPropose",
@@ -521,7 +522,8 @@ namespace kagome::consensus::grandpa {
     const auto &weighted_authorities_res =
         grandpa_api_->authorities(primitives::BlockId(blockInfo.hash));
     if (!weighted_authorities_res.has_value()) {
-      logger_->error("Can't get authorities");
+      logger_->error("Can't get authorities: {}",
+                     weighted_authorities_res.error().message());
       return;
     };
     auto &weighted_authorities = weighted_authorities_res.value();
@@ -538,17 +540,25 @@ namespace kagome::consensus::grandpa {
       logger_->warn("Vote signed by unknown validator");
       return;
     };
+
+    bool isPrevotesChanged = false;
+    bool isPrecommitsChanged = false;
     visit_in_place(
         msg.vote.message,
-        [&target_round, &msg](const PrimaryPropose &) {
-          target_round->onProposal(msg.vote);
+        [&](const PrimaryPropose &) {
+          target_round->onProposal(msg.vote, true);
         },
-        [&target_round, &msg](const Prevote &) {
-          target_round->onPrevote(msg.vote);
+        [&](const Prevote &) {
+          if (target_round->onPrevote(msg.vote, true)) {
+            isPrevotesChanged = true;
+          }
         },
-        [&target_round, &msg](const Precommit &) {
-          target_round->onPrecommit(msg.vote);
+        [&](const Precommit &) {
+          if (target_round->onPrecommit(msg.vote, true)) {
+            isPrecommitsChanged = true;
+          }
         });
+    target_round->update(isPrevotesChanged, isPrecommitsChanged);
   }
 
   void GrandpaImpl::onFinalize(const libp2p::peer::PeerId &peer_id,

--- a/core/consensus/grandpa/impl/voting_round_impl.cpp
+++ b/core/consensus/grandpa/impl/voting_round_impl.cpp
@@ -144,12 +144,23 @@ namespace kagome::consensus::grandpa {
     need_to_notice_at_finalizing_ = false;
 
     if (round_number_ != 0) {
+      bool isPrevotesChanged = false;
+      bool isPrecommitsChanged = false;
+
       // Apply stored votes
       auto apply = [&](const auto &vote) {
         visit_in_place(
             vote.message,
-            [&](const Prevote &) { VotingRoundImpl::onPrevote(vote); },
-            [&](const Precommit &) { VotingRoundImpl::onPrecommit(vote); },
+            [&](const Prevote &) {
+              if (VotingRoundImpl::onPrevote(vote, false)) {
+                isPrevotesChanged = true;
+              };
+            },
+            [&](const Precommit &) {
+              if (VotingRoundImpl::onPrecommit(vote, false)) {
+                isPrecommitsChanged = true;
+              };
+            },
             [](auto...) {});
       };
 
@@ -162,6 +173,9 @@ namespace kagome::consensus::grandpa {
               apply(pair.second);
             });
       }
+
+      update(isPrevotesChanged, isPrecommitsChanged);
+
     } else {
       // Zero-round is always self-finalized
       completable_ = true;
@@ -640,12 +654,26 @@ namespace kagome::consensus::grandpa {
         block_info.number,
         block_info.hash.toHex());
 
-    for (auto &item : justification.items) {
+    bool isPrevotesChanged = false;
+    bool isPrecommitsChanged = false;
+
+    for (auto &vote : justification.items) {
       visit_in_place(
-          item.message,
-          [this, &item](const Precommit &vote) { onPrecommit(item); },
-          [](auto &...) {});
+          vote.message,
+          [&](const Prevote &) {
+            if (VotingRoundImpl::onPrevote(vote, false)) {
+              isPrevotesChanged = true;
+            };
+          },
+          [&](const Precommit &) {
+            if (VotingRoundImpl::onPrecommit(vote, false)) {
+              isPrecommitsChanged = true;
+            };
+          },
+          [](auto...) {});
     }
+
+    update(isPrevotesChanged, isPrecommitsChanged);
 
     // NOTE: Perhaps it's needless or needs to replace by condition
     BOOST_ASSERT(finalizable());
@@ -763,7 +791,8 @@ namespace kagome::consensus::grandpa {
     return voter_set_->id();
   }
 
-  void VotingRoundImpl::onProposal(const SignedMessage &proposal) {
+  void VotingRoundImpl::onProposal(const SignedMessage &proposal,
+                                   bool propagate) {
     if (not isPrimary(proposal.id)) {
       logger_->warn(
           "Round #{}: Proposal received from {} was rejected: voter is not "
@@ -790,29 +819,38 @@ namespace kagome::consensus::grandpa {
              proposal.getBlockHash(),
              proposal.id.toHex());
 
+    if (primary_vote_.has_value()) {
+      propagate = false;
+    }
+
     primary_vote_ = {{proposal.getBlockNumber(), proposal.getBlockHash()}};
+
+    if (propagate) {
+      sendProposal(convertToPrimaryPropose(proposal.getBlockInfo()));
+    }
   }
 
-  void VotingRoundImpl::onPrevote(const SignedMessage &prevote) {
+  bool VotingRoundImpl::onPrevote(const SignedMessage &prevote,
+                                  bool propagate) {
     bool isValid = vote_crypto_provider_->verifyPrevote(prevote);
     if (not isValid) {
       logger_->warn(
           "Round #{}: Prevote received from {} was rejected: invalid signature",
           round_number_,
           prevote.id.toHex());
-      return;
+      return false;
     }
 
     if (auto result = onSignedPrevote(prevote); result.has_failure()) {
       if (result == outcome::failure(VotingRoundError::DUPLICATED_VOTE)) {
-        return;
+        return false;
       }
       logger_->warn("Round #{}: Prevote received from {} was rejected: {}",
                     round_number_,
                     prevote.id.toHex(),
                     result.error().message());
       if (result != outcome::failure(VotingRoundError::EQUIVOCATED_VOTE)) {
-        return;
+        return false;
       }
     }
 
@@ -828,28 +866,28 @@ namespace kagome::consensus::grandpa {
       SL_DEBUG(logger_, "Round #{}: Own prevote was restored", round_number_);
     }
 
-    if (updatePrevoteGhost()) {
-      if (updatePrecommitGhost()) {
-        updateCompletability();
-      }
-      attemptToFinalizeRound();
+    if (propagate) {
+      sendPrevote(convertToPrevote(prevote.getBlockInfo()));
     }
+
+    return true;
   }
 
-  void VotingRoundImpl::onPrecommit(const SignedMessage &precommit) {
+  bool VotingRoundImpl::onPrecommit(const SignedMessage &precommit,
+                                    bool propagate) {
     bool isValid = vote_crypto_provider_->verifyPrecommit(precommit);
     if (not isValid) {
       logger_->warn(
-          "Round #{}: Precommit received from {} was rejected: invalid "
-          "signature",
+          "Round #{}: Precommit received from {} was rejected: "
+          "invalid signature",
           round_number_,
           precommit.id.toHex());
-      return;
+      return false;
     }
 
     if (auto result = onSignedPrecommit(precommit); result.has_failure()) {
       if (result == outcome::failure(VotingRoundError::DUPLICATED_VOTE)) {
-        return;
+        return false;
       }
       logger_->warn("Round #{}: Precommit received from {} was rejected: {}",
                     round_number_,
@@ -857,7 +895,7 @@ namespace kagome::consensus::grandpa {
                     result.error().message());
       env_->onCompleted(result.as_failure());
       if (result != outcome::failure(VotingRoundError::EQUIVOCATED_VOTE)) {
-        return;
+        return false;
       }
     }
 
@@ -873,10 +911,26 @@ namespace kagome::consensus::grandpa {
       SL_DEBUG(logger_, "Round #{}: Own precommit was restored", round_number_);
     }
 
-    if (updatePrecommitGhost()) {
-      updateCompletability();
+    if (propagate) {
+      sendPrecommit(convertToPrecommit(precommit.getBlockInfo()));
     }
-    attemptToFinalizeRound();
+
+    return true;
+  }
+
+  void VotingRoundImpl::update(bool isPrevotesChanged,
+                               bool isPrecommitsChanged) {
+    if (isPrevotesChanged) {
+      if (updatePrevoteGhost()) {
+        isPrecommitsChanged = true;
+      }
+    }
+    if (isPrecommitsChanged) {
+      if (updatePrecommitGhost()) {
+        updateCompletability();
+      }
+      attemptToFinalizeRound();
+    }
   }
 
   outcome::result<void> VotingRoundImpl::onSignedPrevote(

--- a/core/consensus/grandpa/impl/voting_round_impl.hpp
+++ b/core/consensus/grandpa/impl/voting_round_impl.hpp
@@ -124,22 +124,30 @@ namespace kagome::consensus::grandpa {
      * Basically method just checks if received propose was produced by the
      * primary and if so, it is stored in primary_vote_ field
      */
-    void onProposal(const SignedMessage &proposal) override;
+    void onProposal(const SignedMessage &proposal, bool propagate) override;
 
     /**
      * Triggered when we receive prevote for current round
      * \param prevote is stored in prevote tracker and vote graph
      * Then we try to update prevote ghost (\see updatePrevoteGhost) and round
      * state (\see update)
+     * @returns true if inner state has changed
      */
-    void onPrevote(const SignedMessage &prevote) override;
+    bool onPrevote(const SignedMessage &prevote, bool propagate) override;
 
     /**
      * Triggered when we receive precommit for the current round
      * \param precommit is stored in precommit tracker and vote graph
      * Then we try to update round state and finalize
+     * @returns true if inner state has changed
      */
-    void onPrecommit(const SignedMessage &precommit) override;
+    bool onPrecommit(const SignedMessage &precommit, bool propagate) override;
+
+    /**
+     * Updates inner state if {@param isPrevotesChanged} or
+     * {@param isPrecommitsChanged} was changed since last call
+     */
+    void update(bool isPrevotesChanged, bool isPrecommitsChanged) override;
 
     /**
      * Checks if current round is completable and finalized block differs from

--- a/core/consensus/grandpa/structs.hpp
+++ b/core/consensus/grandpa/structs.hpp
@@ -51,6 +51,12 @@ namespace kagome::consensus::grandpa {
                             [](const auto &vote) { return vote.hash; });
     }
 
+    BlockInfo getBlockInfo() const {
+      return visit_in_place(message, [](const auto &vote) {
+        return BlockInfo(vote.number, vote.hash);
+      });
+    }
+
     template <typename T>
     bool is() const {
       return message.type() == typeid(T);

--- a/core/consensus/grandpa/voting_round.hpp
+++ b/core/consensus/grandpa/voting_round.hpp
@@ -96,13 +96,34 @@ namespace kagome::consensus::grandpa {
     /// peer
     virtual void doCatchUpResponse(const libp2p::peer::PeerId &peer_id) = 0;
 
-    // Handling inner messages
+    // Handling incoming messages
 
-    virtual void onProposal(const SignedMessage &primary_propose) = 0;
+    /**
+     * Invoked when we received a primary propose for this round
+     */
+    virtual void onProposal(const SignedMessage &primary_propose,
+                            bool propagate) = 0;
 
-    virtual void onPrevote(const SignedMessage &prevote) = 0;
+    /**
+     * Triggered when we receive {@param prevote} for current round.
+     * Prevote will be propogated if {@param propagate} is true
+     * @returns true if inner state has changed
+     */
+    virtual bool onPrevote(const SignedMessage &prevote, bool propagate) = 0;
 
-    virtual void onPrecommit(const SignedMessage &precommit) = 0;
+    /**
+     * Triggered when we receive {@param precommit} for current round.
+     * Precommit will be propogated if {@param propagate} is true
+     * @returns true if inner state has changed
+     */
+    virtual bool onPrecommit(const SignedMessage &precommit,
+                             bool propagate) = 0;
+
+    /**
+     * Updates inner state if {@param prevote} or {@param precommit} was changed
+     * since last call
+     */
+    virtual void update(bool isPrevotesChanged, bool isPrecommitsChanged) = 0;
 
     // Auxiliary methods
 

--- a/core/network/impl/peer_manager_impl.cpp
+++ b/core/network/impl/peer_manager_impl.cpp
@@ -464,7 +464,9 @@ namespace kagome::network {
 
             // Add to active peer list
             if (auto [ap_it, added] = self->active_peers_.emplace(
-                    peer_id, ActivePeerData{.time = self->clock_->now(), .status = Status{}});
+                    peer_id,
+                    ActivePeerData{.time = self->clock_->now(),
+                                   .status = Status{}});
                 added) {
               self->recently_active_peers_.insert(peer_id);
 

--- a/test/mock/core/consensus/grandpa/voting_round_mock.hpp
+++ b/test/mock/core/consensus/grandpa/voting_round_mock.hpp
@@ -32,9 +32,10 @@ namespace kagome::consensus::grandpa {
     MOCK_METHOD0(doFinalize, void());
     MOCK_METHOD1(doCatchUpRequest, void(const libp2p::peer::PeerId &));
     MOCK_METHOD1(doCatchUpResponse, void(const libp2p::peer::PeerId &));
-    MOCK_METHOD1(onProposal, void(const SignedMessage &));
-    MOCK_METHOD1(onPrevote, void(const SignedMessage &));
-    MOCK_METHOD1(onPrecommit, void(const SignedMessage &));
+    MOCK_METHOD2(onProposal, void(const SignedMessage &, bool));
+    MOCK_METHOD2(onPrevote, bool(const SignedMessage &, bool));
+    MOCK_METHOD2(onPrecommit, bool(const SignedMessage &, bool));
+    MOCK_METHOD2(update, void(bool, bool));
     MOCK_METHOD2(applyJustification,
                  outcome::result<void>(const BlockInfo &,
                                        const GrandpaJustification &));


### PR DESCRIPTION
Signed-off-by: Dmitriy Khaustov aka xDimon <khaustov.dm@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues
Resolves #789 

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
Propagation on demand is implemented
Sepatate votes applying and update inner round state (as optimisation)

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Accordings with a spec. Consume less resources.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->
Existing tests have adapted
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

