### PR TITLE
Make code_substitute loading lazy (#935)

### DIFF
--- a/core/application/chain_spec.hpp
+++ b/core/application/chain_spec.hpp
@@ -51,7 +51,7 @@ namespace kagome::application {
 
     virtual std::optional<std::string> consensusEngine() const = 0;
 
-    virtual outcome::result<common::Buffer> fetchCodeByHash(const common::Hash256 hash) = 0;
+    virtual outcome::result<common::Buffer> fetchCodeByHash(const common::Hash256 hash) const = 0;
 
     /**
      * @return runtime code substitution map

--- a/core/application/chain_spec.hpp
+++ b/core/application/chain_spec.hpp
@@ -51,14 +51,16 @@ namespace kagome::application {
 
     virtual std::optional<std::string> consensusEngine() const = 0;
 
+    /// Fetches code_substitute from json config on demand, by its hash.
+    /// Hashes are being loaded on initial configuration and stored in set.
     virtual outcome::result<common::Buffer> fetchCodeSubstituteByHash(
-        const common::Hash256 hash) const = 0;
+        const common::Hash256 &hash) const = 0;
 
     /**
      * @return runtime code substitution map
      */
-    virtual std::shared_ptr<const primitives::CodeSubstitutes> codeSubstitutes()
-        const = 0;
+    virtual std::shared_ptr<const primitives::CodeSubstituteHashes>
+    codeSubstitutes() const = 0;
 
     /**
      * @return genesis block of the chain

--- a/core/application/chain_spec.hpp
+++ b/core/application/chain_spec.hpp
@@ -51,6 +51,8 @@ namespace kagome::application {
 
     virtual std::optional<std::string> consensusEngine() const = 0;
 
+    virtual outcome::result<common::Buffer> fetchCodeByHash(const common::Hash256 hash) = 0;
+
     /**
      * @return runtime code substitution map
      */

--- a/core/application/chain_spec.hpp
+++ b/core/application/chain_spec.hpp
@@ -51,7 +51,8 @@ namespace kagome::application {
 
     virtual std::optional<std::string> consensusEngine() const = 0;
 
-    virtual outcome::result<common::Buffer> fetchCodeByHash(const common::Hash256 hash) const = 0;
+    virtual outcome::result<common::Buffer> fetchCodeSubstituteByHash(
+        const common::Hash256 hash) const = 0;
 
     /**
      * @return runtime code substitution map

--- a/core/application/impl/chain_spec_impl.cpp
+++ b/core/application/impl/chain_spec_impl.cpp
@@ -171,7 +171,8 @@ namespace kagome::application {
     return outcome::success();
   }
 
-  outcome::result<common::Buffer> ChainSpecImpl::fetchCodeByHash(const common::Hash256 hash) const {
+  outcome::result<common::Buffer> ChainSpecImpl::fetchCodeSubstituteByHash(
+      const common::Hash256 hash) const {
     pt::ptree tree;
     try {
       pt::read_json(config_path_, tree);
@@ -185,7 +186,7 @@ namespace kagome::application {
     if (code_substitutes_opt.has_value()) {
       for (const auto &[_hash, _code] : code_substitutes_opt.value()) {
         OUTCOME_TRY(hash_processed, common::Hash256::fromHexWithPrefix(_hash));
-        if (hash_processed == hash){
+        if (hash_processed == hash) {
           OUTCOME_TRY(code_processed, common::unhexWith0x(_code.data()));
           return outcome::success(code_processed);
         }

--- a/core/application/impl/chain_spec_impl.cpp
+++ b/core/application/impl/chain_spec_impl.cpp
@@ -171,7 +171,7 @@ namespace kagome::application {
     return outcome::success();
   }
 
-  outcome::result<common::Buffer> ChainSpecImpl::fetchCodeByHash(const common::Hash256 hash) {
+  outcome::result<common::Buffer> ChainSpecImpl::fetchCodeByHash(const common::Hash256 hash) const {
     pt::ptree tree;
     try {
       pt::read_json(config_path_, tree);

--- a/core/application/impl/chain_spec_impl.cpp
+++ b/core/application/impl/chain_spec_impl.cpp
@@ -33,7 +33,7 @@ namespace kagome::application {
       const std::string &path) {
     // done so because of private constructor
     std::shared_ptr<ChainSpecImpl> config_storage{new ChainSpecImpl};
-    config_storage->code_substitutes_ =
+    config_storage->known_code_substitutes_ =
         std::make_shared<primitives::CodeSubstituteHashes>();
     OUTCOME_TRY(config_storage->loadFromJson(path));
 
@@ -163,7 +163,7 @@ namespace kagome::application {
     if (code_substitutes_opt.has_value()) {
       for (const auto &[hash, code] : code_substitutes_opt.value()) {
         OUTCOME_TRY(hash_processed, common::Hash256::fromHexWithPrefix(hash));
-        code_substitutes_->emplace(hash_processed);
+        known_code_substitutes_->emplace(hash_processed);
       }
     }
 
@@ -172,6 +172,10 @@ namespace kagome::application {
 
   outcome::result<common::Buffer> ChainSpecImpl::fetchCodeSubstituteByHash(
       const common::Hash256 &hash) const {
+    if (!known_code_substitutes_->count(hash)) {
+      return Error::MISSING_ENTRY;
+    }
+
     pt::ptree tree;
     try {
       pt::read_json(config_path_, tree);

--- a/core/application/impl/chain_spec_impl.cpp
+++ b/core/application/impl/chain_spec_impl.cpp
@@ -34,7 +34,7 @@ namespace kagome::application {
     // done so because of private constructor
     std::shared_ptr<ChainSpecImpl> config_storage{new ChainSpecImpl};
     config_storage->code_substitutes_ =
-        std::make_shared<primitives::CodeSubstitutes>();
+        std::make_shared<primitives::CodeSubstituteHashes>();
     OUTCOME_TRY(config_storage->loadFromJson(path));
 
     return config_storage;
@@ -163,7 +163,6 @@ namespace kagome::application {
     if (code_substitutes_opt.has_value()) {
       for (const auto &[hash, code] : code_substitutes_opt.value()) {
         OUTCOME_TRY(hash_processed, common::Hash256::fromHexWithPrefix(hash));
-        // OUTCOME_TRY(code_processed, common::unhexWith0x(code.data()));
         code_substitutes_->emplace(hash_processed);
       }
     }
@@ -172,7 +171,7 @@ namespace kagome::application {
   }
 
   outcome::result<common::Buffer> ChainSpecImpl::fetchCodeSubstituteByHash(
-      const common::Hash256 hash) const {
+      const common::Hash256 &hash) const {
     pt::ptree tree;
     try {
       pt::read_json(config_path_, tree);
@@ -192,7 +191,7 @@ namespace kagome::application {
         }
       }
     }
-    return outcome::failure(Error::MISSING_ENTRY);
+    return Error::MISSING_ENTRY;
   }
 
   outcome::result<void> ChainSpecImpl::loadGenesis(

--- a/core/application/impl/chain_spec_impl.hpp
+++ b/core/application/impl/chain_spec_impl.hpp
@@ -88,7 +88,8 @@ namespace kagome::application {
       return genesis_;
     }
 
-    outcome::result<common::Buffer> fetchCodeByHash(const common::Hash256 hash) const override;
+    outcome::result<common::Buffer> fetchCodeSubstituteByHash(
+        const common::Hash256 hash) const override;
 
    private:
     outcome::result<void> loadFromJson(const std::string &file_path);

--- a/core/application/impl/chain_spec_impl.hpp
+++ b/core/application/impl/chain_spec_impl.hpp
@@ -88,6 +88,8 @@ namespace kagome::application {
       return genesis_;
     }
 
+    outcome::result<common::Buffer> fetchCodeByHash(const common::Hash256 hash) override;
+
    private:
     outcome::result<void> loadFromJson(const std::string &file_path);
     outcome::result<void> loadFields(const boost::property_tree::ptree &tree);
@@ -111,6 +113,7 @@ namespace kagome::application {
     std::string name_;
     std::string id_;
     std::string chain_type_;
+    std::string config_path_;
     std::vector<libp2p::multi::Multiaddress> boot_nodes_;
     std::vector<std::pair<std::string, size_t>> telemetry_endpoints_;
     std::string protocol_id_{"sup"};

--- a/core/application/impl/chain_spec_impl.hpp
+++ b/core/application/impl/chain_spec_impl.hpp
@@ -79,7 +79,7 @@ namespace kagome::application {
       return consensus_engine_;
     }
 
-    std::shared_ptr<const primitives::CodeSubstitutes> codeSubstitutes()
+    std::shared_ptr<const primitives::CodeSubstituteHashes> codeSubstitutes()
         const override {
       return code_substitutes_;
     }
@@ -89,7 +89,7 @@ namespace kagome::application {
     }
 
     outcome::result<common::Buffer> fetchCodeSubstituteByHash(
-        const common::Hash256 hash) const override;
+        const common::Hash256 &hash) const override;
 
    private:
     outcome::result<void> loadFromJson(const std::string &file_path);
@@ -122,7 +122,7 @@ namespace kagome::application {
     std::set<primitives::BlockHash> fork_blocks_;
     std::set<primitives::BlockHash> bad_blocks_;
     std::optional<std::string> consensus_engine_;
-    std::shared_ptr<primitives::CodeSubstitutes> code_substitutes_;
+    std::shared_ptr<primitives::CodeSubstituteHashes> code_substitutes_;
     GenesisRawData genesis_;
     log::Logger log_ = log::createLogger("chain_spec", "kagome");
   };

--- a/core/application/impl/chain_spec_impl.hpp
+++ b/core/application/impl/chain_spec_impl.hpp
@@ -88,7 +88,7 @@ namespace kagome::application {
       return genesis_;
     }
 
-    outcome::result<common::Buffer> fetchCodeByHash(const common::Hash256 hash) override;
+    outcome::result<common::Buffer> fetchCodeByHash(const common::Hash256 hash) const override;
 
    private:
     outcome::result<void> loadFromJson(const std::string &file_path);

--- a/core/application/impl/chain_spec_impl.hpp
+++ b/core/application/impl/chain_spec_impl.hpp
@@ -81,7 +81,7 @@ namespace kagome::application {
 
     std::shared_ptr<const primitives::CodeSubstituteHashes> codeSubstitutes()
         const override {
-      return code_substitutes_;
+      return known_code_substitutes_;
     }
 
     GenesisRawData getGenesis() const override {
@@ -122,7 +122,7 @@ namespace kagome::application {
     std::set<primitives::BlockHash> fork_blocks_;
     std::set<primitives::BlockHash> bad_blocks_;
     std::optional<std::string> consensus_engine_;
-    std::shared_ptr<primitives::CodeSubstituteHashes> code_substitutes_;
+    std::shared_ptr<primitives::CodeSubstituteHashes> known_code_substitutes_;
     GenesisRawData genesis_;
     log::Logger log_ = log::createLogger("chain_spec", "kagome");
   };

--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -855,9 +855,8 @@ namespace {
               sptr<const blockchain::BlockHeaderRepository>>();
           auto storage =
               injector.template create<sptr<storage::BufferStorage>>();
-          auto substitutes =
-              injector
-                  .template create<sptr<const primitives::CodeSubstitutes>>();
+          auto substitutes = injector.template create<
+              sptr<const primitives::CodeSubstituteHashes>>();
           auto res = runtime::RuntimeUpgradeTrackerImpl::create(
               std::move(header_repo),
               std::move(storage),
@@ -971,7 +970,7 @@ namespace {
 
         di::bind<application::AppStateManager>.template to<application::AppStateManagerImpl>(),
         di::bind<application::AppConfiguration>.to(config),
-        di::bind<primitives::CodeSubstitutes>.to(
+        di::bind<primitives::CodeSubstituteHashes>.to(
             get_chain_spec(config)->codeSubstitutes()),
 
         // compose peer keypair

--- a/core/primitives/code_substitutes.hpp
+++ b/core/primitives/code_substitutes.hpp
@@ -1,7 +1,7 @@
 /**
-* Copyright Soramitsu Co., Ltd. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
-*/
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #ifndef KAGOME_CODE_SUBSTITUTES_HPP
 #define KAGOME_CODE_SUBSTITUTES_HPP

--- a/core/primitives/code_substitutes.hpp
+++ b/core/primitives/code_substitutes.hpp
@@ -10,8 +10,10 @@
 
 namespace kagome::primitives {
 
-  using CodeSubstitutes = std::unordered_set<primitives::BlockHash>;
+  /// A set of valid code_substitute hashes.
+  /// You can pass them to fetchCodeSubstituteByHash() and get code_substitute.
+  using CodeSubstituteHashes = std::unordered_set<primitives::BlockHash>;
 
-}
+}  // namespace kagome::primitives
 
 #endif  // KAGOME_CODE_SUBSTITUTES_HPP

--- a/core/primitives/code_substitutes.hpp
+++ b/core/primitives/code_substitutes.hpp
@@ -6,9 +6,11 @@
 #ifndef KAGOME_CODE_SUBSTITUTES_HPP
 #define KAGOME_CODE_SUBSTITUTES_HPP
 
+#include <unordered_set>
+
 namespace kagome::primitives {
 
-  using CodeSubstitutes = std::map<primitives::BlockHash, common::Buffer>;
+  using CodeSubstitutes = std::unordered_set<primitives::BlockHash>;
 
 }
 

--- a/core/runtime/common/runtime_upgrade_tracker_impl.cpp
+++ b/core/runtime/common/runtime_upgrade_tracker_impl.cpp
@@ -30,7 +30,8 @@ namespace kagome::runtime {
   RuntimeUpgradeTrackerImpl::create(
       std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo,
       std::shared_ptr<storage::BufferStorage> storage,
-      std::shared_ptr<const primitives::CodeSubstitutes> code_substitutes) {
+      std::shared_ptr<const primitives::CodeSubstituteHashes>
+          code_substitutes) {
     BOOST_ASSERT(header_repo);
     BOOST_ASSERT(storage);
     BOOST_ASSERT(code_substitutes);
@@ -54,7 +55,7 @@ namespace kagome::runtime {
   RuntimeUpgradeTrackerImpl::RuntimeUpgradeTrackerImpl(
       std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo,
       std::shared_ptr<storage::BufferStorage> storage,
-      std::shared_ptr<const primitives::CodeSubstitutes> code_substitutes,
+      std::shared_ptr<const primitives::CodeSubstituteHashes> code_substitutes,
       std::vector<RuntimeUpgradeData> &&saved_data)
       : runtime_upgrades_{std::move(saved_data)},
         header_repo_{std::move(header_repo)},

--- a/core/runtime/common/runtime_upgrade_tracker_impl.cpp
+++ b/core/runtime/common/runtime_upgrade_tracker_impl.cpp
@@ -60,12 +60,13 @@ namespace kagome::runtime {
       : runtime_upgrades_{std::move(saved_data)},
         header_repo_{std::move(header_repo)},
         storage_{std::move(storage)},
-        code_substitutes_{std::move(code_substitutes)},
+        known_code_substitutes_{std::move(code_substitutes)},
         logger_{log::createLogger("StorageCodeProvider", "runtime")} {}
 
   bool RuntimeUpgradeTrackerImpl::hasCodeSubstitute(
       const kagome::primitives::BlockHash &hash) const {
-    return code_substitutes_->find(hash) != code_substitutes_->end();
+    return known_code_substitutes_->find(hash)
+           != known_code_substitutes_->end();
   }
 
   bool RuntimeUpgradeTrackerImpl::isStateInChain(

--- a/core/runtime/common/runtime_upgrade_tracker_impl.hpp
+++ b/core/runtime/common/runtime_upgrade_tracker_impl.hpp
@@ -33,7 +33,8 @@ namespace kagome::runtime {
     static outcome::result<std::unique_ptr<RuntimeUpgradeTrackerImpl>> create(
         std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo,
         std::shared_ptr<storage::BufferStorage> storage,
-        std::shared_ptr<const primitives::CodeSubstitutes> code_substitutes);
+        std::shared_ptr<const primitives::CodeSubstituteHashes>
+            code_substitutes);
 
     struct RuntimeUpgradeData {
       RuntimeUpgradeData() = default;
@@ -70,7 +71,8 @@ namespace kagome::runtime {
     RuntimeUpgradeTrackerImpl(
         std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo,
         std::shared_ptr<storage::BufferStorage> storage,
-        std::shared_ptr<const primitives::CodeSubstitutes> code_substitutes,
+        std::shared_ptr<const primitives::CodeSubstituteHashes>
+            code_substitutes,
         std::vector<RuntimeUpgradeData> &&saved_data);
 
     bool isStateInChain(const primitives::BlockInfo &state,
@@ -97,7 +99,7 @@ namespace kagome::runtime {
     std::shared_ptr<const blockchain::BlockTree> block_tree_;
     std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo_;
     std::shared_ptr<storage::BufferStorage> storage_;
-    std::shared_ptr<const primitives::CodeSubstitutes> code_substitutes_;
+    std::shared_ptr<const primitives::CodeSubstituteHashes> code_substitutes_;
     log::Logger logger_;
   };
 

--- a/core/runtime/common/runtime_upgrade_tracker_impl.hpp
+++ b/core/runtime/common/runtime_upgrade_tracker_impl.hpp
@@ -99,7 +99,8 @@ namespace kagome::runtime {
     std::shared_ptr<const blockchain::BlockTree> block_tree_;
     std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo_;
     std::shared_ptr<storage::BufferStorage> storage_;
-    std::shared_ptr<const primitives::CodeSubstituteHashes> code_substitutes_;
+    std::shared_ptr<const primitives::CodeSubstituteHashes>
+        known_code_substitutes_;
     log::Logger logger_;
   };
 

--- a/core/runtime/common/storage_code_provider.cpp
+++ b/core/runtime/common/storage_code_provider.cpp
@@ -22,7 +22,7 @@ namespace kagome::runtime {
       std::shared_ptr<application::ChainSpec> chain_spec)
       : storage_{std::move(storage)},
         runtime_upgrade_tracker_{std::move(runtime_upgrade_tracker)},
-        code_substitutes_{std::move(code_substitutes)},
+        known_code_substitutes_{std::move(code_substitutes)},
         chain_spec_{std::move(chain_spec)} {
     BOOST_ASSERT(storage_ != nullptr);
     BOOST_ASSERT(runtime_upgrade_tracker_ != nullptr);
@@ -47,7 +47,7 @@ namespace kagome::runtime {
 
       auto hash = runtime_upgrade_tracker_->getLastCodeUpdateHash(state);
       if (hash.has_value()) {
-        if (code_substitutes_->count(hash.value())) {
+        if (known_code_substitutes_->count(hash.value())) {
           OUTCOME_TRY(code,
                       chain_spec_->fetchCodeSubstituteByHash(hash.value()));
           OUTCOME_TRY(uncompressCodeIfNeeded(code, cached_code_));

--- a/core/runtime/common/storage_code_provider.cpp
+++ b/core/runtime/common/storage_code_provider.cpp
@@ -46,9 +46,10 @@ namespace kagome::runtime {
       last_state_root_ = state;
 
       auto hash = runtime_upgrade_tracker_->getLastCodeUpdateHash(state);
-      if (hash.has_value()) { 
+      if (hash.has_value()) {
         if (code_substitutes_->find(hash.value()) != code_substitutes_->end()) {
-          OUTCOME_TRY(code, chain_spec_->fetchCodeByHash(hash.value()));
+          OUTCOME_TRY(code,
+                      chain_spec_->fetchCodeSubstituteByHash(hash.value()));
           OUTCOME_TRY(uncompressCodeIfNeeded(code, cached_code_));
           return cached_code_;
         }

--- a/core/runtime/common/storage_code_provider.cpp
+++ b/core/runtime/common/storage_code_provider.cpp
@@ -18,10 +18,12 @@ namespace kagome::runtime {
   StorageCodeProvider::StorageCodeProvider(
       std::shared_ptr<const storage::trie::TrieStorage> storage,
       std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker,
-      std::shared_ptr<const primitives::CodeSubstitutes> code_substitutes)
+      std::shared_ptr<const primitives::CodeSubstitutes> code_substitutes,
+      std::shared_ptr<application::ChainSpec> chain_spec)
       : storage_{std::move(storage)},
         runtime_upgrade_tracker_{std::move(runtime_upgrade_tracker)},
-        code_substitutes_{std::move(code_substitutes)} {
+        code_substitutes_{std::move(code_substitutes)},
+        chain_spec_{std::move(chain_spec)} {
     BOOST_ASSERT(storage_ != nullptr);
     BOOST_ASSERT(runtime_upgrade_tracker_ != nullptr);
     last_state_root_ = storage_->getRootHash();
@@ -44,10 +46,10 @@ namespace kagome::runtime {
       last_state_root_ = state;
 
       auto hash = runtime_upgrade_tracker_->getLastCodeUpdateHash(state);
-      if (hash.has_value()) {
-        if (auto code_it = code_substitutes_->find(hash.value());
-            code_it != code_substitutes_->end()) {
-          OUTCOME_TRY(uncompressCodeIfNeeded(code_it->second, cached_code_));
+      if (hash.has_value()) { 
+        if (code_substitutes_->find(hash.value()) != code_substitutes_->end()) {
+          OUTCOME_TRY(code, chain_spec_->fetchCodeByHash(hash.value()));
+          OUTCOME_TRY(uncompressCodeIfNeeded(code, cached_code_));
           return cached_code_;
         }
       }

--- a/core/runtime/common/storage_code_provider.cpp
+++ b/core/runtime/common/storage_code_provider.cpp
@@ -18,7 +18,7 @@ namespace kagome::runtime {
   StorageCodeProvider::StorageCodeProvider(
       std::shared_ptr<const storage::trie::TrieStorage> storage,
       std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker,
-      std::shared_ptr<const primitives::CodeSubstitutes> code_substitutes,
+      std::shared_ptr<const primitives::CodeSubstituteHashes> code_substitutes,
       std::shared_ptr<application::ChainSpec> chain_spec)
       : storage_{std::move(storage)},
         runtime_upgrade_tracker_{std::move(runtime_upgrade_tracker)},
@@ -47,7 +47,7 @@ namespace kagome::runtime {
 
       auto hash = runtime_upgrade_tracker_->getLastCodeUpdateHash(state);
       if (hash.has_value()) {
-        if (code_substitutes_->find(hash.value()) != code_substitutes_->end()) {
+        if (code_substitutes_->count(hash.value())) {
           OUTCOME_TRY(code,
                       chain_spec_->fetchCodeSubstituteByHash(hash.value()));
           OUTCOME_TRY(uncompressCodeIfNeeded(code, cached_code_));

--- a/core/runtime/common/storage_code_provider.hpp
+++ b/core/runtime/common/storage_code_provider.hpp
@@ -27,7 +27,8 @@ namespace kagome::runtime {
     explicit StorageCodeProvider(
         std::shared_ptr<const storage::trie::TrieStorage> storage,
         std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker,
-        std::shared_ptr<const primitives::CodeSubstitutes> code_substitutes);
+        std::shared_ptr<const primitives::CodeSubstitutes> code_substitutes,
+        std::shared_ptr<application::ChainSpec> chain_spec);
 
     outcome::result<gsl::span<const uint8_t>> getCodeAt(
         const storage::trie::RootHash &state) const override;
@@ -38,6 +39,7 @@ namespace kagome::runtime {
     std::shared_ptr<const storage::trie::TrieStorage> storage_;
     std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker_;
     std::shared_ptr<const primitives::CodeSubstitutes> code_substitutes_;
+    std::shared_ptr<application::ChainSpec> chain_spec_;
     mutable common::Buffer cached_code_;
     mutable storage::trie::RootHash last_state_root_;
     log::Logger logger_;

--- a/core/runtime/common/storage_code_provider.hpp
+++ b/core/runtime/common/storage_code_provider.hpp
@@ -39,7 +39,8 @@ namespace kagome::runtime {
         const storage::trie::EphemeralTrieBatch &batch) const;
     std::shared_ptr<const storage::trie::TrieStorage> storage_;
     std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker_;
-    std::shared_ptr<const primitives::CodeSubstituteHashes> code_substitutes_;
+    std::shared_ptr<const primitives::CodeSubstituteHashes>
+        known_code_substitutes_;
     std::shared_ptr<application::ChainSpec> chain_spec_;
     mutable common::Buffer cached_code_;
     mutable storage::trie::RootHash last_state_root_;

--- a/core/runtime/common/storage_code_provider.hpp
+++ b/core/runtime/common/storage_code_provider.hpp
@@ -27,7 +27,8 @@ namespace kagome::runtime {
     explicit StorageCodeProvider(
         std::shared_ptr<const storage::trie::TrieStorage> storage,
         std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker,
-        std::shared_ptr<const primitives::CodeSubstitutes> code_substitutes,
+        std::shared_ptr<const primitives::CodeSubstituteHashes>
+            code_substitutes,
         std::shared_ptr<application::ChainSpec> chain_spec);
 
     outcome::result<gsl::span<const uint8_t>> getCodeAt(
@@ -38,7 +39,7 @@ namespace kagome::runtime {
         const storage::trie::EphemeralTrieBatch &batch) const;
     std::shared_ptr<const storage::trie::TrieStorage> storage_;
     std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker_;
-    std::shared_ptr<const primitives::CodeSubstitutes> code_substitutes_;
+    std::shared_ptr<const primitives::CodeSubstituteHashes> code_substitutes_;
     std::shared_ptr<application::ChainSpec> chain_spec_;
     mutable common::Buffer cached_code_;
     mutable storage::trie::RootHash last_state_root_;

--- a/test/core/runtime/runtime_test_base.hpp
+++ b/test/core/runtime/runtime_test_base.hpp
@@ -134,7 +134,7 @@ class RuntimeTestBase : public ::testing::Test {
             kagome::runtime::RuntimeUpgradeTrackerImpl::create(
                 header_repo_,
                 std::make_shared<kagome::storage::InMemoryStorage>(),
-                std::make_shared<kagome::primitives::CodeSubstitutes>())
+                std::make_shared<kagome::primitives::CodeSubstituteHashes>())
                 .value();
 
     auto module_repo = std::make_shared<kagome::runtime::ModuleRepositoryImpl>(

--- a/test/core/runtime/runtime_upgrade_tracker_test.cpp
+++ b/test/core/runtime/runtime_upgrade_tracker_test.cpp
@@ -212,7 +212,7 @@ TEST_F(RuntimeUpgradeTrackerTest, CodeSubstituteAndStore) {
               getBlockHeader(kagome::primitives::BlockId{block2.hash}))
       .WillRepeatedly(testing::Return(block2_header));
   code_substitutes_.reset(
-      new kagome::primitives::CodeSubstitutes{{block2.hash, "5203203"_buf}});
+      new kagome::primitives::CodeSubstitutes{{block2.hash}});
 
   // reset tracker
   tracker_ = kagome::runtime::RuntimeUpgradeTrackerImpl::create(
@@ -248,7 +248,7 @@ TEST_F(RuntimeUpgradeTrackerTest, UpgradeAfterCodeSubstitute) {
   auto block1 = makeBlockInfo(5203203);
   auto block1_header = makeBlockHeader(5203203);
   code_substitutes_.reset(
-      new kagome::primitives::CodeSubstitutes{{block1.hash, "5203203"_buf}});
+      new kagome::primitives::CodeSubstitutes{{block1.hash}});
 
   EXPECT_CALL(*header_repo_,
               getBlockHeader(kagome::primitives::BlockId{block1.hash}))

--- a/test/core/runtime/runtime_upgrade_tracker_test.cpp
+++ b/test/core/runtime/runtime_upgrade_tracker_test.cpp
@@ -58,12 +58,12 @@ class RuntimeUpgradeTrackerTest : public testing::Test {
         std::make_shared<kagome::blockchain::BlockHeaderRepositoryMock>();
     block_tree_ = std::make_shared<kagome::blockchain::BlockTreeMock>();
     storage_ = std::make_shared<kagome::storage::InMemoryStorage>();
-    code_substitutes_ =
+    known_code_substitutes_ =
         std::make_shared<kagome::primitives::CodeSubstituteHashes>();
     sub_engine_ =
         std::make_shared<kagome::primitives::events::ChainSubscriptionEngine>();
     tracker_ = kagome::runtime::RuntimeUpgradeTrackerImpl::create(
-                   header_repo_, storage_, code_substitutes_)
+                   header_repo_, storage_, known_code_substitutes_)
                    .value();
   }
 
@@ -75,7 +75,8 @@ class RuntimeUpgradeTrackerTest : public testing::Test {
       sub_engine_;
   std::shared_ptr<kagome::storage::BufferStorage> storage_;
 
-  std::shared_ptr<kagome::primitives::CodeSubstituteHashes> code_substitutes_{};
+  std::shared_ptr<kagome::primitives::CodeSubstituteHashes>
+      known_code_substitutes_{};
   kagome::primitives::BlockInfo genesis_block{0, "block_genesis_hash"_hash256};
   kagome::primitives::BlockHeader genesis_block_header{
       ""_hash256,
@@ -212,12 +213,12 @@ TEST_F(RuntimeUpgradeTrackerTest, CodeSubstituteAndStore) {
   EXPECT_CALL(*header_repo_,
               getBlockHeader(kagome::primitives::BlockId{block2.hash}))
       .WillRepeatedly(testing::Return(block2_header));
-  code_substitutes_.reset(
+  known_code_substitutes_.reset(
       new kagome::primitives::CodeSubstituteHashes{{block2.hash}});
 
   // reset tracker
   tracker_ = kagome::runtime::RuntimeUpgradeTrackerImpl::create(
-                 header_repo_, storage_, code_substitutes_)
+                 header_repo_, storage_, known_code_substitutes_)
                  .value();
   tracker_->subscribeToBlockchainEvents(sub_engine_, block_tree_);
 
@@ -226,7 +227,7 @@ TEST_F(RuntimeUpgradeTrackerTest, CodeSubstituteAndStore) {
 
   // reset tracker
   tracker_ = kagome::runtime::RuntimeUpgradeTrackerImpl::create(
-                 header_repo_, storage_, code_substitutes_)
+                 header_repo_, storage_, known_code_substitutes_)
                  .value();
   tracker_->subscribeToBlockchainEvents(sub_engine_, block_tree_);
 
@@ -242,13 +243,13 @@ TEST_F(RuntimeUpgradeTrackerTest, UpgradeAfterCodeSubstitute) {
       .WillRepeatedly(testing::Return(true));
 
   tracker_ = kagome::runtime::RuntimeUpgradeTrackerImpl::create(
-                 header_repo_, storage_, code_substitutes_)
+                 header_repo_, storage_, known_code_substitutes_)
                  .value();
   tracker_->subscribeToBlockchainEvents(sub_engine_, block_tree_);
 
   auto block1 = makeBlockInfo(5203203);
   auto block1_header = makeBlockHeader(5203203);
-  code_substitutes_.reset(
+  known_code_substitutes_.reset(
       new kagome::primitives::CodeSubstituteHashes{{block1.hash}});
 
   EXPECT_CALL(*header_repo_,

--- a/test/core/runtime/runtime_upgrade_tracker_test.cpp
+++ b/test/core/runtime/runtime_upgrade_tracker_test.cpp
@@ -58,7 +58,8 @@ class RuntimeUpgradeTrackerTest : public testing::Test {
         std::make_shared<kagome::blockchain::BlockHeaderRepositoryMock>();
     block_tree_ = std::make_shared<kagome::blockchain::BlockTreeMock>();
     storage_ = std::make_shared<kagome::storage::InMemoryStorage>();
-    code_substitutes_ = std::make_shared<kagome::primitives::CodeSubstitutes>();
+    code_substitutes_ =
+        std::make_shared<kagome::primitives::CodeSubstituteHashes>();
     sub_engine_ =
         std::make_shared<kagome::primitives::events::ChainSubscriptionEngine>();
     tracker_ = kagome::runtime::RuntimeUpgradeTrackerImpl::create(
@@ -74,7 +75,7 @@ class RuntimeUpgradeTrackerTest : public testing::Test {
       sub_engine_;
   std::shared_ptr<kagome::storage::BufferStorage> storage_;
 
-  std::shared_ptr<kagome::primitives::CodeSubstitutes> code_substitutes_{};
+  std::shared_ptr<kagome::primitives::CodeSubstituteHashes> code_substitutes_{};
   kagome::primitives::BlockInfo genesis_block{0, "block_genesis_hash"_hash256};
   kagome::primitives::BlockHeader genesis_block_header{
       ""_hash256,
@@ -212,7 +213,7 @@ TEST_F(RuntimeUpgradeTrackerTest, CodeSubstituteAndStore) {
               getBlockHeader(kagome::primitives::BlockId{block2.hash}))
       .WillRepeatedly(testing::Return(block2_header));
   code_substitutes_.reset(
-      new kagome::primitives::CodeSubstitutes{{block2.hash}});
+      new kagome::primitives::CodeSubstituteHashes{{block2.hash}});
 
   // reset tracker
   tracker_ = kagome::runtime::RuntimeUpgradeTrackerImpl::create(
@@ -248,7 +249,7 @@ TEST_F(RuntimeUpgradeTrackerTest, UpgradeAfterCodeSubstitute) {
   auto block1 = makeBlockInfo(5203203);
   auto block1_header = makeBlockHeader(5203203);
   code_substitutes_.reset(
-      new kagome::primitives::CodeSubstitutes{{block1.hash}});
+      new kagome::primitives::CodeSubstituteHashes{{block1.hash}});
 
   EXPECT_CALL(*header_repo_,
               getBlockHeader(kagome::primitives::BlockId{block1.hash}))

--- a/test/core/runtime/storage_code_provider_test.cpp
+++ b/test/core/runtime/storage_code_provider_test.cpp
@@ -7,10 +7,10 @@
 
 #include <gtest/gtest.h>
 
+#include "mock/core/application/chain_spec_mock.hpp"
 #include "mock/core/runtime/runtime_upgrade_tracker_mock.hpp"
 #include "mock/core/storage/trie/trie_batches_mock.hpp"
 #include "mock/core/storage/trie/trie_storage_mock.hpp"
-#include "mock/core/application/chain_spec_mock.hpp"
 #include "storage/predefined_keys.hpp"
 #include "testutil/literals.hpp"
 #include "testutil/outcome.hpp"
@@ -57,7 +57,9 @@ TEST_F(StorageCodeProviderTest, GetCodeWhenNoStorageUpdates) {
     return batch;
   }));
   auto wasm_provider = std::make_shared<runtime::StorageCodeProvider>(
-      trie_db, tracker, std::make_shared<primitives::CodeSubstitutes>(), 
+      trie_db,
+      tracker,
+      std::make_shared<primitives::CodeSubstitutes>(),
       std::make_shared<application::ChainSpecMock>());
 
   // when
@@ -93,7 +95,9 @@ TEST_F(StorageCodeProviderTest, DISABLED_GetCodeWhenStorageUpdates) {
     return batch;
   }));
   auto wasm_provider = std::make_shared<runtime::StorageCodeProvider>(
-      trie_db, tracker, std::make_shared<primitives::CodeSubstitutes>(),
+      trie_db,
+      tracker,
+      std::make_shared<primitives::CodeSubstitutes>(),
       std::make_shared<application::ChainSpecMock>());
 
   common::Buffer new_state_code{{1, 3, 3, 8}};

--- a/test/core/runtime/storage_code_provider_test.cpp
+++ b/test/core/runtime/storage_code_provider_test.cpp
@@ -59,7 +59,7 @@ TEST_F(StorageCodeProviderTest, GetCodeWhenNoStorageUpdates) {
   auto wasm_provider = std::make_shared<runtime::StorageCodeProvider>(
       trie_db,
       tracker,
-      std::make_shared<primitives::CodeSubstitutes>(),
+      std::make_shared<primitives::CodeSubstituteHashes>(),
       std::make_shared<application::ChainSpecMock>());
 
   // when
@@ -97,7 +97,7 @@ TEST_F(StorageCodeProviderTest, DISABLED_GetCodeWhenStorageUpdates) {
   auto wasm_provider = std::make_shared<runtime::StorageCodeProvider>(
       trie_db,
       tracker,
-      std::make_shared<primitives::CodeSubstitutes>(),
+      std::make_shared<primitives::CodeSubstituteHashes>(),
       std::make_shared<application::ChainSpecMock>());
 
   common::Buffer new_state_code{{1, 3, 3, 8}};

--- a/test/core/runtime/storage_code_provider_test.cpp
+++ b/test/core/runtime/storage_code_provider_test.cpp
@@ -10,6 +10,7 @@
 #include "mock/core/runtime/runtime_upgrade_tracker_mock.hpp"
 #include "mock/core/storage/trie/trie_batches_mock.hpp"
 #include "mock/core/storage/trie/trie_storage_mock.hpp"
+#include "mock/core/application/chain_spec_mock.hpp"
 #include "storage/predefined_keys.hpp"
 #include "testutil/literals.hpp"
 #include "testutil/outcome.hpp"
@@ -56,7 +57,8 @@ TEST_F(StorageCodeProviderTest, GetCodeWhenNoStorageUpdates) {
     return batch;
   }));
   auto wasm_provider = std::make_shared<runtime::StorageCodeProvider>(
-      trie_db, tracker, std::make_shared<primitives::CodeSubstitutes>());
+      trie_db, tracker, std::make_shared<primitives::CodeSubstitutes>(), 
+      std::make_shared<application::ChainSpecMock>());
 
   // when
   EXPECT_OUTCOME_TRUE(obtained_state_code,
@@ -91,7 +93,8 @@ TEST_F(StorageCodeProviderTest, DISABLED_GetCodeWhenStorageUpdates) {
     return batch;
   }));
   auto wasm_provider = std::make_shared<runtime::StorageCodeProvider>(
-      trie_db, tracker, std::make_shared<primitives::CodeSubstitutes>());
+      trie_db, tracker, std::make_shared<primitives::CodeSubstitutes>(),
+      std::make_shared<application::ChainSpecMock>());
 
   common::Buffer new_state_code{{1, 3, 3, 8}};
   EXPECT_CALL(*trie_db, getEphemeralBatchAt(second_state_root))

--- a/test/mock/core/application/chain_spec_mock.hpp
+++ b/test/mock/core/application/chain_spec_mock.hpp
@@ -57,7 +57,7 @@ namespace kagome::application {
                 (),
                 (const, override));
 
-    MOCK_METHOD(std::shared_ptr<const primitives::CodeSubstitutes>,
+    MOCK_METHOD(std::shared_ptr<const primitives::CodeSubstituteHashes>,
                 codeSubstitutes,
                 (),
                 (const, override));
@@ -66,7 +66,7 @@ namespace kagome::application {
 
     MOCK_METHOD(outcome::result<common::Buffer>,
                 fetchCodeSubstituteByHash,
-                (const common::Hash256 hash),
+                (const common::Hash256 &hash),
                 (const, override));
   };
 

--- a/test/mock/core/application/chain_spec_mock.hpp
+++ b/test/mock/core/application/chain_spec_mock.hpp
@@ -63,6 +63,11 @@ namespace kagome::application {
                 (const, override));
 
     MOCK_METHOD(GenesisRawData, getGenesis, (), (const, override));
+
+    MOCK_METHOD(outcome::result<common::Buffer>,
+                fetchCodeByHash,
+                (const common::Hash256 hash),
+                (const, override));
   };
 
 }  // namespace kagome::application

--- a/test/mock/core/application/chain_spec_mock.hpp
+++ b/test/mock/core/application/chain_spec_mock.hpp
@@ -65,7 +65,7 @@ namespace kagome::application {
     MOCK_METHOD(GenesisRawData, getGenesis, (), (const, override));
 
     MOCK_METHOD(outcome::result<common::Buffer>,
-                fetchCodeByHash,
+                fetchCodeSubstituteByHash,
                 (const common::Hash256 hash),
                 (const, override));
   };


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues
<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
Added new method ChainSpecImpl::fetchCodeByHash, that allows to fetch code_substitute upon request, instead of preloading it on initialization.
Only code hashes are being prefetched now.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs <!-- Optional -->

<!-- Explain what other alternates were considered and why the proposed version was selected -->
