### PR TITLE
Fix runtime context map overflow in WAVM

### DIFF
--- a/core/consensus/babe/impl/babe_impl.cpp
+++ b/core/consensus/babe/impl/babe_impl.cpp
@@ -483,7 +483,6 @@ namespace kagome::consensus::babe {
           log_, "cannot put an inherent data: {}", put_res.error().message());
     }
 
-    //    auto &[best_block_number, best_block_hash] = best_block_;
     SL_INFO(log_,
             "Babe builds block on top of block with number {} and hash {}",
             best_block_.number,

--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -329,7 +329,7 @@ namespace {
     for (const auto &[key_, val_] : genesis_raw_configs) {
       auto &key = key_;
       auto &val = val_;
-      SL_DEBUG(
+      SL_T(
           log, "Key: {}, Val: {}", key.toHex(), val.toHex().substr(0, 200));
       if (auto res = batch->put(key, val); not res) {
         common::raise(res.error());
@@ -766,30 +766,6 @@ namespace {
       application::AppConfiguration::RuntimeExecutionMethod method,
       Ts &&...args) {
     return di::make_injector(
-        di::bind<runtime::RuntimeEnvironmentFactory>.template to(
-            [method](auto const &injector)
-                -> std::shared_ptr<runtime::RuntimeEnvironmentFactory> {
-              static boost::optional<
-                  std::shared_ptr<runtime::RuntimeEnvironmentFactory>>
-                  env_factory;
-              if (env_factory.has_value()) return env_factory.value();
-
-              env_factory = boost::make_optional(
-                  std::make_shared<runtime::RuntimeEnvironmentFactory>(
-                      injector.template create<
-                          sptr<const runtime::RuntimeCodeProvider>>(),
-                      injector
-                          .template create<sptr<runtime::ModuleRepository>>(),
-                      injector.template create<
-                          sptr<const blockchain::BlockHeaderRepository>>()));
-              if (method
-                  == application::AppConfiguration::RuntimeExecutionMethod::
-                      Compile) {
-                env_factory.value()->setEnvCleanupCallback(
-                    [](auto &) { runtime::wavm::popHostApi(); });
-              }
-              return env_factory.value();
-            })[di::override],
         di::bind<runtime::wavm::CompartmentWrapper>.template to(
             [](const auto &injector) {
               static auto compartment =

--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -329,7 +329,7 @@ namespace {
     for (const auto &[key_, val_] : genesis_raw_configs) {
       auto &key = key_;
       auto &val = val_;
-      SL_T(
+      SL_TRACE(
           log, "Key: {}, Val: {}", key.toHex(), val.toHex().substr(0, 200));
       if (auto res = batch->put(key, val); not res) {
         common::raise(res.error());

--- a/core/runtime/common/memory_allocator.cpp
+++ b/core/runtime/common/memory_allocator.cpp
@@ -46,7 +46,7 @@ namespace kagome::runtime {
     BOOST_ASSERT(allocated_.find(ptr) == allocated_.end());
     if (Memory::kMaxMemorySize - offset_ < size) {  // overflow
       logger_->error(
-          "overflow occured while trying to allocate {} bytes at offset 0x{:x}",
+          "overflow occurred while trying to allocate {} bytes at offset 0x{:x}",
           size,
           offset_);
       return 0;

--- a/core/runtime/common/runtime_environment_factory.cpp
+++ b/core/runtime/common/runtime_environment_factory.cpp
@@ -156,8 +156,7 @@ namespace kagome::runtime {
       : code_provider_{std::move(code_provider)},
         module_repo_{std::move(module_repo)},
         header_repo_{std::move(header_repo)},
-        logger_{log::createLogger("RuntimeEnvironmentFactory", "runtime")},
-        env_cleanup_callback_{} {
+        logger_{log::createLogger("RuntimeEnvironmentFactory", "runtime")} {
     BOOST_ASSERT(code_provider_ != nullptr);
     BOOST_ASSERT(module_repo_ != nullptr);
     BOOST_ASSERT(header_repo_ != nullptr);
@@ -192,11 +191,6 @@ namespace kagome::runtime {
       return Error::ABSENT_BLOCK;
     }
     return start(genesis_hash.value());
-  }
-
-  void RuntimeEnvironmentFactory::setEnvCleanupCallback(
-      std::function<void(RuntimeEnvironment &)> &&callback) {
-    env_cleanup_callback_ = std::move(callback);
   }
 
 }  // namespace kagome::runtime

--- a/core/runtime/executor.hpp
+++ b/core/runtime/executor.hpp
@@ -122,7 +122,7 @@ namespace kagome::runtime {
                                    std::string_view name,
                                    Args &&...args) {
       OUTCOME_TRY(env_template, env_factory_->start(block_hash));
-      OUTCOME_TRY(env, env_template->persistent().make());
+      OUTCOME_TRY(env, env_template->make());
       return callInternal<Result>(*env, name, std::forward<Args>(args)...);
     }
 

--- a/core/runtime/runtime_environment_factory.hpp
+++ b/core/runtime/runtime_environment_factory.hpp
@@ -52,9 +52,6 @@ namespace kagome::runtime {
 
     virtual ~RuntimeEnvironmentFactory() = default;
 
-    void setEnvCleanupCallback(
-        std::function<void(RuntimeEnvironment &)> &&callback);
-
     /**
      * @param blockchain_state - the block to take the runtime code from
      * @param storage_state
@@ -95,7 +92,6 @@ namespace kagome::runtime {
     std::shared_ptr<ModuleRepository> module_repo_;
     std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo_;
     log::Logger logger_;
-    std::function<void(RuntimeEnvironment &)> env_cleanup_callback_;
   };
 
   struct RuntimeEnvironmentFactory::RuntimeEnvironmentTemplate {

--- a/core/runtime/wavm/core_api_factory_impl.cpp
+++ b/core/runtime/wavm/core_api_factory_impl.cpp
@@ -99,7 +99,6 @@ namespace kagome::runtime::wavm {
         block_header_repo_);
     auto executor =
         std::make_unique<runtime::Executor>(block_header_repo_, env_factory);
-    env_factory->setEnvCleanupCallback([](auto &) { popHostApi(); });
     return std::make_unique<CoreImpl>(
         std::move(executor), changes_tracker_, block_header_repo_);
   }

--- a/core/runtime/wavm/instance_environment_factory.cpp
+++ b/core/runtime/wavm/instance_environment_factory.cpp
@@ -42,7 +42,7 @@ namespace kagome::runtime::wavm {
         std::shared_ptr<IntrinsicModuleInstance>(
             intrinsic_module_->instantiate());
     auto new_memory_provider = std::make_shared<WavmMemoryProvider>(
-        new_intrinsic_module_instance, compartment_);
+        new_intrinsic_module_instance);
     auto new_storage_provider =
         std::make_shared<TrieStorageProviderImpl>(storage_);
     auto core_factory = std::make_shared<CoreApiFactoryImpl>(compartment_,

--- a/core/runtime/wavm/memory_impl.cpp
+++ b/core/runtime/wavm/memory_impl.cpp
@@ -10,25 +10,20 @@
 namespace kagome::runtime::wavm {
 
   MemoryImpl::MemoryImpl(
-      std::shared_ptr<const CompartmentWrapper> const &compartment,
       WAVM::Runtime::Memory *memory,
       std::unique_ptr<MemoryAllocator> &&allocator)
       : allocator_{std::move(allocator)},
-        compartment_{compartment},
         memory_{memory},
         logger_{log::createLogger("WAVM Memory", "wavm")} {
     BOOST_ASSERT(memory_);
-    BOOST_ASSERT(compartment_);
 
     resize(kInitialMemorySize);
   }
 
   MemoryImpl::MemoryImpl(
-      std::shared_ptr<const CompartmentWrapper> const &compartment,
       WAVM::Runtime::Memory *memory,
       WasmSize heap_base)
-      : MemoryImpl(compartment,
-                   memory,
+      : MemoryImpl(memory,
                    std::make_unique<MemoryAllocator>(
                        MemoryAllocator::MemoryHandle{
                            [this](auto size) { return resize(size); },

--- a/core/runtime/wavm/memory_impl.hpp
+++ b/core/runtime/wavm/memory_impl.hpp
@@ -24,15 +24,11 @@ namespace kagome::runtime {
 
 namespace kagome::runtime::wavm {
 
-  class CompartmentWrapper;
-
   class MemoryImpl final : public kagome::runtime::Memory {
    public:
-    MemoryImpl(std::shared_ptr<const CompartmentWrapper> const &compartment,
-               WAVM::Runtime::Memory *memory,
+    MemoryImpl(WAVM::Runtime::Memory *memory,
                std::unique_ptr<MemoryAllocator> &&allocator);
-    MemoryImpl(std::shared_ptr<const CompartmentWrapper> const &compartment,
-               WAVM::Runtime::Memory *memory,
+    MemoryImpl(WAVM::Runtime::Memory *memory,
                WasmSize heap_base);
     MemoryImpl(const MemoryImpl &copy) = delete;
     MemoryImpl &operator=(const MemoryImpl &copy) = delete;
@@ -115,7 +111,6 @@ namespace kagome::runtime::wavm {
    private:
     constexpr static uint32_t kPageSize = 4096;
     std::unique_ptr<MemoryAllocator> allocator_;
-    const std::shared_ptr<const CompartmentWrapper> compartment_;
     WAVM::Runtime::Memory *memory_;
     log::Logger logger_;
   };

--- a/core/runtime/wavm/module.cpp
+++ b/core/runtime/wavm/module.cpp
@@ -30,8 +30,7 @@ namespace kagome::runtime::wavm {
         "of seconds)");
     if (!WAVM::Runtime::loadBinaryModule(
             code.data(), code.size(), module, featureSpec, &loadError)) {
-      // TODO(Harrm): Introduce an outcome error
-      logger->error("Error loading WAVM binary module: {}", loadError.message);
+      logger->critical("Error loading WAVM binary module: {}", loadError.message);
       return nullptr;
     }
 

--- a/core/runtime/wavm/module_instance.cpp
+++ b/core/runtime/wavm/module_instance.cpp
@@ -42,67 +42,68 @@ namespace kagome::runtime::wavm {
     BOOST_ASSERT(compartment_ != nullptr);
   }
 
-  ModuleInstance::~ModuleInstance() {
-    WAVM::Runtime::collectCompartmentGarbage(compartment_->getCompartment());
-  }
-
   outcome::result<PtrSize> ModuleInstance::callExportFunction(
       std::string_view name, PtrSize args) const {
-    WAVM::Runtime::GCPointer<WAVM::Runtime::Context> context =
-        WAVM::Runtime::createContext(compartment_->getCompartment());
-    WAVM::Runtime::Function *function = WAVM::Runtime::asFunctionNullable(
-        WAVM::Runtime::getInstanceExport(instance_, name.data()));
-    std::vector<WAVM::IR::Value> invokeArgs;
-    if (!function) {
-      logger_->debug("The requested function {} not found", name);
-      return Error::FUNC_NOT_FOUND;
-    }
-    const WAVM::IR::FunctionType functionType =
-        WAVM::Runtime::getFunctionType(function);
-    if (functionType.params().size() != 2) {  // address and size
-      logger_->debug(
-          "The provided function argument count should equal to 2, got {} "
-          "instead",
-          functionType.params().size());
-      return Error::WRONG_ARG_COUNT;
-    }
-    invokeArgs.emplace_back(static_cast<WAVM::U32>(args.ptr));
-    invokeArgs.emplace_back(static_cast<WAVM::U32>(args.size));
-    WAVM_ASSERT(function)
+    auto res = [this, name, args]() -> outcome::result<PtrSize> {
+      WAVM::Runtime::GCPointer<WAVM::Runtime::Context> context =
+          WAVM::Runtime::createContext(compartment_->getCompartment());
+      WAVM::Runtime::Function *function = WAVM::Runtime::asFunctionNullable(
+          WAVM::Runtime::getInstanceExport(instance_, name.data()));
+      std::vector<WAVM::IR::Value> invokeArgs;
+      if (!function) {
+        SL_DEBUG(logger_, "The requested function {} not found", name);
+        return Error::FUNC_NOT_FOUND;
+      }
+      const WAVM::IR::FunctionType functionType =
+          WAVM::Runtime::getFunctionType(function);
+      if (functionType.params().size() != 2) {  // address and size
+        SL_DEBUG(
+            logger_,
+            "The provided function argument count should equal to 2, got {} "
+            "instead",
+            functionType.params().size());
+        return Error::WRONG_ARG_COUNT;
+      }
+      invokeArgs.emplace_back(static_cast<WAVM::U32>(args.ptr));
+      invokeArgs.emplace_back(static_cast<WAVM::U32>(args.size));
+      WAVM_ASSERT(function)
 
-    std::vector<WAVM::IR::ValueType> invokeArgTypes;
-    std::vector<WAVM::IR::UntaggedValue> untaggedInvokeArgs;
-    for (const WAVM::IR::Value &arg : invokeArgs) {
-      invokeArgTypes.push_back(arg.type);
-      untaggedInvokeArgs.push_back(arg);
-    }
-    // Infer the expected type of the function from the number and type of the
-    // invoke arguments and the function's actual result types.
-    const WAVM::IR::FunctionType invokeSig(
-        WAVM::Runtime::getFunctionType(function).results(),
-        WAVM::IR::TypeTuple(invokeArgTypes));
-    // Allocate an array to receive the invoke results.
-    std::vector<WAVM::IR::UntaggedValue> untaggedInvokeResults;
-    untaggedInvokeResults.resize(invokeSig.results().size());
-    try {
-      WAVM::Runtime::unwindSignalsAsExceptions([&context,
-                                                &function,
-                                                &invokeSig,
-                                                &untaggedInvokeArgs,
-                                                &untaggedInvokeResults] {
-        WAVM::Runtime::invokeFunction(context,
-                                      function,
-                                      invokeSig,
-                                      untaggedInvokeArgs.data(),
-                                      untaggedInvokeResults.data());
-      });
-      return PtrSize{untaggedInvokeResults[0].u64};
-    } catch (WAVM::Runtime::Exception *e) {
-      const auto desc = WAVM::Runtime::describeException(e);
-      logger_->debug(desc);
-      WAVM::Runtime::destroyException(e);
-      return Error::EXECUTION_ERROR;
-    }
+      std::vector<WAVM::IR::ValueType> invokeArgTypes;
+      std::vector<WAVM::IR::UntaggedValue> untaggedInvokeArgs;
+      for (const WAVM::IR::Value &arg : invokeArgs) {
+        invokeArgTypes.push_back(arg.type);
+        untaggedInvokeArgs.push_back(arg);
+      }
+      // Infer the expected type of the function from the number and type of the
+      // invoke arguments and the function's actual result types.
+      const WAVM::IR::FunctionType invokeSig(
+          WAVM::Runtime::getFunctionType(function).results(),
+          WAVM::IR::TypeTuple(invokeArgTypes));
+      // Allocate an array to receive the invoke results.
+      std::vector<WAVM::IR::UntaggedValue> untaggedInvokeResults;
+      untaggedInvokeResults.resize(invokeSig.results().size());
+      try {
+        WAVM::Runtime::unwindSignalsAsExceptions([&context,
+                                                  &function,
+                                                  &invokeSig,
+                                                  &untaggedInvokeArgs,
+                                                  &untaggedInvokeResults] {
+          WAVM::Runtime::invokeFunction(context,
+                                        function,
+                                        invokeSig,
+                                        untaggedInvokeArgs.data(),
+                                        untaggedInvokeResults.data());
+        });
+        return PtrSize{untaggedInvokeResults[0].u64};
+      } catch (WAVM::Runtime::Exception *e) {
+        const auto desc = WAVM::Runtime::describeException(e);
+        logger_->debug(desc);
+        WAVM::Runtime::destroyException(e);
+        return Error::EXECUTION_ERROR;
+      }
+    }();
+    WAVM::Runtime::collectCompartmentGarbage(compartment_->getCompartment());
+    return res;
   }
 
   outcome::result<boost::optional<WasmValue>> ModuleInstance::getGlobal(
@@ -123,9 +124,9 @@ namespace kagome::runtime::wavm {
       case WAVM::IR::ValueType::f64:
         return WasmValue{static_cast<double>(value.f64)};
       default:
-        logger_->debug(
-            "Runtime function returned result of unsupported type: {}",
-            asString(value));
+        SL_DEBUG(logger_,
+                 "Runtime function returned result of unsupported type: {}",
+                 asString(value));
         return Error::WRONG_RETURN_TYPE;
     }
   }

--- a/core/runtime/wavm/module_instance.hpp
+++ b/core/runtime/wavm/module_instance.hpp
@@ -38,8 +38,6 @@ namespace kagome::runtime::wavm {
                    WAVM::Runtime::GCPointer<WAVM::Runtime::Instance> instance,
                    std::shared_ptr<const CompartmentWrapper> compartment);
 
-    ~ModuleInstance() override;
-
     outcome::result<PtrSize> callExportFunction(std::string_view name,
                                                 PtrSize args) const override;
 

--- a/core/runtime/wavm/wavm_memory_provider.cpp
+++ b/core/runtime/wavm/wavm_memory_provider.cpp
@@ -12,12 +12,9 @@
 namespace kagome::runtime::wavm {
 
   WavmMemoryProvider::WavmMemoryProvider(
-      std::shared_ptr<IntrinsicModuleInstance> module,
-      std::shared_ptr<const CompartmentWrapper> compartment)
-      : intrinsic_module_{std::move(module)},
-        compartment_{std::move(compartment)} {
+      std::shared_ptr<IntrinsicModuleInstance> module)
+      : intrinsic_module_{std::move(module)} {
     BOOST_ASSERT(intrinsic_module_);
-    BOOST_ASSERT(compartment_);
   }
 
   boost::optional<runtime::Memory &> WavmMemoryProvider::getCurrentMemory()
@@ -29,7 +26,7 @@ namespace kagome::runtime::wavm {
 
   outcome::result<void> WavmMemoryProvider::resetMemory(WasmSize heap_base) {
     current_memory_ = std::make_unique<MemoryImpl>(
-        compartment_, intrinsic_module_->getExportedMemory(), heap_base);
+        intrinsic_module_->getExportedMemory(), heap_base);
     return outcome::success();
   }
 

--- a/core/runtime/wavm/wavm_memory_provider.hpp
+++ b/core/runtime/wavm/wavm_memory_provider.hpp
@@ -17,8 +17,7 @@ namespace kagome::runtime::wavm {
   class WavmMemoryProvider final : public MemoryProvider {
    public:
     WavmMemoryProvider(
-        std::shared_ptr<IntrinsicModuleInstance> intrinsic_module,
-        std::shared_ptr<const CompartmentWrapper> compartment_wrapper);
+        std::shared_ptr<IntrinsicModuleInstance> intrinsic_module);
 
     boost::optional<runtime::Memory &> getCurrentMemory() const override;
     outcome::result<void> resetMemory(WasmSize heap_base) override;
@@ -27,7 +26,6 @@ namespace kagome::runtime::wavm {
     // it contains the memory itself
     std::shared_ptr<IntrinsicModuleInstance> intrinsic_module_;
     std::shared_ptr<Memory> current_memory_;
-    std::shared_ptr<const CompartmentWrapper> compartment_;
   };
 
 }  // namespace kagome::runtime::wavm


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues
resolves #879
<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
Currently used version of WAVM has a bug where overflows in its internal index maps cause endless looping. In order to avoid it, we need to cleanup resources after each call.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Kagome doesn't get stuck every ~13300 blocks.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Resource cleanup on every block could be expensive, but it isn't.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Alternate Designs <!-- Optional -->
Update WAVM to the newest version, but cleanup of past runtime contexts is still a good thing.
<!-- Explain what other alternates were considered and why the proposed version was selected -->
