### PR TITLE
Fix extrinsics propagation

### DIFF
--- a/core/api/jrpc/value_converter.hpp
+++ b/core/api/jrpc/value_converter.hpp
@@ -262,7 +262,7 @@ namespace kagome::api {
         [](const primitives::events::BroadcastEventParams &params)
             -> jsonrpc::Value {
           jArray peers;
-          peers.reserve(params.peers.size());
+          peers.resize(params.peers.size());
           std::transform(
               params.peers.cbegin(),
               params.peers.cend(),

--- a/core/network/impl/protocols/propagate_transactions_protocol.cpp
+++ b/core/network/impl/protocols/propagate_transactions_protocol.cpp
@@ -6,8 +6,8 @@
 #include "network/impl/protocols/propagate_transactions_protocol.hpp"
 
 #include "network/common.hpp"
-#include "network/types/no_data_message.hpp"
 #include "network/impl/protocols/protocol_error.hpp"
+#include "network/types/no_data_message.hpp"
 
 namespace kagome::network {
 
@@ -207,15 +207,8 @@ namespace kagome::network {
               cb(outcome::success());
               break;
             case Direction::INCOMING:
-              if (self->babe_->getCurrentState()
-                  == consensus::babe::Babe::State::SYNCHRONIZED) {
-                self->writeHandshake(
-                    std::move(stream), Direction::INCOMING, std::move(cb));
-                return;
-              }
-
-              stream->close([](auto &&...) {});
-              cb(ProtocolError::NODE_NOT_SYNCHRONIZED_YET);
+              self->writeHandshake(
+                  std::move(stream), Direction::INCOMING, std::move(cb));
               break;
           }
         });


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

Resolves https://github.com/soramitsu/kagome/issues/967

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change

Fixes segfault caused by writing to unallocated memory (`value_converter.hpp`)
Prevents early stream closing for propagate-transactions-protocol, which was the cause of an extrinsic was not broadcast to a validating node.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

No app crash on interaction

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

None

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->

Repro steps from #967

Works correctly with `parity/polkadot:v0.9.12`

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->
