### PR TITLE
Fix submit transaction

### DIFF
--- a/core/api/service/author/author_api.hpp
+++ b/core/api/service/author/author_api.hpp
@@ -10,6 +10,7 @@
 #include "common/buffer.hpp"
 #include "crypto/crypto_store/key_type.hpp"
 #include "primitives/author_api_primitives.hpp"
+#include "primitives/transaction_validity.hpp"
 
 namespace kagome::api {
   class ApiService;
@@ -28,6 +29,7 @@ namespace kagome::api {
     using Metadata = primitives::Metadata;
     using SubscriptionId = primitives::SubscriptionId;
     using ExtrinsicKey = primitives::ExtrinsicKey;
+    using TransactionSource = primitives::TransactionSource;
 
    public:
     virtual ~AuthorApi() = default;
@@ -37,12 +39,14 @@ namespace kagome::api {
 
     /**
      * @brief validates and sends extrinsic to transaction pool
-     * @param bytes encoded extrinsic
+     * @param source how extrinsic was received (for example external or
+     * submitted through offchain worker)
+     * @param extrinsic set of bytes representing either transaction or inherent
      * @return hash of successfully validated extrinsic
      * or error if state is invalid or unknown
      */
     virtual outcome::result<common::Hash256> submitExtrinsic(
-        const Extrinsic &extrinsic) = 0;
+        TransactionSource source, const Extrinsic &extrinsic) = 0;
 
     /**
      * @brief insert an anonimous key pair into the keystore

--- a/core/api/service/author/impl/author_api_impl.hpp
+++ b/core/api/service/author/impl/author_api_impl.hpp
@@ -81,6 +81,7 @@ namespace kagome::api {
     void setApiService(sptr<api::ApiService> const &api_service) override;
 
     outcome::result<common::Hash256> submitExtrinsic(
+        TransactionSource source,
         const primitives::Extrinsic &extrinsic) override;
 
     outcome::result<void> insertKey(
@@ -108,7 +109,7 @@ namespace kagome::api {
 
    private:
     outcome::result<primitives::Transaction> constructTransaction(
-        primitives::Extrinsic ext) const;
+        TransactionSource source, primitives::Extrinsic ext) const;
 
     sptr<runtime::TaggedTransactionQueue> api_;
     sptr<transaction_pool::TransactionPool> pool_;

--- a/core/api/service/author/requests/submit_extrinsic.hpp
+++ b/core/api/service/author/requests/submit_extrinsic.hpp
@@ -25,7 +25,8 @@ namespace kagome::api::author::request {
       auto ext_hex = getParam<0>();
       OUTCOME_TRY(buffer, common::unhexWith0x(ext_hex));
       OUTCOME_TRY(extrinsic, scale::decode<primitives::Extrinsic>(buffer));
-      return api_->submitExtrinsic(extrinsic);
+      return api_->submitExtrinsic(primitives::TransactionSource::External,
+                                   extrinsic);
     }
 
    private:

--- a/core/network/impl/extrinsic_observer_impl.cpp
+++ b/core/network/impl/extrinsic_observer_impl.cpp
@@ -17,7 +17,8 @@ namespace kagome::network {
 
   outcome::result<common::Hash256> ExtrinsicObserverImpl::onTxMessage(
       const primitives::Extrinsic &extrinsic) {
-    return api_->submitExtrinsic(extrinsic);
+    return api_->submitExtrinsic(primitives::TransactionSource::External,
+                                 extrinsic);
   }
 
 }  // namespace kagome::network

--- a/core/offchain/impl/offchain_worker_impl.cpp
+++ b/core/offchain/impl/offchain_worker_impl.cpp
@@ -107,7 +107,8 @@ namespace kagome::offchain {
 
   Result<Success, Failure> OffchainWorkerImpl::submitTransaction(
       const primitives::Extrinsic &ext) {
-    auto result = author_api_->submitExtrinsic(ext);
+    auto result =
+        author_api_->submitExtrinsic(primitives::TransactionSource::Local, ext);
     if (result.has_value()) {
       return Success();
     }

--- a/core/runtime/executor.hpp
+++ b/core/runtime/executor.hpp
@@ -185,6 +185,7 @@ namespace kagome::runtime {
       PtrSize args_span{memory.storeBuffer(encoded_args)};
 
       KAGOME_PROFILE_START(call_execution)
+      SL_TRACE(logger_, "Executing {}", name);
       OUTCOME_TRY(result,
                   env.module_instance->callExportFunction(name, args_span));
       KAGOME_PROFILE_END(call_execution)

--- a/test/core/api/service/author/author_api_test.cpp
+++ b/test/core/api/service/author/author_api_test.cpp
@@ -188,7 +188,9 @@ TEST_F(AuthorApiTest, SubmitExtrinsicSuccess) {
   EXPECT_CALL(*transaction_pool, submitOne(tr))
       .WillOnce(Return(outcome::success()));
   EXPECT_CALL(*transactions_transmitter, propagateTransactions(_)).Times(1);
-  EXPECT_OUTCOME_SUCCESS(hash, author_api->submitExtrinsic(*extrinsic));
+  EXPECT_OUTCOME_SUCCESS(
+      hash,
+      author_api->submitExtrinsic(TransactionSource::External, *extrinsic));
   ASSERT_EQ(hash.value(), Hash256{});
 }
 
@@ -208,7 +210,9 @@ TEST_F(AuthorApiTest, SubmitExtrinsicFail) {
   EXPECT_CALL(*transaction_pool, submitOne(_)).Times(0);
   EXPECT_CALL(*transactions_transmitter, propagateTransactions(_)).Times(0);
   EXPECT_OUTCOME_ERROR(
-      res, author_api->submitExtrinsic(*extrinsic), DummyError::ERROR);
+      res,
+      author_api->submitExtrinsic(TransactionSource::External, *extrinsic),
+      DummyError::ERROR);
 }
 
 MATCHER_P(eventsAreEqual, n, "") {
@@ -535,7 +539,7 @@ TEST_F(AuthorApiTest, PendingExtrinsics) {
  * @then request is forwarded to api service, result returned
  */
 TEST_F(AuthorApiTest, UnwatchExtrinsic) {
-  kagome::primitives::SubscriptionId sub_id;
+  kagome::primitives::SubscriptionId sub_id = 0;
 
   EXPECT_CALL(*api_service_mock, unsubscribeFromExtrinsicLifecycle(sub_id))
       .WillOnce(Return(true));

--- a/test/core/blockchain/block_tree_test.cpp
+++ b/test/core/blockchain/block_tree_test.cpp
@@ -430,7 +430,7 @@ TEST_F(BlockTreeTest, FinalizeWithPruning) {
       .WillRepeatedly(Return(primitives::Version{}));
   EXPECT_CALL(*storage_, getBlockBody(primitives::BlockId{B_hash}))
       .WillRepeatedly(Return(outcome::success(B1_body)));
-  EXPECT_CALL(*author_api_, submitExtrinsic(_))
+  EXPECT_CALL(*author_api_, submitExtrinsic(_, _))
       .WillRepeatedly(
           Return(outcome::success(hasher_->blake2b_256(Buffer{0xaa, 0xbb}))));
 
@@ -498,7 +498,7 @@ TEST_F(BlockTreeTest, FinalizeWithPruningDeepestLeaf) {
       .WillRepeatedly(Return(outcome::success(B1_body)));
   EXPECT_CALL(*storage_, getBlockBody(primitives::BlockId{C1_hash}))
       .WillRepeatedly(Return(outcome::success(C1_body)));
-  EXPECT_CALL(*author_api_, submitExtrinsic(_))
+  EXPECT_CALL(*author_api_, submitExtrinsic(_, _))
       .WillRepeatedly(
           Return(outcome::success(hasher_->blake2b_256(Buffer{0xaa, 0xbb}))));
 

--- a/test/mock/core/api/service/author/author_api_mock.hpp
+++ b/test/mock/core/api/service/author/author_api_mock.hpp
@@ -23,7 +23,7 @@ namespace kagome::api {
 
     MOCK_METHOD(outcome::result<common::Hash256>,
                 submitExtrinsic,
-                (const Extrinsic &),
+                (TransactionSource, const Extrinsic &),
                 (override));
 
     MOCK_METHOD(outcome::result<void>,


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

None

### Description of the Change

Before the fix we were submitting all extrinsics with the source `External` which corresponds only to extrinsics from RPC calls. However, extrinsics submitted through offchain workers have to have source `Local`. 

Becaus of that we had error during validation of extrinsics from offchain workers

### Benefits

Proper handling of offchain worker extrinsics

### Possible Drawbacks 

None
