### PR TITLE
Limit incoming and outcoming connections to other peers

### DIFF
--- a/core/application/app_configuration.hpp
+++ b/core/application/app_configuration.hpp
@@ -92,7 +92,7 @@ namespace kagome::application {
     /**
      * @return maximum number of inbound light nodes peers
      */
-    virtual uint16_t inPeersLite() const = 0;
+    virtual uint16_t inPeersLght() const = 0;
 
     /**
      * @return multiaddresses of bootstrat nodes

--- a/core/application/app_configuration.hpp
+++ b/core/application/app_configuration.hpp
@@ -80,6 +80,21 @@ namespace kagome::application {
     virtual uint16_t p2pPort() const = 0;
 
     /**
+     * @return number of outgoing connections we're trying to maintain
+     */
+    virtual uint16_t outPeers() const = 0;
+
+    /**
+     * @return maximum number of inbound full nodes peers
+     */
+    virtual uint16_t inPeers() const = 0;
+
+    /**
+     * @return maximum number of inbound light nodes peers
+     */
+    virtual uint16_t inPeersLite() const = 0;
+
+    /**
      * @return multiaddresses of bootstrat nodes
      */
     virtual const std::vector<libp2p::multi::Multiaddress> &bootNodes()

--- a/core/application/app_configuration.hpp
+++ b/core/application/app_configuration.hpp
@@ -82,17 +82,17 @@ namespace kagome::application {
     /**
      * @return number of outgoing connections we're trying to maintain
      */
-    virtual uint16_t outPeers() const = 0;
+    virtual uint32_t outPeers() const = 0;
 
     /**
      * @return maximum number of inbound full nodes peers
      */
-    virtual uint16_t inPeers() const = 0;
+    virtual uint32_t inPeers() const = 0;
 
     /**
      * @return maximum number of inbound light nodes peers
      */
-    virtual uint16_t inPeersLght() const = 0;
+    virtual uint32_t inPeersLght() const = 0;
 
     /**
      * @return multiaddresses of bootstrat nodes

--- a/core/application/impl/app_configuration_impl.cpp
+++ b/core/application/impl/app_configuration_impl.cpp
@@ -276,9 +276,9 @@ namespace kagome::application {
     load_str(val, "prometheus-host", openmetrics_http_host_);
     load_u16(val, "prometheus-port", openmetrics_http_port_);
     load_str(val, "name", node_name_);
-    load_u16(val, "out-peers", out_peers_);
-    load_u16(val, "in-peers", in_peers_);
-    load_u16(val, "in-peers-light", in_peers_light_);
+    load_u32(val, "out-peers", out_peers_);
+    load_u32(val, "in-peers", in_peers_);
+    load_u32(val, "in-peers-light", in_peers_light_);
   }
 
   void AppConfigurationImpl::parse_additional_segment(rapidjson::Value &val) {
@@ -818,17 +818,14 @@ namespace kagome::application {
       openmetrics_http_port_ = val;
     });
 
-    find_argument<uint16_t>(vm, "out-peers", [&](uint16_t val) {
-      out_peers_ = val;
-    });
+    find_argument<uint32_t>(
+        vm, "out-peers", [&](uint32_t val) { out_peers_ = val; });
 
-    find_argument<uint16_t>(vm, "in-peers", [&](uint16_t val) {
-      in_peers_ = val;
-    });
+    find_argument<uint32_t>(
+        vm, "in-peers", [&](uint32_t val) { in_peers_ = val; });
 
-    find_argument<uint16_t>(vm, "in-peers-light", [&](uint16_t val) {
-      in_peers_light_ = val;
-    });
+    find_argument<uint32_t>(
+        vm, "in-peers-light", [&](uint32_t val) { in_peers_light_ = val; });
 
     find_argument<uint32_t>(vm, "ws-max-connections", [&](uint32_t val) {
       max_ws_connections_ = val;

--- a/core/application/impl/app_configuration_impl.cpp
+++ b/core/application/impl/app_configuration_impl.cpp
@@ -276,6 +276,9 @@ namespace kagome::application {
     load_str(val, "prometheus-host", openmetrics_http_host_);
     load_u16(val, "prometheus-port", openmetrics_http_port_);
     load_str(val, "name", node_name_);
+    load_u16(val, "out-peers", out_peers_);
+    load_u16(val, "in-peers", in_peers_);
+    load_u16(val, "in-peers-light", in_peers_light_);
   }
 
   void AppConfigurationImpl::parse_additional_segment(rapidjson::Value &val) {
@@ -510,6 +513,9 @@ namespace kagome::application {
         ("ws-max-connections", po::value<uint32_t>(), "maximum number of WS RPC server connections")
         ("prometheus-host", po::value<std::string>(), "address for OpenMetrics over HTTP")
         ("prometheus-port", po::value<uint16_t>(), "port for OpenMetrics over HTTP")
+        ("out-peers", po::value<uint16_t>()->default_value(25), "number of outgoing connections we're trying to maintain")
+        ("in-peers", po::value<uint16_t>()->default_value(25), "maximum number of inbound full nodes peers")
+        ("in-peers-light", po::value<uint16_t>()->default_value(100), "maximum number of inbound light nodes peers")
         ("max-blocks-in-response", po::value<int>(), "max block per response while syncing")
         ("name", po::value<std::string>(), "the human-readable name for this node")
         ;
@@ -810,6 +816,18 @@ namespace kagome::application {
 
     find_argument<uint16_t>(vm, "prometheus-port", [&](uint16_t val) {
       openmetrics_http_port_ = val;
+    });
+
+    find_argument<uint16_t>(vm, "out-peers", [&](uint16_t val) {
+      out_peers_ = val;
+    });
+
+    find_argument<uint16_t>(vm, "in-peers", [&](uint16_t val) {
+      in_peers_ = val;
+    });
+
+    find_argument<uint16_t>(vm, "in-peers-light", [&](uint16_t val) {
+      in_peers_light_ = val;
     });
 
     find_argument<uint32_t>(vm, "ws-max-connections", [&](uint32_t val) {

--- a/core/application/impl/app_configuration_impl.cpp
+++ b/core/application/impl/app_configuration_impl.cpp
@@ -513,9 +513,9 @@ namespace kagome::application {
         ("ws-max-connections", po::value<uint32_t>(), "maximum number of WS RPC server connections")
         ("prometheus-host", po::value<std::string>(), "address for OpenMetrics over HTTP")
         ("prometheus-port", po::value<uint16_t>(), "port for OpenMetrics over HTTP")
-        ("out-peers", po::value<uint16_t>()->default_value(25), "number of outgoing connections we're trying to maintain")
-        ("in-peers", po::value<uint16_t>()->default_value(25), "maximum number of inbound full nodes peers")
-        ("in-peers-light", po::value<uint16_t>()->default_value(100), "maximum number of inbound light nodes peers")
+        ("out-peers", po::value<uint32_t>()->default_value(25), "number of outgoing connections we're trying to maintain")
+        ("in-peers", po::value<uint32_t>()->default_value(25), "maximum number of inbound full nodes peers")
+        ("in-peers-light", po::value<uint32_t>()->default_value(100), "maximum number of inbound light nodes peers")
         ("max-blocks-in-response", po::value<int>(), "max block per response while syncing")
         ("name", po::value<std::string>(), "the human-readable name for this node")
         ;

--- a/core/application/impl/app_configuration_impl.hpp
+++ b/core/application/impl/app_configuration_impl.hpp
@@ -98,13 +98,13 @@ namespace kagome::application {
     uint16_t p2pPort() const override {
       return p2p_port_;
     }
-    uint16_t outPeers() const override {
+    uint32_t outPeers() const override {
       return out_peers_;
     }
-    uint16_t inPeers() const override {
+    uint32_t inPeers() const override {
       return in_peers_;
     }
-    uint16_t inPeersLght() const override {
+    uint32_t inPeersLght() const override {
       return in_peers_light_;
     }
     const boost::asio::ip::tcp::endpoint &rpcHttpEndpoint() const override {
@@ -248,9 +248,9 @@ namespace kagome::application {
     uint16_t rpc_http_port_;
     uint16_t rpc_ws_port_;
     uint16_t openmetrics_http_port_;
-    uint16_t out_peers_;
-    uint16_t in_peers_;
-    uint16_t in_peers_light_;
+    uint32_t out_peers_;
+    uint32_t in_peers_;
+    uint32_t in_peers_light_;
     network::PeeringConfig peering_config_;
     bool dev_mode_;
     std::string node_name_;

--- a/core/application/impl/app_configuration_impl.hpp
+++ b/core/application/impl/app_configuration_impl.hpp
@@ -98,6 +98,15 @@ namespace kagome::application {
     uint16_t p2pPort() const override {
       return p2p_port_;
     }
+    uint16_t outPeers() const override {
+      return out_peers_;
+    }
+    uint16_t inPeers() const override {
+      return in_peers_;
+    }
+    uint16_t inPeersLite() const override {
+      return in_peers_light_;
+    }
     const boost::asio::ip::tcp::endpoint &rpcHttpEndpoint() const override {
       return rpc_http_endpoint_;
     }
@@ -239,6 +248,9 @@ namespace kagome::application {
     uint16_t rpc_http_port_;
     uint16_t rpc_ws_port_;
     uint16_t openmetrics_http_port_;
+    uint16_t out_peers_;
+    uint16_t in_peers_;
+    uint16_t in_peers_light_;
     network::PeeringConfig peering_config_;
     bool dev_mode_;
     std::string node_name_;

--- a/core/application/impl/app_configuration_impl.hpp
+++ b/core/application/impl/app_configuration_impl.hpp
@@ -104,7 +104,7 @@ namespace kagome::application {
     uint16_t inPeers() const override {
       return in_peers_;
     }
-    uint16_t inPeersLite() const override {
+    uint16_t inPeersLght() const override {
       return in_peers_light_;
     }
     const boost::asio::ip::tcp::endpoint &rpcHttpEndpoint() const override {

--- a/core/network/impl/peer_manager_impl.cpp
+++ b/core/network/impl/peer_manager_impl.cpp
@@ -345,9 +345,6 @@ namespace kagome::network {
   void PeerManagerImpl::disconnectFromPeer(const PeerId &peer_id) {
     auto it = active_peers_.find(peer_id);
     if (it != active_peers_.end()) {
-      auto connection =
-          host_.getNetwork().getConnectionManager().getBestConnectionForPeer(
-              peer_id);
       SL_DEBUG(log_, "Disconnect from peer_id={}", peer_id.toBase58());
       stream_engine_->del(peer_id);
       active_peers_.erase(it);

--- a/core/network/impl/peer_manager_impl.cpp
+++ b/core/network/impl/peer_manager_impl.cpp
@@ -503,7 +503,8 @@ namespace kagome::network {
                              [](const auto &el) {
                                return el.second.peer_type
                                       == PeerType::PEER_TYPE_IN;
-                             }) > app_config_.inPeers()) {
+                             })
+               > app_config_.inPeers()) {
       connecting_peers_.erase(peer_id);
       disconnectFromPeer(peer_id);
       return;

--- a/core/network/impl/peer_manager_impl.hpp
+++ b/core/network/impl/peer_manager_impl.hpp
@@ -41,6 +41,16 @@
 
 namespace kagome::network {
 
+  enum class PeerType {
+    PEER_TYPE_IN = 0,
+    PEER_TYPE_OUT
+  };
+
+  struct PeerDescriptor {
+    PeerType peer_type;
+    clock::SteadyClock::TimePoint time_point;
+  };
+
   class PeerManagerImpl : public PeerManager,
                           public std::enable_shared_from_this<PeerManagerImpl> {
    public:
@@ -151,7 +161,7 @@ namespace kagome::network {
     std::unordered_set<libp2p::network::ConnectionManager::ConnectionSPtr>
         pinging_connections_;
 
-    std::map<PeerId, clock::SteadyClock::TimePoint> active_peers_;
+    std::map<PeerId, PeerDescriptor> active_peers_;
     std::unordered_map<PeerId, PeerState> peer_states_;
     libp2p::basic::Scheduler::Handle align_timer_;
     std::set<PeerId> recently_active_peers_;

--- a/test/mock/core/application/app_configuration_mock.hpp
+++ b/test/mock/core/application/app_configuration_mock.hpp
@@ -113,7 +113,7 @@ namespace kagome::application {
 
     MOCK_METHOD(uint16_t, inPeers, (), (const, override));
 
-    MOCK_METHOD(uint16_t, inPeersLite, (), (const, override));
+    MOCK_METHOD(uint16_t, inPeersLght, (), (const, override));
   };
 
 }  // namespace kagome::application

--- a/test/mock/core/application/app_configuration_mock.hpp
+++ b/test/mock/core/application/app_configuration_mock.hpp
@@ -109,11 +109,11 @@ namespace kagome::application {
                 (),
                 (const, override));
 
-    MOCK_METHOD(uint16_t, outPeers, (), (const, override));
+    MOCK_METHOD(uint32_t, outPeers, (), (const, override));
 
-    MOCK_METHOD(uint16_t, inPeers, (), (const, override));
+    MOCK_METHOD(uint32_t, inPeers, (), (const, override));
 
-    MOCK_METHOD(uint16_t, inPeersLght, (), (const, override));
+    MOCK_METHOD(uint32_t, inPeersLght, (), (const, override));
   };
 
 }  // namespace kagome::application

--- a/test/mock/core/application/app_configuration_mock.hpp
+++ b/test/mock/core/application/app_configuration_mock.hpp
@@ -108,6 +108,12 @@ namespace kagome::application {
                 recoverState,
                 (),
                 (const, override));
+
+    MOCK_METHOD(uint16_t, outPeers, (), (const, override));
+
+    MOCK_METHOD(uint16_t, inPeers, (), (const, override));
+
+    MOCK_METHOD(uint16_t, inPeersLite, (), (const, override));
   };
 
 }  // namespace kagome::application


### PR DESCRIPTION

### Referenced issues

#1137 - Limit incoming and outcoming connections to other peers

### Description of the Change

Added 3 new CLI parameters:
* --out-peers (defaults to 25)
* --in-peers (defaults to 25)
* --in-peers-light (defaults to 100)

which hard-limits amount of peer connections accordingly.

### Benefits

We can limit peers amount, reduce excessive network strain in some cases.

### Possible Drawbacks 

Maybe some priority reduction might be useful as well.

