### PR TITLE
Implement all unimplemented child_storage_* stubs

### DIFF
--- a/core/host_api/host_api.hpp
+++ b/core/host_api/host_api.hpp
@@ -488,8 +488,7 @@ namespace kagome::host_api {
      * value.
      */
     virtual runtime::WasmSpan ext_default_child_storage_get_version_1(
-        runtime::WasmSpan child_storage_key,
-        runtime::WasmSpan key) const = 0;
+        runtime::WasmSpan child_storage_key, runtime::WasmSpan key) const = 0;
 
     /**
      * @brief Clears the storage of the given key and its value from the child
@@ -510,16 +509,65 @@ namespace kagome::host_api {
      * Returns None if the entry cannot be found.
      */
     virtual runtime::WasmSpan ext_default_child_storage_next_key_version_1(
-        runtime::WasmSpan child_storage_key,
-        runtime::WasmSpan key) const = 0;
+        runtime::WasmSpan child_storage_key, runtime::WasmSpan key) const = 0;
 
     /**
-     * @brief Commits all existing operations and computes the resulting child storage root.
+     * @brief Commits all existing operations and computes the resulting child
+     * storage root.
      * @param child_storage_key a pointer-size indicating the child storage key
      * @return a pointer-size indicating the SCALE encoded storage root.
      */
     virtual runtime::WasmSpan ext_default_child_storage_root_version_1(
         runtime::WasmSpan child_storage_key) const = 0;
+
+    /**
+     * @brief Clears the child storage of each key/value pair where the key
+     * starts with the given prefix.
+     * @param child_storage_key a pointer-size indicating the child storage key
+     * @param prefix a pointer-size indicating the prefix
+     */
+    virtual void ext_default_child_storage_clear_prefix_version_1(
+        runtime::WasmSpan child_storage_key, runtime::WasmSpan prefix) = 0;
+
+    /**
+     * @brief Gets the given key from storage, placing the value into a buffer
+     * and returning the number of bytes that the entry in storage has beyond
+     * the offset.
+     * @param child_storage_key a pointer-size indicating the child storage key
+     * @param key a pointer-size as defined in Definition D.3 indicating the
+     * key.
+     * @param value_out a pointer-size as defined in Definition D.3 indicating
+     * the buffer to which the value will be written to. This function will
+     * never write more then the length of the buffer, even if the value's
+     * length is bigger.
+     * @param offset an i32 integer containing the offset beyond the value
+     * should be read from.
+     * @return a pointer-size indicating the SCALE encoded Option containing the
+     * number of bytes written into the value_out buffer. Returns None if the
+     * entry does not exists.
+     */
+    virtual runtime::WasmSpan ext_default_child_storage_read_version_1(
+        runtime::WasmSpan child_storage_key,
+        runtime::WasmSpan key,
+        runtime::WasmSpan value_out,
+        runtime::WasmOffset offset) const = 0;
+
+    /**
+     * @brief Checks whether the given key exists in the child storage.
+     * @param child_storage_key a pointer-size indicating the child storage key
+     * @param key a pointer-size indicating the key.
+     * @return a boolean equal to true if the key does exist, false if
+     * otherwise.
+     */
+    virtual uint32_t ext_default_child_storage_exists_version_1(
+        runtime::WasmSpan child_storage_key, runtime::WasmSpan key) const = 0;
+
+    /**
+     * @brief Clears an entire child storage
+     * @param child_storage_key a pointer-size indicating the child storage key
+     */
+    virtual void ext_default_child_storage_storage_kill_version_1(
+        runtime::WasmSpan child_storage_key) = 0;
   };
 }  // namespace kagome::host_api
 

--- a/core/host_api/impl/child_storage_extension.cpp
+++ b/core/host_api/impl/child_storage_extension.cpp
@@ -284,6 +284,16 @@ namespace kagome::host_api {
                          key_buffer,
                          common::Buffer{offset_data.subbuffer(0, written)});
       res = offset_data.size();
