### PR TITLE
Move CodeSubstitutes to primitives

### DIFF
--- a/core/application/chain_spec.hpp
+++ b/core/application/chain_spec.hpp
@@ -7,13 +7,14 @@
 #define KAGOME_CHAIN_SPEC_HPP
 
 #include <libp2p/peer/peer_info.hpp>
+
 #include "crypto/ed25519_types.hpp"
 #include "crypto/sr25519_types.hpp"
 #include "primitives/block.hpp"
+#include "primitives/code_substitutes.hpp"
 
 namespace kagome::application {
 
-  using CodeSubstitutes = std::map<primitives::BlockHash, common::Buffer>;
   using GenesisRawData = std::vector<std::pair<common::Buffer, common::Buffer>>;
 
   /**
@@ -53,7 +54,7 @@ namespace kagome::application {
     /**
      * @return runtime code substitution map
      */
-    virtual const CodeSubstitutes &codeSubstitutes() const = 0;
+    virtual const primitives::CodeSubstitutes &codeSubstitutes() const = 0;
 
     /**
      * @return genesis block of the chain

--- a/core/application/impl/chain_spec_impl.hpp
+++ b/core/application/impl/chain_spec_impl.hpp
@@ -11,6 +11,7 @@
 #include <boost/property_tree/ptree.hpp>
 
 #include "log/logger.hpp"
+#include "primitives/code_substitutes.hpp"
 
 namespace kagome::application {
 
@@ -78,7 +79,7 @@ namespace kagome::application {
       return consensus_engine_;
     }
 
-    const CodeSubstitutes& codeSubstitutes() const override {
+    const primitives::CodeSubstitutes& codeSubstitutes() const override {
       return code_substitutes_;
     }
 
@@ -116,7 +117,7 @@ namespace kagome::application {
     std::set<primitives::BlockHash> fork_blocks_;
     std::set<primitives::BlockHash> bad_blocks_;
     boost::optional<std::string> consensus_engine_;
-    CodeSubstitutes code_substitutes_;
+    primitives::CodeSubstitutes code_substitutes_;
     GenesisRawData genesis_;
     log::Logger log_ = log::createLogger("chain_spec", "kagome");
   };

--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -930,7 +930,7 @@ namespace {
 
         di::bind<application::AppStateManager>.template to<application::AppStateManagerImpl>(),
         di::bind<application::AppConfiguration>.to(config),
-        di::bind<application::CodeSubstitutes>.to(
+        di::bind<primitives::CodeSubstitutes>.to(
             get_chain_spec(config)->codeSubstitutes()),
 
         // compose peer keypair

--- a/core/primitives/code_substitutes.hpp
+++ b/core/primitives/code_substitutes.hpp
@@ -1,0 +1,15 @@
+/**
+* Copyright Soramitsu Co., Ltd. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+#ifndef KAGOME_CODE_SUBSTITUTES_HPP
+#define KAGOME_CODE_SUBSTITUTES_HPP
+
+namespace kagome::primitives {
+
+  using CodeSubstitutes = std::map<primitives::BlockHash, common::Buffer>;
+
+}
+
+#endif  // KAGOME_CODE_SUBSTITUTES_HPP

--- a/core/runtime/common/runtime_upgrade_tracker_impl.cpp
+++ b/core/runtime/common/runtime_upgrade_tracker_impl.cpp
@@ -29,7 +29,7 @@ namespace kagome::runtime {
   RuntimeUpgradeTrackerImpl::RuntimeUpgradeTrackerImpl(
       std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo,
       std::shared_ptr<storage::BufferStorage> storage,
-      const application::CodeSubstitutes &code_substitutes)
+      const primitives::CodeSubstitutes &code_substitutes)
       : header_repo_{std::move(header_repo)},
         storage_{std::move(storage)},
         code_substitutes_{code_substitutes},

--- a/core/runtime/common/runtime_upgrade_tracker_impl.hpp
+++ b/core/runtime/common/runtime_upgrade_tracker_impl.hpp
@@ -29,7 +29,7 @@ namespace kagome::runtime {
     RuntimeUpgradeTrackerImpl(
         std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo,
         std::shared_ptr<storage::BufferStorage> storage,
-        const application::CodeSubstitutes &code_substitutes);
+        const primitives::CodeSubstitutes &code_substitutes);
 
     struct RuntimeUpgradeData {
       RuntimeUpgradeData() = default;
@@ -87,7 +87,7 @@ namespace kagome::runtime {
     std::shared_ptr<const blockchain::BlockTree> block_tree_;
     std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo_;
     std::shared_ptr<storage::BufferStorage> storage_;
-    const application::CodeSubstitutes &code_substitutes_;
+    const primitives::CodeSubstitutes &code_substitutes_;
     log::Logger logger_;
   };
 

--- a/core/runtime/common/storage_code_provider.cpp
+++ b/core/runtime/common/storage_code_provider.cpp
@@ -18,7 +18,7 @@ namespace kagome::runtime {
   StorageCodeProvider::StorageCodeProvider(
       std::shared_ptr<const storage::trie::TrieStorage> storage,
       std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker,
-      const application::CodeSubstitutes &code_substitutes)
+      const primitives::CodeSubstitutes &code_substitutes)
       : storage_{std::move(storage)},
         runtime_upgrade_tracker_{std::move(runtime_upgrade_tracker)},
         code_substitutes_{code_substitutes} {

--- a/core/runtime/common/storage_code_provider.hpp
+++ b/core/runtime/common/storage_code_provider.hpp
@@ -27,7 +27,7 @@ namespace kagome::runtime {
     explicit StorageCodeProvider(
         std::shared_ptr<const storage::trie::TrieStorage> storage,
         std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker,
-        const application::CodeSubstitutes &code_substitutes);
+        const primitives::CodeSubstitutes &code_substitutes);
 
     outcome::result<gsl::span<const uint8_t>> getCodeAt(
         const storage::trie::RootHash &state) const override;
@@ -37,7 +37,7 @@ namespace kagome::runtime {
         const storage::trie::EphemeralTrieBatch &batch) const;
     std::shared_ptr<const storage::trie::TrieStorage> storage_;
     std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker_;
-    const application::CodeSubstitutes &code_substitutes_;
+    const primitives::CodeSubstitutes &code_substitutes_;
     mutable common::Buffer cached_code_;
     mutable storage::trie::RootHash last_state_root_;
     log::Logger logger_;

--- a/test/core/runtime/runtime_upgrade_tracker_test.cpp
+++ b/test/core/runtime/runtime_upgrade_tracker_test.cpp
@@ -72,7 +72,7 @@ class RuntimeUpgradeTrackerTest : public testing::Test {
       sub_engine_;
   std::shared_ptr<kagome::storage::BufferStorage> storage_;
 
-  kagome::application::CodeSubstitutes code_substitutes_{};
+  kagome::primitives::CodeSubstitutes code_substitutes_{};
   kagome::primitives::BlockInfo genesis_block{0, "block_genesis_hash"_hash256};
   kagome::primitives::BlockHeader genesis_block_header{
       ""_hash256,

--- a/test/core/runtime/storage_code_provider_test.cpp
+++ b/test/core/runtime/storage_code_provider_test.cpp
@@ -56,7 +56,7 @@ TEST_F(StorageCodeProviderTest, GetCodeWhenNoStorageUpdates) {
     return batch;
   }));
   auto wasm_provider = std::make_shared<runtime::StorageCodeProvider>(
-      trie_db, tracker, application::CodeSubstitutes{});
+      trie_db, tracker, primitives::CodeSubstitutes{});
 
   // when
   EXPECT_OUTCOME_TRUE(obtained_state_code,
@@ -91,7 +91,7 @@ TEST_F(StorageCodeProviderTest, DISABLED_GetCodeWhenStorageUpdates) {
     return batch;
   }));
   auto wasm_provider = std::make_shared<runtime::StorageCodeProvider>(
-      trie_db, tracker, application::CodeSubstitutes{});
+      trie_db, tracker, primitives::CodeSubstitutes{});
 
   common::Buffer new_state_code{{1, 3, 3, 8}};
   EXPECT_CALL(*trie_db, getEphemeralBatchAt(second_state_root))

--- a/test/core/runtime/uncompress_code_test.cpp
+++ b/test/core/runtime/uncompress_code_test.cpp
@@ -21,28 +21,28 @@ class UncompressCodeIfNeeded : public ::testing::Test {
 TEST_F(UncompressCodeIfNeeded, NotOkSize) {
   common::Buffer buf(5, 'a');
   common::Buffer res;
-  uncompressCodeIfNeeded(buf, res);
+  std::ignore = uncompressCodeIfNeeded(buf, res);
   ASSERT_EQ(res, buf);
 }
 
 TEST_F(UncompressCodeIfNeeded, NotNeeded) {
   common::Buffer buf(9, 'a');
   common::Buffer res;
-  uncompressCodeIfNeeded(buf, res);
+  std::ignore = uncompressCodeIfNeeded(buf, res);
   ASSERT_EQ(res, buf);
 }
 
 TEST_F(UncompressCodeIfNeeded, NotNeeded2) {
   common::Buffer buf({0x52, 0xBC, 0x53, 0x76, 0x46, 0xDB, 0x8E, 0x06, 0xFF});
   common::Buffer res({0xAA});
-  uncompressCodeIfNeeded(buf, res);
+  std::ignore = uncompressCodeIfNeeded(buf, res);
   ASSERT_EQ(res, buf);
 }
 
 TEST_F(UncompressCodeIfNeeded, UncompressFail) {
   common::Buffer buf({0x52, 0xBC, 0x53, 0x76, 0x46, 0xDB, 0x8E, 0x05, 0xFF});
   common::Buffer res({0xAA});
-  uncompressCodeIfNeeded(buf, res);
+  std::ignore = uncompressCodeIfNeeded(buf, res);
   ASSERT_EQ(res, common::Buffer({0xAA}));
 }
 
@@ -51,6 +51,6 @@ TEST_F(UncompressCodeIfNeeded, UncompressSucceed) {
       common::Buffer::fromHex("52BC537646DB8E0528B52FFD200421000062616265")
           .value();
   common::Buffer res;
-  uncompressCodeIfNeeded(buf, res);
+  std::ignore = uncompressCodeIfNeeded(buf, res);
   ASSERT_EQ(res, common::Buffer({'b', 'a', 'b', 'e'}));
 }

--- a/test/mock/core/application/chain_spec_mock.hpp
+++ b/test/mock/core/application/chain_spec_mock.hpp
@@ -42,7 +42,7 @@ namespace kagome::application {
 
     MOCK_CONST_METHOD0(consensusEngine, boost::optional<std::string>());
 
-    MOCK_CONST_METHOD0(codeSubstitutes, const CodeSubstitutes &());
+    MOCK_CONST_METHOD0(codeSubstitutes, const primitives::CodeSubstitutes &());
 
     MOCK_CONST_METHOD0(getGenesis, GenesisRawData());
   };


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
Move CodeSubstitutes type definition to primitives/ from application/
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
runtime/ won't depend on application/ (which is not just sort of counterintuitive, but also, for example, breaks some classes in runtime/ when installing Kagoma and using her as an external project).
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None expected.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
