### PR TITLE
BlockTree pruning fix

### DIFF
--- a/core/blockchain/impl/block_tree_impl.cpp
+++ b/core/blockchain/impl/block_tree_impl.cpp
@@ -895,6 +895,7 @@ namespace kagome::blockchain {
         }
       }
 
+      tree_->removeFromMeta(tree_->getRoot().findByHash(hash));
       OUTCOME_TRY(storage_->removeBlock(hash, number));
     }
 

--- a/core/blockchain/impl/block_tree_impl.cpp
+++ b/core/blockchain/impl/block_tree_impl.cpp
@@ -74,7 +74,7 @@ namespace kagome::blockchain {
     // if it is yet undefined).
 
     for (;;) {
-      if (hash_tmp.empty()) {
+      if (hash_tmp == primitives::BlockHash{}) {
         if (not curr_epoch_number.has_value()) {
           curr_epoch_number = 0;
         }
@@ -243,8 +243,7 @@ namespace kagome::blockchain {
 
     metric_known_chain_leaves_ =
         metrics_registry_->registerGaugeMetric(knownChainLeavesMetricName);
-    metric_known_chain_leaves_->set(
-        static_cast<double>(tree_->getMetadata().leaves.size()));
+    metric_known_chain_leaves_->set(tree_->getMetadata().leaves.size());
   }
 
   outcome::result<void> BlockTreeImpl::addBlockHeader(
@@ -273,8 +272,7 @@ namespace kagome::blockchain {
         block_hash, header.number, parent, epoch_number, std::move(next_epoch));
     tree_->updateMeta(new_node);
 
-    metric_known_chain_leaves_->set(
-        static_cast<double>(tree_->getMetadata().leaves.size()));
+    metric_known_chain_leaves_->set(tree_->getMetadata().leaves.size());
     metric_best_block_height_->set(
         tree_->getMetadata().deepest_leaf.lock()->depth);
 
@@ -329,8 +327,7 @@ namespace kagome::blockchain {
       }
     }
 
-    metric_known_chain_leaves_->set(
-        static_cast<double>(tree_->getMetadata().leaves.size()));
+    metric_known_chain_leaves_->set(tree_->getMetadata().leaves.size());
     metric_best_block_height_->set(
         tree_->getMetadata().deepest_leaf.lock()->depth);
 
@@ -373,8 +370,7 @@ namespace kagome::blockchain {
 
     tree_->updateMeta(new_node);
 
-    metric_known_chain_leaves_->set(
-        static_cast<double>(tree_->getMetadata().leaves.size()));
+    metric_known_chain_leaves_->set(tree_->getMetadata().leaves.size());
     metric_best_block_height_->set(
         tree_->getMetadata().deepest_leaf.lock()->depth);
 

--- a/core/blockchain/impl/block_tree_impl.cpp
+++ b/core/blockchain/impl/block_tree_impl.cpp
@@ -871,7 +871,7 @@ namespace kagome::blockchain {
           current_node->children.begin(),
           current_node->children.end(),
           std::back_inserter(to_remove),
-          [&following_node](auto child) { return child != following_node; });
+          [&following_node](const auto &child) { return child != following_node; });
       auto last = to_remove.back();
       while (last != nullptr) {
         to_remove.pop_back();

--- a/core/blockchain/impl/block_tree_impl.hpp
+++ b/core/blockchain/impl/block_tree_impl.hpp
@@ -194,10 +194,6 @@ namespace kagome::blockchain {
      */
     std::vector<primitives::BlockHash> getLeavesSorted() const;
 
-    static void collectDescendants(
-        std::shared_ptr<TreeNode> node,
-        std::list<std::shared_ptr<TreeNode>> &container);
-
     outcome::result<void> prune(
         const std::shared_ptr<TreeNode> &lastFinalizedNode);
 

--- a/core/blockchain/impl/block_tree_impl.hpp
+++ b/core/blockchain/impl/block_tree_impl.hpp
@@ -41,7 +41,6 @@ namespace kagome::blockchain {
   class CachedTree;
 
   class BlockTreeImpl : public BlockTree {
-
    public:
     enum class Error {
       // target block number is past the given maximum number
@@ -197,8 +196,7 @@ namespace kagome::blockchain {
 
     static void collectDescendants(
         std::shared_ptr<TreeNode> node,
-        std::vector<std::pair<primitives::BlockHash, primitives::BlockNumber>>
-            &container);
+        std::list<std::shared_ptr<TreeNode>> &container);
 
     outcome::result<void> prune(
         const std::shared_ptr<TreeNode> &lastFinalizedNode);
@@ -228,8 +226,6 @@ namespace kagome::blockchain {
     metrics::Gauge *metric_best_block_height_;
     metrics::Gauge *metric_finalized_block_height_;
     metrics::Gauge *metric_known_chain_leaves_;
-
-
   };
 }  // namespace kagome::blockchain
 

--- a/core/blockchain/impl/cached_tree.cpp
+++ b/core/blockchain/impl/cached_tree.cpp
@@ -244,7 +244,8 @@ namespace kagome::blockchain {
   void CachedTree::removeFromMeta(const std::shared_ptr<TreeNode> &node) {
     auto parent = node->parent.lock();
     if (parent != nullptr) {
-      parent->children.erase(std::find(parent->children.begin(), parent->children.end(), node));
+      parent->children.erase(
+          std::find(parent->children.begin(), parent->children.end(), node));
     }
 
     metadata_->leaves.erase(node->block_hash);

--- a/core/blockchain/impl/cached_tree.cpp
+++ b/core/blockchain/impl/cached_tree.cpp
@@ -240,4 +240,34 @@ namespace kagome::blockchain {
       metadata_->deepest_leaf = new_node;
     }
   }
+
+  void CachedTree::removeFromMeta(const std::shared_ptr<TreeNode> &node) {
+    auto parent = node->parent.lock();
+    parent->children.erase(std::find_if(
+        parent->children.begin(),
+        parent->children.end(),
+        [hash = node->block_hash](auto a) { return a->block_hash == hash; }));
+
+    metadata_->leaves.erase(node->block_hash);
+    if (parent->children.empty()) {
+      metadata_->leaves.insert(parent->block_hash);
+    }
+    if (metadata_->deepest_leaf.expired()) {
+      std::vector<primitives::BlockInfo> leaf_depths;
+      leaf_depths.reserve(metadata_->leaves.size());
+      std::transform(metadata_->leaves.begin(),
+                     metadata_->leaves.end(),
+                     std::back_inserter(leaf_depths),
+                     [this](const auto &hash) {
+                       auto leaf_node = root_->findByHash(hash);
+                       return primitives::BlockInfo{leaf_node->depth,
+                                                    leaf_node->block_hash};
+                     });
+      std::sort(
+          leaf_depths.begin(),
+          leaf_depths.end(),
+          [](auto const &p1, auto const &p2) { return p1.number > p2.number; });
+      metadata_->deepest_leaf = root_->findByHash(leaf_depths.end()->hash);
+    }
+  }
 }  // namespace kagome::blockchain

--- a/core/blockchain/impl/cached_tree.cpp
+++ b/core/blockchain/impl/cached_tree.cpp
@@ -243,13 +243,16 @@ namespace kagome::blockchain {
 
   void CachedTree::removeFromMeta(const std::shared_ptr<TreeNode> &node) {
     auto parent = node->parent.lock();
-    parent->children.erase(std::find_if(
-        parent->children.begin(),
-        parent->children.end(),
-        [hash = node->block_hash](auto a) { return a->block_hash == hash; }));
+    if (parent.get()) {
+      auto child_it = std::find_if(
+          parent->children.begin(),
+          parent->children.end(),
+          [hash = node->block_hash](auto a) { return a->block_hash == hash; });
+      parent->children.erase(child_it);
+    }
 
     metadata_->leaves.erase(node->block_hash);
-    if (parent->children.empty()) {
+    if (parent.get() && parent->children.empty()) {
       metadata_->leaves.insert(parent->block_hash);
     }
     if (metadata_->deepest_leaf.expired()) {

--- a/core/blockchain/impl/cached_tree.cpp
+++ b/core/blockchain/impl/cached_tree.cpp
@@ -243,12 +243,8 @@ namespace kagome::blockchain {
 
   void CachedTree::removeFromMeta(const std::shared_ptr<TreeNode> &node) {
     auto parent = node->parent.lock();
-    if (parent.get()) {
-      auto child_it = std::find_if(
-          parent->children.begin(),
-          parent->children.end(),
-          [hash = node->block_hash](auto a) { return a->block_hash == hash; });
-      parent->children.erase(child_it);
+    if (parent != nullptr) {
+      parent->children.erase(std::find(parent->children.begin(), parent->children.end(), node));
     }
 
     metadata_->leaves.erase(node->block_hash);
@@ -263,6 +259,7 @@ namespace kagome::blockchain {
                      std::back_inserter(leaf_depths),
                      [this](const auto &hash) {
                        auto leaf_node = root_->findByHash(hash);
+                       BOOST_ASSERT(leaf_node != nullptr);
                        return primitives::BlockInfo{leaf_node->depth,
                                                     leaf_node->block_hash};
                      });
@@ -270,7 +267,7 @@ namespace kagome::blockchain {
           leaf_depths.begin(),
           leaf_depths.end(),
           [](auto const &p1, auto const &p2) { return p1.number > p2.number; });
-      metadata_->deepest_leaf = root_->findByHash(leaf_depths.end()->hash);
+      metadata_->deepest_leaf = root_->findByHash(leaf_depths.back().hash);
     }
   }
 }  // namespace kagome::blockchain

--- a/core/blockchain/impl/cached_tree.hpp
+++ b/core/blockchain/impl/cached_tree.hpp
@@ -24,14 +24,14 @@ namespace kagome::blockchain {
    public:
     enum class Error { NO_CHAIN_BETWEEN_BLOCKS = 1 };
 
-    TreeNode(const primitives::BlockHash& hash,
+    TreeNode(const primitives::BlockHash &hash,
              primitives::BlockNumber depth,
              consensus::EpochDigest &&curr_epoch_digest,
              consensus::EpochNumber epoch_number,
              consensus::EpochDigest &&next_epoch_digest,
              bool finalized = false);
 
-    TreeNode(const primitives::BlockHash& hash,
+    TreeNode(const primitives::BlockHash &hash,
              primitives::BlockNumber depth,
              const std::shared_ptr<TreeNode> &parent,
              consensus::EpochNumber epoch_number,
@@ -100,11 +100,11 @@ namespace kagome::blockchain {
    * the operations faster
    */
   struct TreeMeta {
-    explicit TreeMeta(const std::shared_ptr<TreeNode>& subtree_root_node);
+    explicit TreeMeta(const std::shared_ptr<TreeNode> &subtree_root_node);
 
     TreeMeta(std::unordered_set<primitives::BlockHash> leaves,
-             const std::shared_ptr<TreeNode>& deepest_leaf,
-             const std::shared_ptr<TreeNode>& last_finalized);
+             const std::shared_ptr<TreeNode> &deepest_leaf,
+             const std::shared_ptr<TreeNode> &last_finalized);
 
     std::unordered_set<primitives::BlockHash> leaves;
     std::weak_ptr<TreeNode> deepest_leaf;
@@ -132,6 +132,14 @@ namespace kagome::blockchain {
     void updateTreeRoot(std::shared_ptr<TreeNode> new_trie_root);
 
     void updateMeta(const std::shared_ptr<TreeNode> &new_node);
+
+    /**
+     * @brief
+     * A reversal of updateMeta - it's called upon block tree branch prunung to
+     * remove pruned block from leaves list, update deepest node wptr etc.
+     * @param node Removed node
+     */
+    void removeFromMeta(const std::shared_ptr<TreeNode> &node);
 
     TreeNode const &getRoot() const;
     TreeNode &getRoot();

--- a/core/blockchain/impl/cached_tree.hpp
+++ b/core/blockchain/impl/cached_tree.hpp
@@ -69,7 +69,8 @@ namespace kagome::blockchain {
 
       enum Value { EXIT, CONTINUE } value;
 
-      ExitToken(Value value) : value{value} {}
+      ExitToken(Value value)  // NOLINT(google-explicit-constructor)
+          : value{value} {}
 
       bool operator==(Value v) const {
         return value == v;

--- a/core/metrics/metrics.hpp
+++ b/core/metrics/metrics.hpp
@@ -20,7 +20,7 @@ namespace kagome::metrics {
 
   /**
    * @brief A counter metric to represent a monotonically increasing value.
-   * 
+   *
    * This class represents the metric type counter:
    * https://prometheus.io/docs/concepts/metric_types/#counter
    */
@@ -42,7 +42,7 @@ namespace kagome::metrics {
   /**
    * @brief A gauge metric to represent a value that can arbitrarily go up and
    * down.
-   * 
+   *
    * The class represents the metric type gauge:
    * https://prometheus.io/docs/concepts/metric_types/#gauge
    */
@@ -74,12 +74,17 @@ namespace kagome::metrics {
      * @brief Set the gauge to the given value.
      */
     virtual void set(double val) = 0;
+
+    template <typename T>
+    void set(T val) {
+      set(static_cast<double>(val));
+    }
   };
 
   /**
    * @brief A summary metric samples observations over a sliding window of
    * time.
-   * 
+   *
    * This class represents the metric type summary:
    * https://prometheus.io/docs/instrumenting/writing_clientlibs/#summary
    */
@@ -96,7 +101,7 @@ namespace kagome::metrics {
   /**
    * @brief A histogram metric to represent aggregatable distributions of
    * events.
-   * 
+   *
    * This class represents the metric type histogram:
    * https://prometheus.io/docs/concepts/metric_types/#histogram
    */

--- a/core/network/impl/synchronizer_impl.cpp
+++ b/core/network/impl/synchronizer_impl.cpp
@@ -510,7 +510,7 @@ namespace kagome::network {
           peer_id,
           from,
           outcome::result<void>(Error::DUPLICATE_REQUEST).error().message());
-      handler(Error::DUPLICATE_REQUEST);
+      if (handler) handler(Error::DUPLICATE_REQUEST);
       return;
     }
 

--- a/test/core/blockchain/block_tree_test.cpp
+++ b/test/core/blockchain/block_tree_test.cpp
@@ -205,7 +205,7 @@ TEST_F(BlockTreeTest, AddBlock) {
   auto hash = addBlock(new_block);
 
   // THEN
-  auto &&[__, new_deepest_block_hash] = block_tree_->deepestLeaf();
+  auto &&[_, new_deepest_block_hash] = block_tree_->deepestLeaf();
   ASSERT_EQ(new_deepest_block_hash, hash);
 
   leaves = block_tree_->getLeaves();


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

The issue is basically a bug that shows itself upon pruning branches in block tree. If deepest leaf is being pruned, CachedTree keeps a wptr to deleted element, which eventually leads to crash.
To fix it, I added a method to CachedTree that fixes the state upon leaf pruning.

### Benefits

It doesn't crash.

### Possible Drawbacks 

It's a bit more work, thus slightly less performant. 

### Alternate Designs <!-- Optional -->

If branches are many and they're extensive, it would make sense to promote vector of leafs hashes to priority queue of {depth; hash} pairs, sorted by depth. But AFAIK, it doesn't have that much of impact in our case since leafs are few.