+    } else if (read.error() == TrieError::NO_VALUE){
+      logger_->info(
+          "ext_default_child_storage_clear_prefix_version_1 returned no value "
+          "reason: {}",
+          read.error().message());
+    } else {
+      logger_->error(
+          "ext_default_child_storage_clear_prefix_version_1 failed with "
+          "reason: {}",
+          read.error().message());
     }
     return memory.storeBuffer(scale::encode(res).value());
   }
@@ -300,6 +310,13 @@ namespace kagome::host_api {
         child_key_buffer,
         [](auto &child_batch, auto &key) { return child_batch->contains(key); },
         key_buffer);
+
+    if (not res) {
+      logger_->error(
+          "ext_default_child_storage_exists_version_1 failed with "
+          "reason: {}",
+          res.error().message());
+    }
 
     return (res.has_value() and res.value()) ? 1 : 0;
   }

--- a/core/host_api/impl/child_storage_extension.cpp
+++ b/core/host_api/impl/child_storage_extension.cpp
@@ -234,4 +234,95 @@ namespace kagome::host_api {
     return memory.storeBuffer(root);
   }
 
+  void ChildStorageExtension::ext_default_child_storage_clear_prefix_version_1(
+      runtime::WasmSpan child_storage_key, runtime::WasmSpan prefix) {
+    auto &memory = memory_provider_->getCurrentMemory()->get();
+    auto [child_key_buffer, prefix_buffer] =
+        loadBuffer(memory, child_storage_key, prefix);
+
+    SL_TRACE_VOID_FUNC_CALL(logger_, child_key_buffer, prefix);
+
+    auto result = executeOnChildStorage<std::tuple<bool, uint32_t>>(
+        child_key_buffer,
+        [](auto &child_batch, auto &prefix) {
+          return child_batch->clearPrefix(prefix, std::nullopt);
+        },
+        prefix_buffer);
+
+    if (not result) {
+      logger_->error(
+          "ext_default_child_storage_clear_prefix_version_1 failed with "
+          "reason: {}",
+          result.error().message());
+    }
+  }
+
+  runtime::WasmSpan
+  ChildStorageExtension::ext_default_child_storage_read_version_1(
+      runtime::WasmSpan child_storage_key,
+      runtime::WasmSpan key,
+      runtime::WasmSpan value_out,
+      runtime::WasmOffset offset) const {
+    auto &memory = memory_provider_->getCurrentMemory()->get();
+    auto [child_key_buffer, key_buffer] =
+        loadBuffer(memory, child_storage_key, key);
+    auto [value_ptr, value_size] = runtime::PtrSize(value_out);
+
+    auto read = executeOnChildStorage<common::Buffer>(
+        child_key_buffer,
+        [](auto &child_batch, auto &key) { return child_batch->get(key); },
+        key_buffer);
+    std::optional<uint32_t> res{std::nullopt};
+    if (read) {
+      auto data = read.value();
+      auto offset_data = data.subbuffer(std::min<size_t>(offset, data.size()));
+      auto written = std::min<size_t>(offset_data.size(), value_size);
+      memory.storeBuffer(value_ptr,
+                         gsl::make_span(offset_data).subspan(0, written));
+      SL_TRACE_FUNC_CALL(logger_,
+                         child_key_buffer,
+                         key_buffer,
+                         common::Buffer{offset_data.subbuffer(0, written)});
+      res = offset_data.size();
+    }
+    return memory.storeBuffer(scale::encode(res).value());
+  }
+
+  uint32_t ChildStorageExtension::ext_default_child_storage_exists_version_1(
+      runtime::WasmSpan child_storage_key, runtime::WasmSpan key) const {
+    auto &memory = memory_provider_->getCurrentMemory()->get();
+    auto [child_key_buffer, key_buffer] =
+        loadBuffer(memory, child_storage_key, key);
+
+    SL_TRACE_VOID_FUNC_CALL(logger_, child_key_buffer, key_buffer);
+
+    auto res = executeOnChildStorage<bool>(
+        child_key_buffer,
+        [](auto &child_batch, auto &key) { return child_batch->contains(key); },
+        key_buffer);
+
+    return (res.has_value() and res.value()) ? 1 : 0;
+  }
+
+  void ChildStorageExtension::ext_default_child_storage_storage_kill_version_1(
+      runtime::WasmSpan child_storage_key) {
+    auto &memory = memory_provider_->getCurrentMemory()->get();
+    auto [child_key_buffer] = loadBuffer(memory, child_storage_key);
+
+    SL_TRACE_VOID_FUNC_CALL(logger_, child_key_buffer);
+
+    auto result = executeOnChildStorage<std::tuple<bool, uint32_t>>(
+        child_key_buffer,
+        [](auto &child_batch) {
+          return child_batch->clearPrefix(common::Buffer{}, std::nullopt);
+        });
+
+    if (not result) {
+      logger_->error(
+          "ext_default_child_storage_storage_kill_version_1 failed with "
+          "reason: {}",
+          result.error().message());
+    }
+  }
+
 }  // namespace kagome::host_api

