### PR TITLE
Init first block slot number during syncing and block production

### DIFF
--- a/core/blockchain/impl/block_tree_impl.cpp
+++ b/core/blockchain/impl/block_tree_impl.cpp
@@ -139,6 +139,8 @@ namespace kagome::blockchain {
     auto least_leaf = *block_tree_leaves.begin();
     auto best_leaf = *block_tree_leaves.rbegin();
 
+    OUTCOME_TRY(last_finalized_block_info, storage->getLastFinalized());
+
     std::optional<consensus::EpochNumber> curr_epoch_number;
 
     // First, look up slot number of block number 1
@@ -172,17 +174,14 @@ namespace kagome::blockchain {
       // Now we have all to calculate epoch number
       auto epoch_number = (last_slot_number - first_slot_number)
                           / babe_configuration->epoch_length;
-      consensus::EpochDescriptor epoch{
-          .epoch_number = epoch_number,
-          .start_slot = first_slot_number
-                        + epoch_number * babe_configuration->epoch_length};
 
-      babe_util->syncEpoch(epoch);
+      babe_util->syncEpoch([&] {
+        auto is_first_block_finalized = last_finalized_block_info.number > 0;
+        return std::tuple(first_slot_number, is_first_block_finalized);
+      });
 
       curr_epoch_number.emplace(epoch_number);
     }
-
-    OUTCOME_TRY(last_finalized_block_info, storage->getLastFinalized());
 
     std::optional<consensus::EpochDigest> curr_epoch;
     std::optional<consensus::EpochDigest> next_epoch;

--- a/core/consensus/babe/babe_util.hpp
+++ b/core/consensus/babe/babe_util.hpp
@@ -21,9 +21,11 @@ namespace kagome::consensus {
     virtual ~BabeUtil() = default;
 
     /**
-     * Init inner state by {@param epoch_descriptor}
+     * Init inner state by call {@param f} returning first block slot and flag
+     * if first block is already finalized
      */
-    virtual void syncEpoch(EpochDescriptor epoch_descriptor) = 0;
+    virtual BabeSlotNumber syncEpoch(
+        std::function<std::tuple<BabeSlotNumber, bool>()> &&f) = 0;
 
     /**
      * @returns current unix time slot number

--- a/core/consensus/babe/impl/babe_impl.cpp
+++ b/core/consensus/babe/impl/babe_impl.cpp
@@ -253,8 +253,6 @@ namespace kagome::consensus::babe {
     current_epoch_ = epoch;
     current_slot_ = current_epoch_.start_slot;
 
-    babe_util_->syncEpoch(current_epoch_);
-
     runSlot();
   }
 

--- a/core/consensus/babe/impl/babe_impl.cpp
+++ b/core/consensus/babe/impl/babe_impl.cpp
@@ -193,20 +193,31 @@ namespace kagome::consensus::babe {
   }
 
   void BabeImpl::adjustEpochDescriptor() {
-    if (current_epoch_.epoch_number > 1) {
-      return;
-    }
+    auto first_slot_number = babe_util_->syncEpoch([&]() {
+      auto res = block_tree_->getBlockHeader(primitives::BlockNumber(1));
+      if (res.has_error()) {
+        SL_TRACE(log_,
+                 "First block slot is {}: no first block (at adjusting)",
+                 babe_util_->getCurrentSlot());
+        return std::tuple(babe_util_->getCurrentSlot(), false);
+      }
 
-    auto res = block_tree_->getBlockHeader(primitives::BlockNumber(1));
-    if (res.has_error()) {
-      return;
-    }
+      auto &first_block_header = res.value();
+      auto babe_digest_res = consensus::getBabeDigests(first_block_header);
+      BOOST_ASSERT_MSG(babe_digest_res.has_value(),
+                       "Any non genesis block must contain babe digest");
+      auto first_slot_number = babe_digest_res.value().second.slot_number;
 
-    auto &first_block_header = res.value();
-    auto babe_digest_res = consensus::getBabeDigests(first_block_header);
-    BOOST_ASSERT_MSG(babe_digest_res.has_value(),
-                     "Any non genesis block must contain babe digest");
-    auto first_slot_number = babe_digest_res.value().second.slot_number;
+      auto is_first_block_finalized =
+          block_tree_->getLastFinalized().number > 0;
+
+      SL_TRACE(
+          log_,
+          "First block slot is {}: by {}finalized first block (at adjusting)",
+          first_slot_number,
+          is_first_block_finalized ? "" : "non-");
+      return std::tuple(first_slot_number, is_first_block_finalized);
+    });
 
     auto current_epoch_start_slot =
         first_slot_number
@@ -216,12 +227,10 @@ namespace kagome::consensus::babe {
       SL_WARN(log_,
               "Start-slot of current epoch {} has updated from {} to {}",
               current_epoch_.epoch_number,
-              current_epoch_start_slot,
-              current_epoch_.start_slot);
+              current_epoch_.start_slot,
+              current_epoch_start_slot);
 
-      current_epoch_.start_slot =current_epoch_start_slot;
-
-      babe_util_->syncEpoch(current_epoch_);
+      current_epoch_.start_slot = current_epoch_start_slot;
     }
   }
 
@@ -232,6 +241,8 @@ namespace kagome::consensus::babe {
     }
 
     BOOST_ASSERT(keypair_ != nullptr);
+
+    adjustEpochDescriptor();
 
     SL_DEBUG(
         log_,
@@ -842,7 +853,31 @@ namespace kagome::consensus::babe {
     ++current_epoch_.epoch_number;
     current_epoch_.start_slot = current_slot_;
 
-    babe_util_->syncEpoch(current_epoch_);
+    babe_util_->syncEpoch([&]() {
+      auto res = block_tree_->getBlockHeader(primitives::BlockNumber(1));
+      if (res.has_error()) {
+        SL_WARN(log_,
+                "First block slot is {}: no first block (at start next epoch)",
+                babe_util_->getCurrentSlot());
+        return std::tuple(babe_util_->getCurrentSlot(), false);
+      }
+
+      auto &first_block_header = res.value();
+      auto babe_digest_res = consensus::getBabeDigests(first_block_header);
+      BOOST_ASSERT_MSG(babe_digest_res.has_value(),
+                       "Any non genesis block must contain babe digest");
+      auto first_slot_number = babe_digest_res.value().second.slot_number;
+
+      auto is_first_block_finalized =
+          block_tree_->getLastFinalized().number > 0;
+
+      SL_WARN(log_,
+              "First block slot is {}: by {}finalized first block (at start "
+              "next epoch)",
+              first_slot_number,
+              is_first_block_finalized ? "" : "non-");
+      return std::tuple(first_slot_number, is_first_block_finalized);
+    });
   }
 
   bool BabeImpl::isSecondarySlotsAllowed() const {

--- a/core/consensus/babe/impl/babe_util_impl.cpp
+++ b/core/consensus/babe/impl/babe_util_impl.cpp
@@ -16,10 +16,14 @@ namespace kagome::consensus {
                      "Epoch length must be non zero");
   }
 
-  void BabeUtilImpl::syncEpoch(EpochDescriptor epoch_descriptor) {
-    first_block_slot_number_.emplace(
-        epoch_descriptor.start_slot
-        - epoch_descriptor.epoch_number * babe_configuration_->epoch_length);
+  BabeSlotNumber BabeUtilImpl::syncEpoch(
+      std::function<std::tuple<BabeSlotNumber, bool>()> &&f) {
+    if (not is_first_block_finalized_) {
+      auto [first_block_slot_number, is_first_block_finalized] = f();
+      first_block_slot_number_.emplace(first_block_slot_number);
+      is_first_block_finalized_ = is_first_block_finalized;
+    }
+    return first_block_slot_number_.value();
   }
 
   BabeSlotNumber BabeUtilImpl::getCurrentSlot() const {

--- a/core/consensus/babe/impl/babe_util_impl.hpp
+++ b/core/consensus/babe/impl/babe_util_impl.hpp
@@ -20,7 +20,8 @@ namespace kagome::consensus {
         std::shared_ptr<primitives::BabeConfiguration> babe_configuration,
         const BabeClock &clock);
 
-    void syncEpoch(EpochDescriptor epoch_descriptor) override;
+    BabeSlotNumber syncEpoch(
+        std::function<std::tuple<BabeSlotNumber, bool>()> &&f) override;
 
     BabeSlotNumber getCurrentSlot() const override;
 
@@ -42,6 +43,7 @@ namespace kagome::consensus {
     const BabeClock &clock_;
 
     std::optional<BabeSlotNumber> first_block_slot_number_;
+    bool is_first_block_finalized_ = false;
   };
 }  // namespace kagome::consensus
 #endif  // KAGOME_CONSENSUS_BABEUTILIMPL

--- a/core/consensus/babe/impl/block_executor_impl.cpp
+++ b/core/consensus/babe/impl/block_executor_impl.cpp
@@ -132,6 +132,40 @@ namespace kagome::consensus {
     const auto &babe_header = babe_digests.second;
 
     auto slot_number = babe_header.slot_number;
+
+    babe_util_->syncEpoch([&] {
+      auto res = block_tree_->getBlockHeader(primitives::BlockNumber(1));
+      if (res.has_error()) {
+        if (block.header.number == 1) {
+          SL_TRACE(logger_,
+                   "First block slot is {}: it is first block (at executing)",
+                   slot_number);
+          return std::tuple(slot_number, false);
+        } else {
+          SL_TRACE(logger_,
+                   "First block slot is {}: no first block (at executing)",
+                   babe_util_->getCurrentSlot());
+          return std::tuple(babe_util_->getCurrentSlot(), false);
+        }
+      }
+
+      auto &first_block_header = res.value();
+      auto babe_digest_res = consensus::getBabeDigests(first_block_header);
+      BOOST_ASSERT_MSG(babe_digest_res.has_value(),
+                       "Any non genesis block must contain babe digest");
+      auto first_slot_number = babe_digest_res.value().second.slot_number;
+
+      auto is_first_block_finalized =
+          block_tree_->getLastFinalized().number > 0;
+
+      SL_TRACE(
+          logger_,
+          "First block slot is {}: by {}finalized first block (at executing)",
+          first_slot_number,
+          is_first_block_finalized ? "" : "non-");
+      return std::tuple(first_slot_number, is_first_block_finalized);
+    });
+
     auto epoch_number = babe_util_->slotToEpoch(slot_number);
 
     logger_->info(

--- a/test/core/blockchain/block_tree_test.cpp
+++ b/test/core/blockchain/block_tree_test.cpp
@@ -124,7 +124,7 @@ struct BlockTreeTest : public testing::Test {
     babe_config_->epoch_length = 2;
 
     babe_util_ = std::make_shared<BabeUtilMock>();
-    EXPECT_CALL(*babe_util_, syncEpoch(_)).WillRepeatedly(Return());
+    EXPECT_CALL(*babe_util_, syncEpoch(_)).WillRepeatedly(Return(1));
     EXPECT_CALL(*babe_util_, slotToEpoch(_)).WillRepeatedly(Return(0));
 
     block_tree_ = BlockTreeImpl::create(header_repo_,

--- a/test/mock/core/consensus/babe/babe_util_mock.hpp
+++ b/test/mock/core/consensus/babe/babe_util_mock.hpp
@@ -16,11 +16,10 @@ namespace kagome::consensus {
    public:
     using SyncFunctor = std::function<std::tuple<BabeSlotNumber, bool>()>;
 
-    MOCK_METHOD(BabeSlotNumber, syncEpoch, (SyncFunctor), ());
+    MOCK_METHOD(BabeSlotNumber, syncEpoch, (SyncFunctor &), ());
 
-    BabeSlotNumber syncEpoch(SyncFunctor &f_arg) override {
-      SyncFunctor f = f_arg;
-      return syncEpoch(f);
+    BabeSlotNumber syncEpoch(SyncFunctor &&func) override {
+      return syncEpoch(func);
     }
 
     MOCK_METHOD(BabeSlotNumber, getCurrentSlot, (), (const, override));

--- a/test/mock/core/consensus/babe/babe_util_mock.hpp
+++ b/test/mock/core/consensus/babe/babe_util_mock.hpp
@@ -14,7 +14,14 @@ namespace kagome::consensus {
 
   class BabeUtilMock : public BabeUtil {
    public:
-    MOCK_METHOD(void, syncEpoch, (EpochDescriptor), (override));
+    using SyncFunctor = std::function<std::tuple<BabeSlotNumber, bool>()>;
+
+    MOCK_METHOD(BabeSlotNumber, syncEpoch, (SyncFunctor), ());
+
+    BabeSlotNumber syncEpoch(SyncFunctor &f_arg) override {
+      SyncFunctor f = f_arg;
+      return syncEpoch(f);
+    }
 
     MOCK_METHOD(BabeSlotNumber, getCurrentSlot, (), (const, override));
 


### PR DESCRIPTION
Signed-off-by: Dmitriy Khaustov aka xDimon <khaustov.dm@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues
Resolves #1159 

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
Added mechanism to init first block slot number.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Works right
