### PR TITLE
Fix storage root calculation / Enable sync after 8179282

### DIFF
--- a/core/host_api/impl/CMakeLists.txt
+++ b/core/host_api/impl/CMakeLists.txt
@@ -70,6 +70,7 @@ target_link_libraries(storage_extension
     ordered_trie_hash
     scale::scale_encode_append
     runtime_transaction_error
+    polkadot_codec
     )
 kagome_install(storage_extension)
 

--- a/core/host_api/impl/storage_extension.cpp
+++ b/core/host_api/impl/storage_extension.cpp
@@ -5,6 +5,7 @@
 
 #include "host_api/impl/storage_extension.hpp"
 
+#include <algorithm>
 #include <forward_list>
 
 #include "clock/impl/clock_impl.hpp"
@@ -15,6 +16,7 @@
 #include "runtime/ptr_size.hpp"
 #include "runtime/trie_storage_provider.hpp"
 #include "scale/encode_append.hpp"
+#include "storage/predefined_keys.hpp"
 #include "storage/trie/polkadot_trie/trie_error.hpp"
 #include "storage/trie/serialization/ordered_trie_hash.hpp"
 
@@ -202,8 +204,9 @@ namespace kagome::host_api {
     return clearPrefix(prefix, limit_opt);
   }
 
-  runtime::WasmSpan StorageExtension::ext_storage_root_version_1() const {
+  runtime::WasmSpan StorageExtension::ext_storage_root_version_1() {
     outcome::result<storage::trie::RootHash> res{{}};
+    removeEmptyChildStorages();
     if (auto opt_batch = storage_provider_->tryGetPersistentBatch();
         opt_batch.has_value() and opt_batch.value() != nullptr) {
       res = opt_batch.value()->commit();
@@ -464,6 +467,34 @@ namespace kagome::host_api {
       throw std::runtime_error(msg);
     }
     return memory.storeBuffer(enc_res.value());
+  }
+
+  void StorageExtension::removeEmptyChildStorages() {
+    static const auto &prefix = storage::kChildStorageDefaultPrefix;
+    static const auto empty_hash = Buffer(codec_.hash256({0}));
+    auto current_key = prefix;
+    auto key_res = getStorageNextKey(current_key);
+    while (key_res and key_res.value()) {
+      current_key = key_res.value().value();
+
+      bool contains_prefix =
+          std::equal(prefix.begin(), prefix.end(), current_key.begin());
+      if (not contains_prefix) {
+        break;
+      }
+      auto value_res = get(current_key);
+      if (value_res and value_res.value() == empty_hash) {
+        auto batch = storage_provider_->getCurrentBatch();
+        auto remove_res = batch->remove(current_key);
+        if (not remove_res) {
+          logger_->error(
+              "Unable to remove empty child storage under key {}, error is {}",
+              current_key,
+              remove_res.error().message());
+        }
+      }
+      key_res = getStorageNextKey(current_key);
+    }
   }
 
 }  // namespace kagome::host_api

--- a/core/host_api/impl/storage_extension.hpp
+++ b/core/host_api/impl/storage_extension.hpp
@@ -11,6 +11,7 @@
 #include "log/logger.hpp"
 #include "runtime/types.hpp"
 #include "storage/changes_trie/changes_tracker.hpp"
+#include "storage/trie/serialization/polkadot_codec.hpp"
 
 namespace kagome::runtime {
   class MemoryProvider;
@@ -77,7 +78,7 @@ namespace kagome::host_api {
     /**
      * @see HostApi::ext_storage_root_version_1
      */
-    runtime::WasmSpan ext_storage_root_version_1() const;
+    runtime::WasmSpan ext_storage_root_version_1();
 
     /**
      * @see HostApi::ext_storage_changes_root_version_1
@@ -155,9 +156,16 @@ namespace kagome::host_api {
     runtime::WasmSpan clearPrefix(const common::Buffer &prefix,
                                   std::optional<uint32_t> limit);
 
+    /**
+     * Removes all empty child storages from the primary storage.
+     * Such cleanup is required for the correct storage root calculation.
+     */
+    void removeEmptyChildStorages();
+
     std::shared_ptr<runtime::TrieStorageProvider> storage_provider_;
     std::shared_ptr<const runtime::MemoryProvider> memory_provider_;
     std::shared_ptr<storage::changes_trie::ChangesTracker> changes_tracker_;
+    storage::trie::PolkadotCodec codec_;
     log::Logger logger_;
 
     constexpr static auto kDefaultLoggerTag = "WASM Runtime [StorageExtension]";


### PR DESCRIPTION
Add empty child storages removal before root calculation

Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

Resolves #942 

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change

The change brings empty child storages removal from the primary storage before storage root hash calculation.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Block 8179282 could be applied

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

None?

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
