### PR TITLE
Added block # support as a key for codeSubstitutes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ cmake-build*
 /.gtm/
 
 *.deb
+*.idx
 
 build
 dist
@@ -44,3 +45,4 @@ _builds
 _logs
 _build
 examples/**/db
+.cache/**

--- a/core/application/chain_spec.hpp
+++ b/core/application/chain_spec.hpp
@@ -51,15 +51,16 @@ namespace kagome::application {
 
     virtual std::optional<std::string> consensusEngine() const = 0;
 
-    /// Fetches code_substitute from json config on demand, by its hash.
-    /// Hashes are being loaded on initial configuration and stored in set.
-    virtual outcome::result<common::Buffer> fetchCodeSubstituteByHash(
-        const common::Hash256 &hash) const = 0;
+    /// Fetches code_substitute from json config on demand, by its BlockInfo.
+    /// BlockInfo is being compared with BlockIds that were loaded on initial
+    /// configuration and stored in set.
+    virtual outcome::result<common::Buffer> fetchCodeSubstituteByBlockInfo(
+        const primitives::BlockInfo &block_info) const = 0;
 
     /**
      * @return runtime code substitution map
      */
-    virtual std::shared_ptr<const primitives::CodeSubstituteHashes>
+    virtual std::shared_ptr<const primitives::CodeSubstituteBlockIds>
     codeSubstitutes() const = 0;
 
     /**

--- a/core/application/impl/chain_spec_impl.cpp
+++ b/core/application/impl/chain_spec_impl.cpp
@@ -196,8 +196,7 @@ namespace kagome::application {
 
   outcome::result<common::Buffer> ChainSpecImpl::fetchCodeSubstituteByBlockInfo(
       const primitives::BlockInfo &block_info) const {
-    if (known_code_substitutes_->count(block_info.hash) != 0
-        && known_code_substitutes_->count(block_info.number) != 0) {
+    if (!known_code_substitutes_->contains(block_info)) {
       return Error::MISSING_ENTRY;
     }
 

--- a/core/application/impl/chain_spec_impl.hpp
+++ b/core/application/impl/chain_spec_impl.hpp
@@ -79,7 +79,7 @@ namespace kagome::application {
       return consensus_engine_;
     }
 
-    std::shared_ptr<const primitives::CodeSubstituteHashes> codeSubstitutes()
+    std::shared_ptr<const primitives::CodeSubstituteBlockIds> codeSubstitutes()
         const override {
       return known_code_substitutes_;
     }
@@ -88,8 +88,8 @@ namespace kagome::application {
       return genesis_;
     }
 
-    outcome::result<common::Buffer> fetchCodeSubstituteByHash(
-        const common::Hash256 &hash) const override;
+    outcome::result<common::Buffer> fetchCodeSubstituteByBlockInfo(
+        const primitives::BlockInfo &block_info) const override;
 
    private:
     outcome::result<void> loadFromJson(const std::string &file_path);
@@ -109,6 +109,9 @@ namespace kagome::application {
       return opt_entry.value();
     }
 
+    outcome::result<primitives::BlockId> parseBlockId(
+        const std::string_view block_id_str) const;
+
     ChainSpecImpl() = default;
 
     std::string name_;
@@ -122,7 +125,7 @@ namespace kagome::application {
     std::set<primitives::BlockHash> fork_blocks_;
     std::set<primitives::BlockHash> bad_blocks_;
     std::optional<std::string> consensus_engine_;
-    std::shared_ptr<primitives::CodeSubstituteHashes> known_code_substitutes_;
+    std::shared_ptr<primitives::CodeSubstituteBlockIds> known_code_substitutes_;
     GenesisRawData genesis_;
     log::Logger log_ = log::createLogger("chain_spec", "kagome");
   };

--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -821,7 +821,7 @@ namespace {
           auto storage =
               injector.template create<sptr<storage::BufferStorage>>();
           auto substitutes = injector.template create<
-              sptr<const primitives::CodeSubstituteHashes>>();
+              sptr<const primitives::CodeSubstituteBlockIds>>();
           auto res = runtime::RuntimeUpgradeTrackerImpl::create(
               std::move(header_repo),
               std::move(storage),
@@ -938,7 +938,7 @@ namespace {
 
         di::bind<application::AppStateManager>.template to<application::AppStateManagerImpl>(),
         di::bind<application::AppConfiguration>.to(config),
-        di::bind<primitives::CodeSubstituteHashes>.to(
+        di::bind<primitives::CodeSubstituteBlockIds>.to(
             get_chain_spec(config)->codeSubstitutes()),
 
         // compose peer keypair
@@ -1348,7 +1348,7 @@ namespace kagome::injector {
     using Injector = decltype(makeKagomeNodeInjector(
         std::declval<application::AppConfiguration const &>()));
 
-    KagomeNodeInjectorImpl(Injector injector)
+    explicit KagomeNodeInjectorImpl(Injector injector)
         : injector_{std::move(injector)} {}
     Injector injector_;
   };

--- a/core/primitives/code_substitutes.hpp
+++ b/core/primitives/code_substitutes.hpp
@@ -8,11 +8,14 @@
 
 #include <unordered_set>
 
+#include "block_id.hpp"
+
 namespace kagome::primitives {
 
-  /// A set of valid code_substitute hashes.
-  /// You can pass them to fetchCodeSubstituteByHash() and get code_substitute.
-  using CodeSubstituteHashes = std::unordered_set<primitives::BlockHash>;
+  /// A set of valid code_substitute ids.
+  /// To get a code substitute you should get BlockInfo for this BlockId and
+  /// pass it to fetchCodeSubstituteByBlockInfo()
+  using CodeSubstituteBlockIds = std::unordered_set<primitives::BlockId>;
 
 }  // namespace kagome::primitives
 

--- a/core/primitives/code_substitutes.hpp
+++ b/core/primitives/code_substitutes.hpp
@@ -6,6 +6,7 @@
 #ifndef KAGOME_CODE_SUBSTITUTES_HPP
 #define KAGOME_CODE_SUBSTITUTES_HPP
 
+#include <initializer_list>
 #include <unordered_set>
 
 #include "block_id.hpp"
@@ -15,7 +16,28 @@ namespace kagome::primitives {
   /// A set of valid code_substitute ids.
   /// To get a code substitute you should get BlockInfo for this BlockId and
   /// pass it to fetchCodeSubstituteByBlockInfo()
-  using CodeSubstituteBlockIds = std::unordered_set<primitives::BlockId>;
+  struct CodeSubstituteBlockIds
+      : public std::unordered_set<primitives::BlockId> {
+    CodeSubstituteBlockIds() = default;
+    CodeSubstituteBlockIds(const CodeSubstituteBlockIds &src) = default;
+    CodeSubstituteBlockIds(CodeSubstituteBlockIds &&src) = default;
+    explicit CodeSubstituteBlockIds(
+        std::initializer_list<primitives::BlockId> init)
+        : unordered_set<primitives::BlockId>(init) {}
+    ~CodeSubstituteBlockIds() = default;
+
+    CodeSubstituteBlockIds &operator=(const CodeSubstituteBlockIds &src) =
+        default;
+    CodeSubstituteBlockIds &operator=(CodeSubstituteBlockIds &&src) = default;
+
+    bool contains(const primitives::BlockInfo &block_info) const {
+      return count(block_info.number) != 0 || count(block_info.hash) != 0;
+    };
+
+    bool contains(const primitives::BlockId &block_id) const {
+      return count(block_id) != 0;
+    }
+  };
 
 }  // namespace kagome::primitives
 

--- a/core/runtime/common/runtime_upgrade_tracker_impl.cpp
+++ b/core/runtime/common/runtime_upgrade_tracker_impl.cpp
@@ -66,8 +66,7 @@ namespace kagome::runtime {
 
   bool RuntimeUpgradeTrackerImpl::hasCodeSubstitute(
       const kagome::primitives::BlockInfo &block_info) const {
-    return known_code_substitutes_->count(block_info.number) != 0
-           || known_code_substitutes_->count(block_info.hash) != 0;
+    return known_code_substitutes_->contains(block_info);
   }
 
   bool RuntimeUpgradeTrackerImpl::isStateInChain(

--- a/core/runtime/common/runtime_upgrade_tracker_impl.hpp
+++ b/core/runtime/common/runtime_upgrade_tracker_impl.hpp
@@ -33,7 +33,7 @@ namespace kagome::runtime {
     static outcome::result<std::unique_ptr<RuntimeUpgradeTrackerImpl>> create(
         std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo,
         std::shared_ptr<storage::BufferStorage> storage,
-        std::shared_ptr<const primitives::CodeSubstituteHashes>
+        std::shared_ptr<const primitives::CodeSubstituteBlockIds>
             code_substitutes);
 
     struct RuntimeUpgradeData {
@@ -64,14 +64,14 @@ namespace kagome::runtime {
     outcome::result<storage::trie::RootHash> getLastCodeUpdateState(
         const primitives::BlockInfo &block) override;
 
-    outcome::result<primitives::BlockHash> getLastCodeUpdateHash(
+    outcome::result<primitives::BlockInfo> getLastCodeUpdateBlockInfo(
         const storage::trie::RootHash &state) const override;
 
    private:
     RuntimeUpgradeTrackerImpl(
         std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo,
         std::shared_ptr<storage::BufferStorage> storage,
-        std::shared_ptr<const primitives::CodeSubstituteHashes>
+        std::shared_ptr<const primitives::CodeSubstituteBlockIds>
             code_substitutes,
         std::vector<RuntimeUpgradeData> &&saved_data);
 
@@ -83,7 +83,8 @@ namespace kagome::runtime {
         std::vector<RuntimeUpgradeData>::const_reverse_iterator
             latest_upgrade_it) const;
 
-    bool hasCodeSubstitute(const kagome::primitives::BlockHash &hash) const;
+    bool hasCodeSubstitute(
+        const kagome::primitives::BlockInfo &block_info) const;
 
     outcome::result<storage::trie::RootHash> push(
         const primitives::BlockHash &hash);
@@ -99,7 +100,7 @@ namespace kagome::runtime {
     std::shared_ptr<const blockchain::BlockTree> block_tree_;
     std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo_;
     std::shared_ptr<storage::BufferStorage> storage_;
-    std::shared_ptr<const primitives::CodeSubstituteHashes>
+    std::shared_ptr<const primitives::CodeSubstituteBlockIds>
         known_code_substitutes_;
     log::Logger logger_;
   };

--- a/core/runtime/common/storage_code_provider.cpp
+++ b/core/runtime/common/storage_code_provider.cpp
@@ -35,17 +35,13 @@ namespace kagome::runtime {
     if (last_state_root_ != state) {
       last_state_root_ = state;
 
-      auto block_info =
-          runtime_upgrade_tracker_->getLastCodeUpdateBlockInfo(state);
-      if (block_info.has_value()) {
-        if (known_code_substitutes_->count(block_info.value().number)
-            || known_code_substitutes_->count(block_info.value().hash)) {
-          OUTCOME_TRY(
-              code,
-              chain_spec_->fetchCodeSubstituteByBlockInfo(block_info.value()));
-          OUTCOME_TRY(uncompressCodeIfNeeded(code, cached_code_));
-          return cached_code_;
-        }
+      OUTCOME_TRY(block_info,
+                  runtime_upgrade_tracker_->getLastCodeUpdateBlockInfo(state));
+      if (known_code_substitutes_->contains(block_info)) {
+        OUTCOME_TRY(code,
+                    chain_spec_->fetchCodeSubstituteByBlockInfo(block_info));
+        OUTCOME_TRY(uncompressCodeIfNeeded(code, cached_code_));
+        return cached_code_;
       }
       OUTCOME_TRY(batch, storage_->getEphemeralBatchAt(state));
       OUTCOME_TRY(setCodeFromBatch(*batch.get()));

--- a/core/runtime/common/storage_code_provider.cpp
+++ b/core/runtime/common/storage_code_provider.cpp
@@ -18,13 +18,14 @@ namespace kagome::runtime {
   StorageCodeProvider::StorageCodeProvider(
       std::shared_ptr<const storage::trie::TrieStorage> storage,
       std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker,
-      std::shared_ptr<const primitives::CodeSubstituteHashes> code_substitutes,
+      std::shared_ptr<const primitives::CodeSubstituteBlockIds>
+          code_substitutes,
       std::shared_ptr<application::ChainSpec> chain_spec)
       : storage_{std::move(storage)},
         runtime_upgrade_tracker_{std::move(runtime_upgrade_tracker)},
         known_code_substitutes_{std::move(code_substitutes)},
         chain_spec_{std::move(chain_spec)},
-        logger_ {log::createLogger("StorageCodeProvider", "runtime")} {
+        logger_{log::createLogger("StorageCodeProvider", "runtime")} {
     BOOST_ASSERT(storage_ != nullptr);
     BOOST_ASSERT(runtime_upgrade_tracker_ != nullptr);
   }
@@ -34,11 +35,14 @@ namespace kagome::runtime {
     if (last_state_root_ != state) {
       last_state_root_ = state;
 
-      auto hash = runtime_upgrade_tracker_->getLastCodeUpdateHash(state);
-      if (hash.has_value()) {
-        if (known_code_substitutes_->count(hash.value())) {
-          OUTCOME_TRY(code,
-                      chain_spec_->fetchCodeSubstituteByHash(hash.value()));
+      auto block_info =
+          runtime_upgrade_tracker_->getLastCodeUpdateBlockInfo(state);
+      if (block_info.has_value()) {
+        if (known_code_substitutes_->count(block_info.value().number)
+            || known_code_substitutes_->count(block_info.value().hash)) {
+          OUTCOME_TRY(
+              code,
+              chain_spec_->fetchCodeSubstituteByBlockInfo(block_info.value()));
           OUTCOME_TRY(uncompressCodeIfNeeded(code, cached_code_));
           return cached_code_;
         }

--- a/core/runtime/common/storage_code_provider.hpp
+++ b/core/runtime/common/storage_code_provider.hpp
@@ -19,6 +19,7 @@ namespace kagome::storage::trie {
 namespace kagome::runtime {
 
   class RuntimeUpgradeTracker;
+  using  primitives::CodeSubstituteBlockIds;
 
   class StorageCodeProvider final : public RuntimeCodeProvider {
    public:
@@ -27,8 +28,7 @@ namespace kagome::runtime {
     explicit StorageCodeProvider(
         std::shared_ptr<const storage::trie::TrieStorage> storage,
         std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker,
-        std::shared_ptr<const primitives::CodeSubstituteHashes>
-            code_substitutes,
+        std::shared_ptr<const CodeSubstituteBlockIds> code_substitutes,
         std::shared_ptr<application::ChainSpec> chain_spec);
 
     outcome::result<gsl::span<const uint8_t>> getCodeAt(
@@ -39,8 +39,7 @@ namespace kagome::runtime {
         const storage::trie::EphemeralTrieBatch &batch) const;
     std::shared_ptr<const storage::trie::TrieStorage> storage_;
     std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker_;
-    std::shared_ptr<const primitives::CodeSubstituteHashes>
-        known_code_substitutes_;
+    std::shared_ptr<const CodeSubstituteBlockIds> known_code_substitutes_;
     std::shared_ptr<application::ChainSpec> chain_spec_;
     mutable common::Buffer cached_code_;
     mutable storage::trie::RootHash last_state_root_;

--- a/core/runtime/runtime_upgrade_tracker.hpp
+++ b/core/runtime/runtime_upgrade_tracker.hpp
@@ -7,8 +7,8 @@
 #define KAGOME_CORE_RUNTIME_RUNTIME_UPGRADE_TRACKER_HPP
 
 #include "outcome/outcome.hpp"
-#include "primitives/common.hpp"
 #include "storage/trie/types.hpp"
+#include "primitives/common.hpp"
 
 namespace kagome::runtime {
 
@@ -27,7 +27,7 @@ namespace kagome::runtime {
     virtual outcome::result<storage::trie::RootHash> getLastCodeUpdateState(
         const primitives::BlockInfo &block) = 0;
 
-    virtual outcome::result<primitives::BlockHash> getLastCodeUpdateHash(
+    virtual outcome::result<primitives::BlockInfo> getLastCodeUpdateBlockInfo(
         const storage::trie::RootHash &state) const = 0;
   };
 

--- a/test/core/runtime/runtime_test_base.hpp
+++ b/test/core/runtime/runtime_test_base.hpp
@@ -137,7 +137,7 @@ class RuntimeTestBase : public ::testing::Test {
         runtime::RuntimeUpgradeTrackerImpl::create(
             header_repo_,
             std::make_shared<storage::InMemoryStorage>(),
-            std::make_shared<primitives::CodeSubstituteHashes>())
+            std::make_shared<primitives::CodeSubstituteBlockIds>())
             .value();
 
     auto module_repo = std::make_shared<runtime::ModuleRepositoryImpl>(

--- a/test/core/runtime/runtime_upgrade_tracker_test.cpp
+++ b/test/core/runtime/runtime_upgrade_tracker_test.cpp
@@ -59,7 +59,7 @@ class RuntimeUpgradeTrackerTest : public testing::Test {
     block_tree_ = std::make_shared<kagome::blockchain::BlockTreeMock>();
     storage_ = std::make_shared<kagome::storage::InMemoryStorage>();
     known_code_substitutes_ =
-        std::make_shared<kagome::primitives::CodeSubstituteHashes>();
+        std::make_shared<kagome::primitives::CodeSubstituteBlockIds>();
     sub_engine_ =
         std::make_shared<kagome::primitives::events::ChainSubscriptionEngine>();
     tracker_ = kagome::runtime::RuntimeUpgradeTrackerImpl::create(
@@ -75,7 +75,7 @@ class RuntimeUpgradeTrackerTest : public testing::Test {
       sub_engine_;
   std::shared_ptr<kagome::storage::BufferStorage> storage_;
 
-  std::shared_ptr<kagome::primitives::CodeSubstituteHashes>
+  std::shared_ptr<kagome::primitives::CodeSubstituteBlockIds>
       known_code_substitutes_{};
   kagome::primitives::BlockInfo genesis_block{0, "block_genesis_hash"_hash256};
   kagome::primitives::BlockHeader genesis_block_header{
@@ -214,7 +214,7 @@ TEST_F(RuntimeUpgradeTrackerTest, CodeSubstituteAndStore) {
               getBlockHeader(kagome::primitives::BlockId{block2.hash}))
       .WillRepeatedly(testing::Return(block2_header));
   known_code_substitutes_.reset(
-      new kagome::primitives::CodeSubstituteHashes{{block2.hash}});
+      new kagome::primitives::CodeSubstituteBlockIds{{block2.number}});
 
   // reset tracker
   tracker_ = kagome::runtime::RuntimeUpgradeTrackerImpl::create(
@@ -249,8 +249,7 @@ TEST_F(RuntimeUpgradeTrackerTest, UpgradeAfterCodeSubstitute) {
 
   auto block1 = makeBlockInfo(5203203);
   auto block1_header = makeBlockHeader(5203203);
-  known_code_substitutes_.reset(
-      new kagome::primitives::CodeSubstituteHashes{{block1.hash}});
+  known_code_substitutes_.reset(new kagome::primitives::CodeSubstituteBlockIds({block1.number}));
 
   EXPECT_CALL(*header_repo_,
               getBlockHeader(kagome::primitives::BlockId{block1.hash}))

--- a/test/core/runtime/runtime_upgrade_tracker_test.cpp
+++ b/test/core/runtime/runtime_upgrade_tracker_test.cpp
@@ -249,7 +249,8 @@ TEST_F(RuntimeUpgradeTrackerTest, UpgradeAfterCodeSubstitute) {
 
   auto block1 = makeBlockInfo(5203203);
   auto block1_header = makeBlockHeader(5203203);
-  known_code_substitutes_.reset(new kagome::primitives::CodeSubstituteBlockIds({block1.number}));
+  known_code_substitutes_.reset(
+      new kagome::primitives::CodeSubstituteBlockIds({block1.number}));
 
   EXPECT_CALL(*header_repo_,
               getBlockHeader(kagome::primitives::BlockId{block1.hash}))

--- a/test/core/runtime/storage_code_provider_test.cpp
+++ b/test/core/runtime/storage_code_provider_test.cpp
@@ -47,6 +47,7 @@ TEST_F(StorageCodeProviderTest, GetCodeWhenNoStorageUpdates) {
   auto trie_db = std::make_shared<storage::trie::TrieStorageMock>();
   auto tracker = std::make_shared<runtime::RuntimeUpgradeTrackerMock>();
   storage::trie::RootHash first_state_root{{1, 1, 1, 1}};
+  primitives::BlockInfo block_info(11, primitives::BlockHash{{11, 11, 11, 11}});
 
   // given
   EXPECT_CALL(*trie_db, getEphemeralBatchAt(first_state_root))
@@ -56,12 +57,12 @@ TEST_F(StorageCodeProviderTest, GetCodeWhenNoStorageUpdates) {
             .WillOnce(Return(state_code_));
         return batch;
       }));
-  EXPECT_CALL(*tracker, getLastCodeUpdateHash(first_state_root))
-      .WillOnce(Return(first_state_root));
+  EXPECT_CALL(*tracker, getLastCodeUpdateBlockInfo(first_state_root))
+      .WillOnce(Return(block_info));
   auto wasm_provider = std::make_shared<runtime::StorageCodeProvider>(
       trie_db,
       tracker,
-      std::make_shared<primitives::CodeSubstituteHashes>(),
+      std::make_shared<primitives::CodeSubstituteBlockIds>(),
       std::make_shared<application::ChainSpecMock>());
 
   // when
@@ -99,7 +100,7 @@ TEST_F(StorageCodeProviderTest, DISABLED_GetCodeWhenStorageUpdates) {
   auto wasm_provider = std::make_shared<runtime::StorageCodeProvider>(
       trie_db,
       tracker,
-      std::make_shared<primitives::CodeSubstituteHashes>(),
+      std::make_shared<primitives::CodeSubstituteBlockIds>(),
       std::make_shared<application::ChainSpecMock>());
 
   common::Buffer new_state_code{{1, 3, 3, 8}};

--- a/test/mock/core/application/chain_spec_mock.hpp
+++ b/test/mock/core/application/chain_spec_mock.hpp
@@ -57,7 +57,7 @@ namespace kagome::application {
                 (),
                 (const, override));
 
-    MOCK_METHOD(std::shared_ptr<const primitives::CodeSubstituteHashes>,
+    MOCK_METHOD(std::shared_ptr<const primitives::CodeSubstituteBlockIds>,
                 codeSubstitutes,
                 (),
                 (const, override));
@@ -65,8 +65,8 @@ namespace kagome::application {
     MOCK_METHOD(GenesisRawData, getGenesis, (), (const, override));
 
     MOCK_METHOD(outcome::result<common::Buffer>,
-                fetchCodeSubstituteByHash,
-                (const common::Hash256 &hash),
+                fetchCodeSubstituteByBlockInfo,
+                (const primitives::BlockInfo &block_info),
                 (const, override));
   };
 

--- a/test/mock/core/runtime/runtime_upgrade_tracker_mock.hpp
+++ b/test/mock/core/runtime/runtime_upgrade_tracker_mock.hpp
@@ -19,8 +19,8 @@ namespace kagome::runtime {
                 (const primitives::BlockInfo &block),
                 (override));
 
-    MOCK_METHOD(outcome::result<primitives::BlockHash>,
-                getLastCodeUpdateHash,
+    MOCK_METHOD(outcome::result<primitives::BlockInfo>,
+                getLastCodeUpdateBlockInfo,
                 (const storage::trie::RootHash &state),
                 (const, override));
   };


### PR DESCRIPTION
### Referenced issues

Issue #1099

### Description of the Change

Recently there was a change in chainspec format. 
Previously, in codeSubstitutes dictionary blocks hashes were used as keys. Now, it's block s numbers instead.
I tried to keep backwards compatibility by using internally BlockId type and parsing/comparing ad hoc.
 Instead of just aliasing unordered_set, it required actually subclassing CodeSubstituteBlockIds and implementing contains() method that may check for BlockIds and BlockInfos alike.

### Benefits

Now we support both new and old chainspec formats.