--- a/core/host_api/impl/child_storage_extension.hpp
+++ b/core/host_api/impl/child_storage_extension.hpp
@@ -62,6 +62,33 @@ namespace kagome::host_api {
     runtime::WasmSpan ext_default_child_storage_root_version_1(
         runtime::WasmSpan child_storage_key) const;
 
+    /**
+     * @see HostApi::ext_default_child_storage_clear_prefix_version_1
+     */
+    void ext_default_child_storage_clear_prefix_version_1(
+        runtime::WasmSpan child_storage_key, runtime::WasmSpan prefix);
+
+    /**
+     * @see HostApi::ext_default_child_storage_read_version_1
+     */
+    runtime::WasmSpan ext_default_child_storage_read_version_1(
+        runtime::WasmSpan child_storage_key,
+        runtime::WasmSpan key,
+        runtime::WasmSpan value_out,
+        runtime::WasmOffset offset) const;
+
+    /**
+     * @see HostApi::ext_default_child_storage_exists_version_1
+     */
+    uint32_t ext_default_child_storage_exists_version_1(
+        runtime::WasmSpan child_storage_key, runtime::WasmSpan key) const;
+
+    /**
+     * @see HostApi::ext_default_child_storage_storage_kill_version_1
+     */
+    void ext_default_child_storage_storage_kill_version_1(
+        runtime::WasmSpan child_storage_key);
+
    private:
     std::shared_ptr<runtime::TrieStorageProvider> storage_provider_;
     std::shared_ptr<const runtime::MemoryProvider> memory_provider_;

--- a/core/host_api/impl/host_api_impl.cpp
+++ b/core/host_api/impl/host_api_impl.cpp
@@ -451,4 +451,31 @@ namespace kagome::host_api {
         child_storage_key);
   }
 
+  void HostApiImpl::ext_default_child_storage_clear_prefix_version_1(
+      runtime::WasmSpan child_storage_key, runtime::WasmSpan prefix) {
+    return child_storage_ext_.ext_default_child_storage_clear_prefix_version_1(
+        child_storage_key, prefix);
+  }
+
+  runtime::WasmSpan HostApiImpl::ext_default_child_storage_read_version_1(
+      runtime::WasmSpan child_storage_key,
+      runtime::WasmSpan key,
+      runtime::WasmSpan value_out,
+      runtime::WasmOffset offset) const {
+    return child_storage_ext_.ext_default_child_storage_read_version_1(
+        child_storage_key, key, value_out, offset);
+  }
+
+  uint32_t HostApiImpl::ext_default_child_storage_exists_version_1(
+      runtime::WasmSpan child_storage_key, runtime::WasmSpan key) const {
+    return child_storage_ext_.ext_default_child_storage_exists_version_1(
+        child_storage_key, key);
+  }
+
+  void HostApiImpl::ext_default_child_storage_storage_kill_version_1(
+      runtime::WasmSpan child_storage_key) {
+    return child_storage_ext_.ext_default_child_storage_storage_kill_version_1(
+        child_storage_key);
+  }
+
 }  // namespace kagome::host_api

--- a/core/host_api/impl/host_api_impl.hpp
+++ b/core/host_api/impl/host_api_impl.hpp
@@ -8,13 +8,13 @@
 
 #include "host_api/host_api.hpp"
 
