### PR TITLE
fix getting code from state after pruning

### DIFF
--- a/core/runtime/binaryen/core_api_factory_impl.cpp
+++ b/core/runtime/binaryen/core_api_factory_impl.cpp
@@ -24,9 +24,10 @@ namespace kagome::runtime::binaryen {
       BOOST_ASSERT(env_factory_);
     }
 
-    outcome::result<std::shared_ptr<runtime::ModuleInstance>>
-    getInstanceAt(std::shared_ptr<const RuntimeCodeProvider>,
-                  const primitives::BlockInfo &b) override {
+    outcome::result<std::shared_ptr<runtime::ModuleInstance>> getInstanceAt(
+        std::shared_ptr<const RuntimeCodeProvider>,
+        const primitives::BlockInfo &,
+        const primitives::BlockHeader &) override {
       if (instance_ == nullptr) {
         OUTCOME_TRY(module, ModuleImpl::createFromCode(code_, env_factory_));
         OUTCOME_TRY(inst, module->instantiate());

--- a/core/runtime/common/CMakeLists.txt
+++ b/core/runtime/common/CMakeLists.txt
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-
 add_library(storage_code_provider
     storage_code_provider.cpp
     uncompress_code_if_needed.cpp

--- a/core/runtime/common/module_repository_impl.hpp
+++ b/core/runtime/common/module_repository_impl.hpp
@@ -95,7 +95,8 @@ namespace kagome::runtime {
 
     outcome::result<std::shared_ptr<ModuleInstance>> getInstanceAt(
         std::shared_ptr<const RuntimeCodeProvider> code_provider,
-        const primitives::BlockInfo &block) override;
+        const primitives::BlockInfo &block,
+        const primitives::BlockHeader &header) override;
 
    private:
     static constexpr size_t MODULES_CACHE_SIZE = 2;

--- a/core/runtime/common/runtime_environment_factory.cpp
+++ b/core/runtime/common/runtime_environment_factory.cpp
@@ -78,9 +78,11 @@ namespace kagome::runtime {
 
     OUTCOME_TRY(instance,
                 parent_factory->module_repo_->getInstanceAt(
-                    parent_factory->code_provider_, blockchain_state_));
+                    parent_factory->code_provider_,
+                    blockchain_state_,
+                    header_res.value()));
 
-    auto& env = instance->getEnvironment();
+    auto &env = instance->getEnvironment();
     if (persistent_) {
       if (auto res = env.storage_provider->setToPersistentAt(storage_state_);
           !res) {

--- a/core/runtime/common/storage_code_provider.cpp
+++ b/core/runtime/common/storage_code_provider.cpp
@@ -61,5 +61,6 @@ namespace kagome::runtime {
       const storage::trie::EphemeralTrieBatch &batch) const {
     OUTCOME_TRY(code, batch.get(storage::kRuntimeCodeKey));
     OUTCOME_TRY(uncompressCodeIfNeeded(code, cached_code_));
+    return outcome::success();
   }
 }  // namespace kagome::runtime

--- a/core/runtime/common/storage_code_provider.cpp
+++ b/core/runtime/common/storage_code_provider.cpp
@@ -26,8 +26,16 @@ namespace kagome::runtime {
     BOOST_ASSERT(runtime_upgrade_tracker_ != nullptr);
     last_state_root_ = storage_->getRootHash();
     auto batch = storage_->getEphemeralBatch();
-    BOOST_ASSERT_MSG(batch.has_value(), "Error getting a batch of the storage");
-    setStateCodeFromBatch(*batch.value().get());
+    if (batch.has_error()) {
+      SL_CRITICAL(logger_,
+                  "Error getting a batch of the storage: {}",
+                  batch.error().message());
+    }
+    auto res = setCodeFromBatch(*batch.value().get());
+    if (res.has_error()) {
+      SL_CRITICAL(
+          logger_, "Error setting code from batch: {}", res.error().message());
+    }
   }
 
   outcome::result<gsl::span<const uint8_t>> StorageCodeProvider::getCodeAt(
@@ -39,21 +47,19 @@ namespace kagome::runtime {
       if (hash.has_value()) {
         if (auto code_it = code_substitutes_.find(hash.value());
             code_it != code_substitutes_.end()) {
-          uncompressCodeIfNeeded(code_it->second, cached_code_);
+          OUTCOME_TRY(uncompressCodeIfNeeded(code_it->second, cached_code_));
           return cached_code_;
         }
       }
       OUTCOME_TRY(batch, storage_->getEphemeralBatchAt(state));
-      setStateCodeFromBatch(*batch.get());
+      OUTCOME_TRY(setCodeFromBatch(*batch.get()));
     }
     return cached_code_;
   }
 
-  void StorageCodeProvider::setStateCodeFromBatch(
+  outcome::result<void> StorageCodeProvider::setCodeFromBatch(
       const storage::trie::EphemeralTrieBatch &batch) const {
-    auto state_code_res = batch.get(storage::kRuntimeCodeKey);
-    BOOST_ASSERT_MSG(state_code_res.has_value(),
-                     "Runtime code does not exist in the storage");
-    uncompressCodeIfNeeded(state_code_res.value(), cached_code_);
+    OUTCOME_TRY(code, batch.get(storage::kRuntimeCodeKey));
+    OUTCOME_TRY(uncompressCodeIfNeeded(code, cached_code_));
   }
 }  // namespace kagome::runtime

--- a/core/runtime/common/storage_code_provider.hpp
+++ b/core/runtime/common/storage_code_provider.hpp
@@ -34,8 +34,7 @@ namespace kagome::runtime {
 
    private:
     void setStateCodeFromBatch(
-        const outcome::result<
-            std::unique_ptr<storage::trie::EphemeralTrieBatch>> &batch) const;
+        const storage::trie::EphemeralTrieBatch &batch) const;
     std::shared_ptr<const storage::trie::TrieStorage> storage_;
     std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker_;
     const application::CodeSubstitutes &code_substitutes_;

--- a/core/runtime/common/storage_code_provider.hpp
+++ b/core/runtime/common/storage_code_provider.hpp
@@ -33,7 +33,7 @@ namespace kagome::runtime {
         const storage::trie::RootHash &state) const override;
 
    private:
-    void setStateCodeFromBatch(
+    outcome::result<void> setCodeFromBatch(
         const storage::trie::EphemeralTrieBatch &batch) const;
     std::shared_ptr<const storage::trie::TrieStorage> storage_;
     std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker_;

--- a/core/runtime/common/uncompress_code_if_needed.hpp
+++ b/core/runtime/common/uncompress_code_if_needed.hpp
@@ -9,7 +9,12 @@
 #include "common/buffer.hpp"
 
 namespace kagome::runtime {
-  void uncompressCodeIfNeeded(const common::Buffer &buf, common::Buffer &res);
+  enum class UncompressError : uint8_t { ZSTD_ERROR };
+
+  outcome::result<void> uncompressCodeIfNeeded(const common::Buffer &buf,
+                                               common::Buffer &res);
 }  // namespace kagome::runtime
+
+OUTCOME_HPP_DECLARE_ERROR(kagome::runtime, UncompressError);
 
 #endif  // KAGOME_CORE_RUNTIME_UNCOMPRESS_IF_NEEDED_HPP

--- a/core/runtime/module_repository.hpp
+++ b/core/runtime/module_repository.hpp
@@ -40,9 +40,10 @@ namespace kagome::runtime {
      * @param block info of the block at which the runtime code should be
      * extracted
      */
-    virtual outcome::result<std::shared_ptr<ModuleInstance>>
-    getInstanceAt(std::shared_ptr<const RuntimeCodeProvider> code_provider,
-                  const primitives::BlockInfo &block) = 0;
+    virtual outcome::result<std::shared_ptr<ModuleInstance>> getInstanceAt(
+        std::shared_ptr<const RuntimeCodeProvider> code_provider,
+        const primitives::BlockInfo &block,
+        const primitives::BlockHeader &header) = 0;
   };
 
 }  // namespace kagome::runtime

--- a/core/runtime/module_repository.hpp
+++ b/core/runtime/module_repository.hpp
@@ -39,6 +39,7 @@ namespace kagome::runtime {
      * from the given block
      * @param block info of the block at which the runtime code should be
      * extracted
+     * @param header of the block at which the runtime code should be extracted
      */
     virtual outcome::result<std::shared_ptr<ModuleInstance>> getInstanceAt(
         std::shared_ptr<const RuntimeCodeProvider> code_provider,

--- a/core/runtime/wavm/core_api_factory_impl.cpp
+++ b/core/runtime/wavm/core_api_factory_impl.cpp
@@ -39,7 +39,8 @@ namespace kagome::runtime::wavm {
 
     outcome::result<std::shared_ptr<runtime::ModuleInstance>> getInstanceAt(
         std::shared_ptr<const RuntimeCodeProvider>,
-        const primitives::BlockInfo &) override {
+        const primitives::BlockInfo &,
+        const primitives::BlockHeader &) override {
       if (instance_ == nullptr) {
         auto module = ModuleImpl::compileFrom(
             compartment_, intrinsic_module_, instance_env_factory_, code_);

--- a/test/mock/core/runtime/module_repository_mock.hpp
+++ b/test/mock/core/runtime/module_repository_mock.hpp
@@ -16,10 +16,11 @@ namespace kagome::runtime {
 
   class ModuleRepositoryMock final : public ModuleRepository {
    public:
-    MOCK_METHOD2(getInstanceAt,
+    MOCK_METHOD3(getInstanceAt,
                  outcome::result<std::shared_ptr<ModuleInstance>>(
                      std::shared_ptr<const RuntimeCodeProvider> code_provider,
-                     const primitives::BlockInfo &block));
+                     const primitives::BlockInfo &block,
+                     const primitives::BlockHeader &header));
   };
 
 }  // namespace kagome::runtime


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues
Fix for #864
<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
In case state is not present in DB (after pruning) use last state code.
Header is passed into getInstanceAt for reading latest state root.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs <!-- Optional -->

<!-- Explain what other alternates were considered and why the proposed version was selected -->
