### PR TITLE
Fix crash in peer manager

### DIFF
--- a/core/network/impl/peer_manager_impl.cpp
+++ b/core/network/impl/peer_manager_impl.cpp
@@ -484,6 +484,10 @@ namespace kagome::network {
     auto connection =
         host_.getNetwork().getConnectionManager().getBestConnectionForPeer(
             peer_id);
+    if (connection == nullptr) {
+      connecting_peers_.erase(peer_id);
+      return;
+    }
     if (connection->isInitiator()) {
       auto out_peers_count = std::count_if(
           active_peers_.begin(), active_peers_.end(), [](const auto &el) {


### PR DESCRIPTION


### Referenced issues

#1137 - Limit incoming and outcoming connections to other peers

### Description of the Change

Connection may be expired in processFullyConnectedPeer - so we must check that.

### Benefits

Fixes a crash.

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs <!-- Optional -->

<!-- Explain what other alternates were considered and why the proposed version was selected -->
