### PR TITLE
cmake: build all runtime tests

### DIFF
--- a/test/core/runtime/CMakeLists.txt
+++ b/test/core/runtime/CMakeLists.txt
@@ -2,6 +2,8 @@
 # Copyright Soramitsu Co., Ltd. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
+add_subdirectory(binaryen)
+add_subdirectory(wavm)
 
 addtest(wasm_result_test
     wasm_result_test.cpp


### PR DESCRIPTION
### Referenced issues

Currently the two subfolders `binaryen` and `wavm` of `test/core/runtime` are not included when building the testsuite.

### Description of the Change

This patch add the two missing subfolders and their respective `CMakeLists.txt` file to CMake's the build tree.

Build currently fails because the added tests never compiled when committed in the first place and new changes e.g. in #914 added to that.

### Benefits

Once compilation issues are resolved, the new tests for both runtime backends are build and executed.

### Possible Drawbacks 
 
Somebody now has to fix all the broken tests in these subfolders.