+#include "host_api/impl/child_storage_extension.hpp"
 #include "host_api/impl/crypto_extension.hpp"
 #include "host_api/impl/io_extension.hpp"
 #include "host_api/impl/memory_extension.hpp"
 #include "host_api/impl/misc_extension.hpp"
 #include "host_api/impl/offchain_extension.hpp"
 #include "host_api/impl/storage_extension.hpp"
-#include "host_api/impl/child_storage_extension.hpp"
 #include "offchain/impl/offchain_persistent_storage.hpp"
 
 namespace kagome::runtime {
@@ -275,8 +275,7 @@ namespace kagome::host_api {
         runtime::WasmSpan key) const override;
 
     void ext_default_child_storage_clear_version_1(
-        runtime::WasmSpan child_storage_key,
-        runtime::WasmSpan key) override;
+        runtime::WasmSpan child_storage_key, runtime::WasmSpan key) override;
 
     runtime::WasmSpan ext_default_child_storage_next_key_version_1(
         runtime::WasmSpan child_storage_key,
@@ -284,6 +283,22 @@ namespace kagome::host_api {
 
     runtime::WasmSpan ext_default_child_storage_root_version_1(
         runtime::WasmSpan child_storage_key) const override;
+
+    void ext_default_child_storage_clear_prefix_version_1(
+        runtime::WasmSpan child_storage_key, runtime::WasmSpan prefix) override;
+
+    virtual runtime::WasmSpan ext_default_child_storage_read_version_1(
+        runtime::WasmSpan child_storage_key,
+        runtime::WasmSpan key,
+        runtime::WasmSpan value_out,
+        runtime::WasmOffset offset) const override;
+        
+    virtual uint32_t ext_default_child_storage_exists_version_1(
+        runtime::WasmSpan child_storage_key,
+        runtime::WasmSpan key) const override;
+        
+    virtual void ext_default_child_storage_storage_kill_version_1(
+        runtime::WasmSpan child_storage_key) override;
 
    private:
     static constexpr uint64_t DEFAULT_CHAIN_ID = 42;

--- a/core/runtime/binaryen/runtime_external_interface.cpp
+++ b/core/runtime/binaryen/runtime_external_interface.cpp
@@ -18,6 +18,8 @@ namespace kagome::runtime::binaryen {
 
   const static wasm::Name ext_default_child_storage_clear_version_1 =
       "ext_default_child_storage_clear_version_1";
+  const static wasm::Name ext_default_child_storage_clear_prefix_version_1 =
+      "ext_default_child_storage_clear_prefix_version_1";
   const static wasm::Name ext_default_child_storage_get_version_1 =
       "ext_default_child_storage_get_version_1";
   const static wasm::Name ext_default_child_storage_next_key_version_1 =
@@ -26,8 +28,12 @@ namespace kagome::runtime::binaryen {
       "ext_default_child_storage_root_version_1";
   const static wasm::Name ext_default_child_storage_set_version_1 =
       "ext_default_child_storage_set_version_1";
-  const static wasm::Name ext_default_child_storage_kill_version_1 =
-      "ext_default_child_storage_kill_version_1";
+  const static wasm::Name ext_default_child_storage_storage_kill_version_1 =
+      "ext_default_child_storage_storage_kill_version_1";
+  const static wasm::Name ext_default_child_storage_read_version_1 =
+      "ext_default_child_storage_read_version_1";
+  const static wasm::Name ext_default_child_storage_exists_version_1 =
+      "ext_default_child_storage_exists_version_1";
 
   const static wasm::Name ext_logging_log_version_1 =
       "ext_logging_log_version_1";
@@ -238,6 +244,13 @@ namespace kagome::runtime::binaryen {
             arguments.at(0).geti64(), arguments.at(1).geti64());
         return wasm::Literal();
       }
+      /// ext_default_child_storage_clear_prefix_version_1
+      if (import->base == ext_default_child_storage_clear_prefix_version_1) {
+        checkArguments(import->base.c_str(), 2, arguments.size());
+        host_api_->ext_default_child_storage_clear_prefix_version_1(
+            arguments.at(0).geti64(), arguments.at(1).geti64());
+        return wasm::Literal();
+      }
       /// ext_default_child_storage_next_key_version_1
       if (import->base == ext_default_child_storage_next_key_version_1) {
         checkArguments(import->base.c_str(), 2, arguments.size());
@@ -245,10 +258,26 @@ namespace kagome::runtime::binaryen {
             arguments.at(0).geti64(), arguments.at(1).geti64());
         return wasm::Literal(res);
       }
-      /// ext_default_child_storage_kill_version_1
-      if (import->base == ext_default_child_storage_kill_version_1) {
-        SL_WARN(logger_, "Call unimplemented import {}", import->base);
+      /// ext_default_child_storage_storage_kill_version_1
+      if (import->base == ext_default_child_storage_storage_kill_version_1) {
+        checkArguments(import->base.c_str(), 1, arguments.size());
+        host_api_->ext_default_child_storage_storage_kill_version_1(
+            arguments.at(0).geti64());
         return wasm::Literal();
+      }
+      /// ext_default_child_storage_read_version_1
+      if (import->base == ext_default_child_storage_read_version_1) {
+        checkArguments(import->base.c_str(), 4, arguments.size());
+        auto res = host_api_->ext_default_child_storage_read_version_1(
+            arguments.at(0).geti64(), arguments.at(1).geti64(), arguments.at(2).geti64(), arguments.at(3).geti32());
+        return wasm::Literal(res);
+      }
+      /// ext_default_child_storage_exists_version_1
+      if (import->base == ext_default_child_storage_exists_version_1) {
+        checkArguments(import->base.c_str(), 2, arguments.size());
+        auto res = host_api_->ext_default_child_storage_exists_version_1(
+            arguments.at(0).geti64(), arguments.at(1).geti64());
+        return wasm::Literal(res);
       }
       /// ext_logging_log_version_1
       if (import->base == ext_logging_log_version_1) {

--- a/core/runtime/wavm/intrinsics/intrinsic_functions.cpp
+++ b/core/runtime/wavm/intrinsics/intrinsic_functions.cpp
@@ -198,7 +198,7 @@ namespace kagome::runtime::wavm {
                                  WAVM::I64 values_data) {
     return peekHostApi()->ext_misc_runtime_version_version_1(values_data);
   }
-  
+
   WAVM_DEFINE_INTRINSIC_FUNCTION(void,
                                  ext_default_child_storage_clear_version_1,
                                  WAVM::I64 child_storage_key,
@@ -242,9 +242,12 @@ namespace kagome::runtime::wavm {
       WAVM::I64,
       WAVM::I64)
 
-  WAVM_DEFINE_INTRINSIC_FUNCTION_STUB(WAVM::I64,
-                                      ext_default_child_storage_root_version_1,
-                                      WAVM::I64)
+  WAVM_DEFINE_INTRINSIC_FUNCTION(WAVM::I64,
+                                 ext_default_child_storage_root_version_1,
+                                 WAVM::I64 child_storage_key) {
+    return peekHostApi()->ext_default_child_storage_root_version_1(
+        child_storage_key);
+  }
 
   WAVM_DEFINE_INTRINSIC_FUNCTION(void,
                                  ext_default_child_storage_set_version_1,

--- a/core/runtime/wavm/intrinsics/intrinsic_functions.cpp
+++ b/core/runtime/wavm/intrinsics/intrinsic_functions.cpp
@@ -207,18 +207,23 @@ namespace kagome::runtime::wavm {
         child_storage_key, key);
   }
 
-  WAVM_DEFINE_INTRINSIC_FUNCTION_STUB(WAVM::I64,
-                                      ext_default_child_storage_read_version_1,
-                                      WAVM::I64,
-                                      WAVM::I64,
-                                      WAVM::I64,
-                                      WAVM::I32)
+  WAVM_DEFINE_INTRINSIC_FUNCTION(WAVM::I64,
+                                 ext_default_child_storage_read_version_1,
+                                 WAVM::I64 child_storage_key,
+                                 WAVM::I64 key,
+                                 WAVM::I64 value_out,
+                                 WAVM::I32 offset) {
+    return peekHostApi()->ext_default_child_storage_read_version_1(
+        child_storage_key, key, value_out, offset);
+  }
 
-  WAVM_DEFINE_INTRINSIC_FUNCTION_STUB(
-      WAVM::I32,
-      ext_default_child_storage_exists_version_1,
-      WAVM::I64,
-      WAVM::I64)
+  WAVM_DEFINE_INTRINSIC_FUNCTION(WAVM::I32,
+                                 ext_default_child_storage_exists_version_1,
+                                 WAVM::I64 child_storage_key,
+                                 WAVM::I64 key) {
+    return peekHostApi()->ext_default_child_storage_exists_version_1(
+        child_storage_key, key);
+  }
 
   WAVM_DEFINE_INTRINSIC_FUNCTION(WAVM::I64,
                                  ext_default_child_storage_get_version_1,
@@ -236,11 +241,14 @@ namespace kagome::runtime::wavm {
         child_storage_key, key);
   }
 
-  WAVM_DEFINE_INTRINSIC_FUNCTION_STUB(
+  WAVM_DEFINE_INTRINSIC_FUNCTION(
       void,
       ext_default_child_storage_clear_prefix_version_1,
-      WAVM::I64,
-      WAVM::I64)
+      WAVM::I64 child_storage_key,
+      WAVM::I64 prefix) {
+    return peekHostApi()->ext_default_child_storage_clear_prefix_version_1(
+        child_storage_key, prefix);
+  }
 
   WAVM_DEFINE_INTRINSIC_FUNCTION(WAVM::I64,
                                  ext_default_child_storage_root_version_1,
@@ -258,8 +266,13 @@ namespace kagome::runtime::wavm {
         child_storage_key, key, value);
   }
 
-  WAVM_DEFINE_INTRINSIC_FUNCTION_STUB(
-      void, ext_default_child_storage_storage_kill_version_1, WAVM::I64)
+  WAVM_DEFINE_INTRINSIC_FUNCTION(
+      void,
+      ext_default_child_storage_storage_kill_version_1,
+      WAVM::I64 child_storage_key) {
+    return peekHostApi()->ext_default_child_storage_storage_kill_version_1(
+        child_storage_key);
+  }
 
   WAVM_DEFINE_INTRINSIC_FUNCTION(WAVM::I32,
                                  ext_hashing_blake2_128_version_1,

--- a/test/mock/core/host_api/host_api_mock.hpp
+++ b/test/mock/core/host_api/host_api_mock.hpp
@@ -362,9 +362,7 @@ namespace kagome::host_api {
 
     MOCK_METHOD(void,
                 ext_default_child_storage_set_version_1,
-                (runtime::WasmSpan,
-                 runtime::WasmSpan,
-                 runtime::WasmSpan),
+                (runtime::WasmSpan, runtime::WasmSpan, runtime::WasmSpan),
                 (override));
 
     MOCK_METHOD(runtime::WasmSpan,
@@ -386,6 +384,29 @@ namespace kagome::host_api {
                 ext_default_child_storage_root_version_1,
                 (runtime::WasmSpan),
                 (const, override));
+
+    MOCK_METHOD(void,
+                ext_default_child_storage_clear_prefix_version_1,
+                (runtime::WasmSpan, runtime::WasmSpan),
+                (override));
+
+    MOCK_METHOD(runtime::WasmSpan,
+                ext_default_child_storage_read_version_1,
+                (runtime::WasmSpan,
+                 runtime::WasmSpan,
+                 runtime::WasmSpan,
+                 runtime::WasmOffset),
+                (const, override));
+
+    MOCK_METHOD(uint32_t,
+                ext_default_child_storage_exists_version_1,
+                (runtime::WasmSpan, runtime::WasmSpan),
+                (const, override));
+
+    MOCK_METHOD(void,
+                ext_default_child_storage_storage_kill_version_1,
+                (runtime::WasmSpan),
+                (override));
   };
 
 }  // namespace kagome::host_api


### PR DESCRIPTION
Fixes #1089


Adds missing implementation of child_storage_key to WAVM.
