### PR TITLE
Fix for HttpSession error

### DIFF
--- a/core/api/transport/impl/http/http_session.cpp
+++ b/core/api/transport/impl/http/http_session.cpp
@@ -103,6 +103,7 @@ namespace kagome::api {
       }
 
       stop();
+      return;
     }
 
     handleRequest(parser_->release());


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

Fix for #1088.

### Description of the Change

We've got "Broken pipe" error on each rpc request. The reason was that after exausting reads in RPC's HTTP session we gracefully shutdown our socket and, for some reason, continue handling requests, which leads to attempt to write to closed socket. 
I just added a return on error to HttpSession::onRead.

### Benefits

We no longer get "Broken pipe" error on each RPC request.

### Usage Examples or Tests <!-- Optional -->

$ curl -H 'Content-Type: application/json' -d '{"id":1, "jsonrpc":"2.0", "method": "system_health", "params":[]}' 127.0.0.1:9933

A request like this must not produce an error in log.