### PR TITLE
Sync Speed up - Prevent Early Extrinsics Processing

### DIFF
--- a/core/consensus/babe/babe.hpp
+++ b/core/consensus/babe/babe.hpp
@@ -55,6 +55,14 @@ namespace kagome::consensus::babe {
      * @returns current state
      */
     virtual State getCurrentState() const = 0;
+
+    /**
+     * Checks whether the node was in a synchronized state at least once since
+     * startup.
+     * @return true when current state was ever set to synchronized during the
+     * current run, otherwise - false.
+     */
+    virtual bool wasSynchronized() const = 0;
   };
 }  // namespace kagome::consensus::babe
 

--- a/core/consensus/babe/impl/babe_impl.hpp
+++ b/core/consensus/babe/impl/babe_impl.hpp
@@ -97,6 +97,8 @@ namespace kagome::consensus::babe {
 
     void onSynchronized() override;
 
+    bool wasSynchronized() const override;
+
    private:
     void startCatchUp(const libp2p::peer::PeerId &peer_id,
                       const primitives::BlockInfo &target_block);
@@ -138,6 +140,7 @@ namespace kagome::consensus::babe {
 
     bool isSecondarySlotsAllowed() const;
 
+    bool was_synchronized_;
     std::shared_ptr<BabeLottery> lottery_;
     std::shared_ptr<storage::trie::TrieStorage> trie_storage_;
     std::shared_ptr<primitives::BabeConfiguration> babe_configuration_;

--- a/core/network/impl/protocols/propagate_transactions_protocol.cpp
+++ b/core/network/impl/protocols/propagate_transactions_protocol.cpp
@@ -302,13 +302,19 @@ namespace kagome::network {
                  message.extrinsics.size(),
                  peer_id.toBase58());
 
-      for (auto &ext : message.extrinsics) {
-        auto result = self->extrinsic_observer_->onTxMessage(ext);
-        if (result) {
-          SL_DEBUG(self->log_, "  Received tx {}", result.value());
-        } else {
-          SL_DEBUG(self->log_, "  Rejected tx: {}", result.error().message());
+      if (self->babe_->wasSynchronized()) {
+        for (auto &ext : message.extrinsics) {
+          auto result = self->extrinsic_observer_->onTxMessage(ext);
+          if (result) {
+            SL_DEBUG(self->log_, "  Received tx {}", result.value());
+          } else {
+            SL_DEBUG(self->log_, "  Rejected tx: {}", result.error().message());
+          }
         }
+      } else {
+        SL_TRACE(self->log_,
+                 "Skipping extrinsics processing since the node was not in a "
+                 "synchronized state yet.");
       }
 
       self->readPropagatedExtrinsics(std::move(stream));

--- a/core/network/impl/stream_engine.hpp
+++ b/core/network/impl/stream_engine.hpp
@@ -437,7 +437,7 @@ namespace kagome::network {
 
             std::unique_lock cs(self->streams_cs_);
 
-            bool existing = false;  // NOLINT
+            [[maybe_unused]] bool existing = false;
             self->forSubscriber(peer_id, protocol, [&](auto, auto &subscriber) {
               existing = true;
               self->uploadStream(

--- a/test/mock/core/consensus/babe/babe_mock.hpp
+++ b/test/mock/core/consensus/babe/babe_mock.hpp
@@ -33,6 +33,8 @@ namespace kagome::consensus::babe {
                 (override));
 
     MOCK_METHOD(void, onSynchronized, (), (override));
+
+    MOCK_METHOD(bool, wasSynchronized, (), (const, override));
   };
 
 }  // namespace kagome::consensus::babe


### PR DESCRIPTION


<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

Resolves https://github.com/soramitsu/kagome/issues/1075

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change

That is a general performance improvement. 

The change lets begin extrinsics' processing only after the node eventually appears in a synced state since the launch.

This optimization minimizes the risk of extrinsic validation against an improper runtime (an old non-update runtime).
Eliminating these unnecessary and failure-prone checks allows us to speed up the whole sync process.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Speed up Synchronization

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

None?

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
