### PR TITLE
Ban peers temporarily on duplicated sync requests

### DIFF
--- a/core/injector/CMakeLists.txt
+++ b/core/injector/CMakeLists.txt
@@ -119,4 +119,5 @@ target_link_libraries(application_injector
     offchain_worker_api
     offchain_persistent_storage
     offchain_local_storage
+    rating_repository
     )

--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -85,6 +85,7 @@
 #include "network/impl/grandpa_transmitter_impl.hpp"
 #include "network/impl/kademlia_storage_backend.hpp"
 #include "network/impl/peer_manager_impl.hpp"
+#include "network/impl/rating_repository_impl.hpp"
 #include "network/impl/router_libp2p.hpp"
 #include "network/impl/sync_protocol_observer_impl.hpp"
 #include "network/impl/synchronizer_impl.hpp"
@@ -670,7 +671,8 @@ namespace {
         injector.template create<const network::OwnPeerInfo &>(),
         injector.template create<sptr<network::Router>>(),
         injector.template create<sptr<storage::BufferStorage>>(),
-        injector.template create<sptr<crypto::Hasher>>());
+        injector.template create<sptr<crypto::Hasher>>(),
+        injector.template create<sptr<network::PeerRatingRepository>>());
 
     auto protocol_factory =
         injector.template create<std::shared_ptr<network::ProtocolFactory>>();
@@ -1098,6 +1100,7 @@ namespace {
         di::bind<crypto::Sr25519Provider>.template to<crypto::Sr25519ProviderImpl>(),
         di::bind<crypto::VRFProvider>.template to<crypto::VRFProviderImpl>(),
         di::bind<network::StreamEngine>.template to<network::StreamEngine>(),
+        di::bind<network::PeerRatingRepository>.template to<network::PeerRatingRepositoryImpl>(),
         di::bind<crypto::Bip39Provider>.template to<crypto::Bip39ProviderImpl>(),
         di::bind<crypto::Pbkdf2Provider>.template to<crypto::Pbkdf2ProviderImpl>(),
         di::bind<crypto::Secp256k1Provider>.template to<crypto::Secp256k1ProviderImpl>(),

--- a/core/network/impl/CMakeLists.txt
+++ b/core/network/impl/CMakeLists.txt
@@ -77,3 +77,11 @@ target_link_libraries(peer_manager
     logger
     scale_libp2p_types
     )
+
+add_library(rating_repository
+    rating_repository_impl.cpp
+    )
+target_link_libraries(rating_repository
+    p2p::p2p_peer_id
+    p2p::p2p_basic_scheduler
+    )

--- a/core/network/impl/peer_manager_impl.hpp
+++ b/core/network/impl/peer_manager_impl.hpp
@@ -32,6 +32,7 @@
 #include "network/impl/protocols/protocol_factory.hpp"
 #include "network/impl/stream_engine.hpp"
 #include "network/protocols/sync_protocol.hpp"
+#include "network/rating_repository.hpp"
 #include "network/router.hpp"
 #include "network/types/block_announce.hpp"
 #include "network/types/bootstrap_nodes.hpp"
@@ -41,10 +42,7 @@
 
 namespace kagome::network {
 
-  enum class PeerType {
-    PEER_TYPE_IN = 0,
-    PEER_TYPE_OUT
-  };
+  enum class PeerType { PEER_TYPE_IN = 0, PEER_TYPE_OUT };
 
   struct PeerDescriptor {
     PeerType peer_type;
@@ -69,7 +67,8 @@ namespace kagome::network {
         const OwnPeerInfo &own_peer_info,
         std::shared_ptr<network::Router> router,
         std::shared_ptr<storage::BufferStorage> storage,
-        std::shared_ptr<crypto::Hasher> hasher);
+        std::shared_ptr<crypto::Hasher> hasher,
+        std::shared_ptr<PeerRatingRepository> peer_rating_repository);
 
     /** @see AppStateManager::takeControl */
     bool prepare();
@@ -153,6 +152,7 @@ namespace kagome::network {
     std::shared_ptr<network::Router> router_;
     std::shared_ptr<storage::BufferStorage> storage_;
     std::shared_ptr<crypto::Hasher> hasher_;
+    std::shared_ptr<PeerRatingRepository> peer_rating_repository_;
 
     libp2p::event::Handle add_peer_handle_;
     std::unordered_set<PeerId> peers_in_queue_;

--- a/core/network/impl/protocols/protocol_factory.cpp
+++ b/core/network/impl/protocols/protocol_factory.cpp
@@ -18,7 +18,8 @@ namespace kagome::network {
       std::shared_ptr<primitives::events::ExtrinsicSubscriptionEngine>
           extrinsic_events_engine,
       std::shared_ptr<subscription::ExtrinsicEventKeyRepository>
-          ext_event_key_repo)
+          ext_event_key_repo,
+      std::shared_ptr<PeerRatingRepository> peer_rating_repository)
       : host_(host),
         app_config_(app_config),
         chain_spec_(chain_spec),
@@ -27,12 +28,14 @@ namespace kagome::network {
         hasher_(std::move(hasher)),
         stream_engine_(std::move(stream_engine)),
         extrinsic_events_engine_{std::move(extrinsic_events_engine)},
-        ext_event_key_repo_{std::move(ext_event_key_repo)} {
+        ext_event_key_repo_{std::move(ext_event_key_repo)},
+        peer_rating_repository_{std::move(peer_rating_repository)} {
     BOOST_ASSERT(io_context_ != nullptr);
     BOOST_ASSERT(hasher_ != nullptr);
     BOOST_ASSERT(stream_engine_ != nullptr);
     BOOST_ASSERT(extrinsic_events_engine_ != nullptr);
     BOOST_ASSERT(ext_event_key_repo_ != nullptr);
+    BOOST_ASSERT(peer_rating_repository_ != nullptr);
   }
 
   std::shared_ptr<BlockAnnounceProtocol>
@@ -71,7 +74,7 @@ namespace kagome::network {
 
   std::shared_ptr<SyncProtocol> ProtocolFactory::makeSyncProtocol() const {
     return std::make_shared<SyncProtocolImpl>(
-        host_, chain_spec_, sync_observer_.lock());
+        host_, chain_spec_, sync_observer_.lock(), peer_rating_repository_);
   }
 
 }  // namespace kagome::network

--- a/core/network/impl/protocols/protocol_factory.hpp
+++ b/core/network/impl/protocols/protocol_factory.hpp
@@ -13,6 +13,7 @@
 #include "network/impl/protocols/propagate_transactions_protocol.hpp"
 #include "network/impl/protocols/sync_protocol_impl.hpp"
 #include "network/impl/stream_engine.hpp"
+#include "network/rating_repository.hpp"
 #include "primitives/event_types.hpp"
 
 namespace kagome::network {
@@ -30,7 +31,8 @@ namespace kagome::network {
         std::shared_ptr<primitives::events::ExtrinsicSubscriptionEngine>
             extrinsic_events_engine,
         std::shared_ptr<subscription::ExtrinsicEventKeyRepository>
-            ext_event_key_repo);
+            ext_event_key_repo,
+        std::shared_ptr<PeerRatingRepository> peer_rating_repository);
 
     void setBlockTree(
         const std::shared_ptr<blockchain::BlockTree> &block_tree) {
@@ -82,6 +84,7 @@ namespace kagome::network {
         extrinsic_events_engine_;
     std::shared_ptr<subscription::ExtrinsicEventKeyRepository>
         ext_event_key_repo_;
+    std::shared_ptr<PeerRatingRepository> peer_rating_repository_;
 
     std::weak_ptr<blockchain::BlockTree> block_tree_;
     std::weak_ptr<consensus::babe::Babe> babe_;

--- a/core/network/impl/protocols/sync_protocol_impl.cpp
+++ b/core/network/impl/protocols/sync_protocol_impl.cpp
@@ -18,11 +18,120 @@
 
 namespace kagome::network {
 
+  namespace detail {
+    BlocksResponseCache::BlocksResponseCache(
+        std::size_t capacity, std::chrono::seconds expiration_time)
+        : capacity_{capacity}, expiration_time_{expiration_time} {
+      // resize to preallocate elements
+      storage_.resize(capacity_);
+      // preallocate internal storage of containers
+      lookup_table_.reserve(capacity_);
+      free_slots_.reserve(capacity_);
+      for (std::size_t i = 0; i < capacity_; ++i) {
+        free_slots_.emplace(i);
+      }
+    }
+
+    bool BlocksResponseCache::isDuplicate(
+        const PeerId &peer_id, BlocksRequest::Fingerprint request_fingerprint) {
+      auto found = lookup_table_.find(peer_id);
+
+      // the peer is not cached yet
+      if (found == lookup_table_.end()) {
+        cache(peer_id, request_fingerprint);
+        return false;
+      }
+
+      // the peer was previously cached
+      auto slot = found->second;
+      auto &entry = storage_[slot];
+      auto now = std::chrono::system_clock::now();
+      if (not storage_[slot]          // dangling reference was found
+          or now > entry->valid_till  // the record was expired
+      ) {
+        cache(peer_id, request_fingerprint, slot);
+        return false;
+      }
+
+      // peer record in cache is valid and not expired
+      entry->valid_till = now + expiration_time_;  // prolong expiry time
+      auto &requests = entry->fingerprints;
+      if (std::find(requests.begin(), requests.end(), request_fingerprint)
+          != requests.end()) {
+        return true;
+      }
+      requests.push_back(request_fingerprint);
+      return false;
+    }
+
+    void BlocksResponseCache::cache(
+        const PeerId &peer_id,
+        BlocksRequest::Fingerprint request_fingerprint,
+        std::optional<CacheRecordIndex> target_slot) {
+      CacheRecordIndex slot;
+      if (target_slot) {
+        slot = *target_slot;
+      } else {
+        if (free_slots_.empty()) {
+          purge();
+        }
+        if (free_slots_.empty()) {
+          return;
+        }
+        auto free_slot = free_slots_.begin();
+        slot = *free_slot;
+        free_slots_.erase(free_slot);
+      }
+
+      boost::circular_buffer<BlocksRequest::Fingerprint> fingerprints(
+          kMaxCacheEntriesPerPeer);
+      if (target_slot and storage_[*target_slot]) {
+        fingerprints = std::move(storage_[*target_slot]->fingerprints);
+      }
+      fingerprints.push_back(request_fingerprint);
+
+      CacheRecord record{
+          .peer_id = peer_id,
+          .valid_till = std::chrono::system_clock::now() + expiration_time_,
+          .fingerprints = std::move(fingerprints),
+      };
+
+      storage_[slot] = std::move(record);
+      lookup_table_[peer_id] = slot;
+    }
+
+    void BlocksResponseCache::purge() {
+      auto it = lookup_table_.begin();
+      while (it != lookup_table_.end()) {
+        auto slot = it->second;
+        // remove dangling reference from lookup table
+        if (not storage_[slot]) {
+          free_slots_.insert(slot);
+          it = lookup_table_.erase(it);  // points to the following element
+          continue;
+        }
+        auto &record = storage_[slot].value();
+        // remove expired entries
+        if (std::chrono::system_clock::now() > record.valid_till) {
+          storage_[slot] = std::nullopt;
+          free_slots_.insert(slot);
+          it = lookup_table_.erase(it);  // points to the following element
+          continue;
+        }
+        it++;
+      }
+    }
+
+  }  // namespace detail
+
   SyncProtocolImpl::SyncProtocolImpl(
       libp2p::Host &host,
       const application::ChainSpec &chain_spec,
       std::shared_ptr<SyncProtocolObserver> sync_observer)
-      : host_(host), sync_observer_(std::move(sync_observer)) {
+      : host_(host),
+        sync_observer_(std::move(sync_observer)),
+        response_cache_(kResponsesCacheCapacity,
+                        kResponsesCacheExpirationTimeout) {
     BOOST_ASSERT(sync_observer_ != nullptr);
     const_cast<Protocol &>(protocol_) =
         fmt::format(kSyncProtocol.data(), chain_spec.protocolId());
@@ -167,6 +276,41 @@ namespace kagome::network {
         return;
       }
       auto &block_response = block_response_res.value();
+
+      // the commented code will be removed in the following commit
+      //      if (not block_response.blocks.empty()) {
+      //        for (auto i = 0; i < 5; ++i) {
+      //          block_response.blocks[0].header->state_root.at(i) = 0xa;
+      //        }
+      //        std::cout << block_request.fingerprint() << std::endl;
+      //      }
+
+      if ((not block_response.blocks.empty()) and stream->remotePeerId()
+          and self->response_cache_.isDuplicate(stream->remotePeerId().value(),
+                                                block_request.fingerprint())) {
+        stream->reset();
+        //        auto peer_id = stream->remotePeerId().value();
+        //        SL_DEBUG(self->log_,
+        //                 "Stream {} to {} scheduled to be reset in {} seconds
+        //                 due to " "repeating non-polite block request with
+        //                 fingerprint {}", self->protocol_, peer_id,
+        //                 kResponsesCacheExpirationTimeout.count(),
+        //                 block_request.fingerprint());
+        //        self->scheduler_->schedule(
+        //            [stream, wp, peer_id] {
+        //              if (not stream->isClosed()) {
+        //                stream->reset();
+        //              }
+        //              if (auto self = wp.lock()) {
+        //                SL_DEBUG(self->log_,
+        //                         "Stream {} to {} was reset by timeout",
+        //                         self->protocol_,
+        //                         peer_id);
+        //              }
+        //            },
+        //            kResponsesCacheExpirationTimeout);
+        return;
+      }
 
       self->writeResponse(std::move(stream), block_response);
     });

--- a/core/network/impl/protocols/sync_protocol_impl.hpp
+++ b/core/network/impl/protocols/sync_protocol_impl.hpp
@@ -19,6 +19,7 @@
 #include <libp2p/host/host.hpp>
 #include "application/chain_spec.hpp"
 #include "log/logger.hpp"
+#include "network/rating_repository.hpp"
 #include "network/sync_protocol_observer.hpp"
 
 namespace kagome::network {
@@ -106,7 +107,8 @@ namespace kagome::network {
    public:
     SyncProtocolImpl(libp2p::Host &host,
                      const application::ChainSpec &chain_spec,
-                     std::shared_ptr<SyncProtocolObserver> sync_observer);
+                     std::shared_ptr<SyncProtocolObserver> sync_observer,
+                     std::shared_ptr<PeerRatingRepository> rating_repository);
 
     const Protocol &protocol() const override {
       return protocol_;
@@ -142,6 +144,7 @@ namespace kagome::network {
    private:
     libp2p::Host &host_;
     std::shared_ptr<SyncProtocolObserver> sync_observer_;
+    std::shared_ptr<PeerRatingRepository> rating_repository_;
     const libp2p::peer::Protocol protocol_;
     detail::BlocksResponseCache response_cache_;
     log::Logger log_ = log::createLogger("SyncProtocol", "sync_protocol");

--- a/core/network/impl/protocols/sync_protocol_impl.hpp
+++ b/core/network/impl/protocols/sync_protocol_impl.hpp
@@ -8,11 +8,15 @@
 
 #include "network/protocols/sync_protocol.hpp"
 
+#include <chrono>
 #include <memory>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
 
+#include <boost/circular_buffer.hpp>
 #include <libp2p/connection/stream.hpp>
 #include <libp2p/host/host.hpp>
-
 #include "application/chain_spec.hpp"
 #include "log/logger.hpp"
 #include "network/sync_protocol_observer.hpp"
@@ -23,6 +27,78 @@ namespace kagome::network {
   using Protocol = libp2p::peer::Protocol;
   using PeerId = libp2p::peer::PeerId;
   using PeerInfo = libp2p::peer::PeerInfo;
+
+  static constexpr auto kResponsesCacheCapacity = 500;
+  static constexpr auto kResponsesCacheExpirationTimeout =
+      std::chrono::seconds(30);
+  static constexpr auto kMaxCacheEntriesPerPeer = 5;
+
+  namespace detail {
+
+    /**
+     * Container to store the most recent block requests by peers we replied to
+     * with non empty responses.
+     */
+    class BlocksResponseCache {
+     public:
+      /**
+       * Initialize the cache
+       * @param capacity - max amount of cache entries
+       * @param expiration_time - cache entry expiry time in seconds
+       */
+      BlocksResponseCache(std::size_t capacity,
+                          std::chrono::seconds expiration_time);
+
+      /**
+       * Checks whether specified request came from the peer more than once.
+       *
+       * Some repeating request done past "expiration_time" seconds since last
+       * request from the peer would not be considered as duplicating request.
+       *
+       * @param peer_id - peer identifier
+       * @param request_fingerprint - request identifier
+       * @return true when the request is found in a list of last peers'
+       * requests of size kMaxCacheEntriesPerPeer and the last request
+       * took a place not later than "expiration_time" seconds.
+       * Otherwise - false.
+       */
+      bool isDuplicate(const PeerId &peer_id,
+                       BlocksRequest::Fingerprint request_fingerprint);
+
+     private:
+      using ExpirationTimepoint =
+          std::chrono::time_point<std::chrono::system_clock>;
+      using CacheRecordIndex = std::size_t;
+
+      /**
+       * Save a record about peer's request to cache
+       * @param peer_id - peer identifier
+       * @param request_fingerprint - request identifier
+       * @param target_slot - (optional) a slot of internal storage to put a
+       * record into
+       */
+      void cache(const PeerId &peer_id,
+                 BlocksRequest::Fingerprint request_fingerprint,
+                 std::optional<CacheRecordIndex> target_slot = std::nullopt);
+
+      /// removes all stale records
+      void purge();
+
+      struct CacheRecord {
+        PeerId peer_id;
+        ExpirationTimepoint valid_till;
+        boost::circular_buffer<BlocksRequest::Fingerprint> fingerprints{
+            kMaxCacheEntriesPerPeer};
+      };
+
+      const std::size_t capacity_;
+      const std::chrono::seconds expiration_time_;
+      std::unordered_map<PeerId, CacheRecordIndex> lookup_table_;
+      std::vector<std::optional<CacheRecord>> storage_;
+      std::unordered_set<CacheRecordIndex> free_slots_;
+    };
+
+  }  // namespace detail
 
   class SyncProtocolImpl final
       : public SyncProtocol,
@@ -67,6 +143,7 @@ namespace kagome::network {
     libp2p::Host &host_;
     std::shared_ptr<SyncProtocolObserver> sync_observer_;
     const libp2p::peer::Protocol protocol_;
+    detail::BlocksResponseCache response_cache_;
     log::Logger log_ = log::createLogger("SyncProtocol", "sync_protocol");
   };
 

--- a/core/network/impl/rating_repository_impl.cpp
+++ b/core/network/impl/rating_repository_impl.cpp
@@ -1,0 +1,89 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "network/impl/rating_repository_impl.hpp"
+
+#include <boost/assert.hpp>
+
+namespace kagome::network {
+
+  PeerRatingRepositoryImpl::PeerRatingRepositoryImpl(
+      std::shared_ptr<libp2p::basic::Scheduler> scheduler)
+      : scheduler_{std::move(scheduler)} {
+    BOOST_ASSERT(scheduler_);
+  }
+
+  PeerScore PeerRatingRepositoryImpl::rating(
+      const PeerRatingRepository::PeerId &peer_id) const {
+    return rating_table_.count(peer_id) == 0 ? 0 : rating_table_.at(peer_id);
+  }
+
+  PeerScore PeerRatingRepositoryImpl::upvote(
+      const PeerRatingRepository::PeerId &peer_id) {
+    ensurePeerPresence(peer_id);
+    return ++rating_table_[peer_id];
+  }
+
+  PeerScore PeerRatingRepositoryImpl::downvote(
+      const PeerRatingRepository::PeerId &peer_id) {
+    ensurePeerPresence(peer_id);
+    return --rating_table_[peer_id];
+  }
+
+  PeerScore PeerRatingRepositoryImpl::update(
+      const PeerRatingRepository::PeerId &peer_id, PeerScore diff) {
+    ensurePeerPresence(peer_id);
+    return rating_table_[peer_id] += diff;
+  }
+
+  void PeerRatingRepositoryImpl::ensurePeerPresence(const PeerId &peer_id) {
+    if (rating_table_.count(peer_id) == 0) {
+      rating_table_[peer_id] = 0;
+    }
+  }
+
+  PeerScore PeerRatingRepositoryImpl::upvoteForATime(
+      const PeerRatingRepository::PeerId &peer_id,
+      std::chrono::seconds duration) {
+    auto score = upvote(peer_id);
+    scheduler_->schedule(
+        [wp{weak_from_this()}, peer_id] {
+          if (auto self = wp.lock()) {
+            self->downvote(peer_id);
+          }
+        },
+        duration);
+    return score;
+  }
+
+  PeerScore PeerRatingRepositoryImpl::downvoteForATime(
+      const PeerRatingRepository::PeerId &peer_id,
+      std::chrono::seconds duration) {
+    auto score = downvote(peer_id);
+    scheduler_->schedule(
+        [wp{weak_from_this()}, peer_id] {
+          if (auto self = wp.lock()) {
+            self->upvote(peer_id);
+          }
+        },
+        duration);
+    return score;
+  }
+
+  PeerScore PeerRatingRepositoryImpl::updateForATime(
+      const PeerRatingRepository::PeerId &peer_id,
+      PeerScore diff,
+      std::chrono::seconds duration) {
+    auto score = update(peer_id, diff);
+    scheduler_->schedule(
+        [wp{weak_from_this()}, peer_id, diff] {
+          if (auto self = wp.lock()) {
+            self->update(peer_id, -1 * diff);
+          }
+        },
+        duration);
+    return score;
+  }
+}  // namespace kagome::network

--- a/core/network/impl/rating_repository_impl.hpp
+++ b/core/network/impl/rating_repository_impl.hpp
@@ -1,0 +1,52 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_RATING_REPOSITORY_IMPL_HPP
+#define KAGOME_RATING_REPOSITORY_IMPL_HPP
+
+#include "network/rating_repository.hpp"
+
+#include <memory>
+#include <unordered_map>
+
+#include <libp2p/basic/scheduler.hpp>
+
+namespace kagome::network {
+
+  class PeerRatingRepositoryImpl
+      : public PeerRatingRepository,
+        public std::enable_shared_from_this<PeerRatingRepositoryImpl> {
+   public:
+    PeerRatingRepositoryImpl(
+        std::shared_ptr<libp2p::basic::Scheduler> scheduler);
+
+    PeerScore rating(const PeerId &peer_id) const override;
+
+    PeerScore upvote(const PeerId &peer_id) override;
+
+    PeerScore downvote(const PeerId &peer_id) override;
+
+    PeerScore update(const PeerId &peer_id, PeerScore diff) override;
+
+    PeerScore upvoteForATime(const PeerId &peer_id,
+                             std::chrono::seconds duration) override;
+
+    PeerScore downvoteForATime(const PeerId &peer_id,
+                               std::chrono::seconds duration) override;
+
+    PeerScore updateForATime(const PeerId &peer_id,
+                             PeerScore diff,
+                             std::chrono::seconds duration) override;
+
+   private:
+    void ensurePeerPresence(const PeerId &peer_id);
+
+    std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
+    std::unordered_map<PeerId, PeerScore> rating_table_;
+  };
+
+}  // namespace kagome::network
+
+#endif  // KAGOME_RATING_REPOSITORY_IMPL_HPP

--- a/core/network/rating_repository.hpp
+++ b/core/network/rating_repository.hpp
@@ -1,0 +1,78 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_RATING_REPOSITORY_HPP
+#define KAGOME_RATING_REPOSITORY_HPP
+
+#include <chrono>
+
+#include <libp2p/peer/peer_id.hpp>
+
+namespace kagome::network {
+
+  using PeerScore = std::int32_t;
+
+  /**
+   * Storage to handle peers' rating
+   */
+  class PeerRatingRepository {
+   public:
+    using PeerId = libp2p::peer::PeerId;
+
+    virtual ~PeerRatingRepository() = default;
+
+    /// Current peer rating
+    virtual PeerScore rating(const PeerId &peer_id) const = 0;
+
+    /// Raise peer rating by one, returns resulting rating
+    virtual PeerScore upvote(const PeerId &peer_id) = 0;
+
+    /**
+     * Raise peer rating by one for a specified amount of time.
+     * When time is over, the rating decreases automatically by one.
+     * @param peer_id - peer identifier
+     * @param duration - amount of time to increase peer rating for
+     * @return - resulting peer rating
+     */
+    virtual PeerScore upvoteForATime(const PeerId &peer_id,
+                                     std::chrono::seconds duration) = 0;
+
+    /// Decrease peer rating by one, returns resulting rating
+    virtual PeerScore downvote(const PeerId &peer_id) = 0;
+
+    /**
+     * Decrease peer rating by one for a specified amount of time.
+     * When time is over, the rating increases automatically by one.
+     * @param peer_id - peer identifier
+     * @param duration - amount of time to decrease peer rating for
+     * @return - resulting peer rating
+     */
+    virtual PeerScore downvoteForATime(const PeerId &peer_id,
+                                       std::chrono::seconds duration) = 0;
+
+    /**
+     * Change peer rating by arbitrary amount of points
+     * @param peer_id - peer identifier
+     * @param diff - rating increment or decrement
+     * @return - resulting peer rating
+     */
+    virtual PeerScore update(const PeerId &peer_id, PeerScore diff) = 0;
+
+    /**
+     * Change peer rating by arbitrary amount of points for a specified amount
+     * of time
+     * @param peer_id - peer identifier
+     * @param difff - rating increment or decrement
+     * @param duration - amount of time to change peer rating for
+     * @return - resulting peer rating
+     */
+    virtual PeerScore updateForATime(const PeerId &peer_id,
+                                     PeerScore diff,
+                                     std::chrono::seconds duration) = 0;
+  };
+
+}  // namespace kagome::network
+
+#endif  // KAGOME_RATING_REPOSITORY_HPP

--- a/test/mock/core/network/rating_repository_mock.hpp
+++ b/test/mock/core/network/rating_repository_mock.hpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_RATING_REPOSITORY_MOCK_HPP
+#define KAGOME_RATING_REPOSITORY_MOCK_HPP
+
+#include <gmock/gmock.h>
+
+#include "network/rating_repository.hpp"
+
+namespace kagome::network {
+
+  class PeerRatingRepositoryMock : public PeerRatingRepository {
+   public:
+    MOCK_METHOD(PeerScore, rating, (const PeerId &), (const override));
+
+    MOCK_METHOD(PeerScore, upvote, (const PeerId &), (override));
+
+    MOCK_METHOD(PeerScore, downvote, (const PeerId &), (override));
+
+    MOCK_METHOD(PeerScore, update, (const PeerId &, PeerScore), (override));
+
+    MOCK_METHOD(PeerScore,
+                upvoteForATime,
+                (const PeerId &, std::chrono::seconds),
+                (override));
+
+    MOCK_METHOD(PeerScore,
+                downvoteForATime,
+                (const PeerId &, std::chrono::seconds),
+                (override));
+
+    MOCK_METHOD(PeerScore,
+                updateForATime,
+                (const PeerId &, PeerScore, std::chrono::seconds),
+                (override));
+  };
+
+}  // namespace kagome::network
+
+#endif  // KAGOME_RATING_REPOSITORY_MOCK_HPP


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->



### Referenced issues

Resolves #1157 

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change

Kagome node will respond on block requests only once within a specified time gap for every requesting peer.
That restriction applies only for the cases when the first blocks request was satisfied with non empty content of response.
The situation should not normally happen and occurs only when the same peer repeats the requests even after receiving the proper response from kagome. Thus, temporary banning that peer does not bring any negative impact for kagome.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Proper behavior

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

None?

Please note modified code of PeerManagerImpl::diconnectFromPeer.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->
examples/network/testchain.json

put this before writeResponse into SyncProtocolImpl::readRequest to broke our response
```
      if (not block_response.blocks.empty()) {
        for (auto i = 0; i < 5; ++i) {
          block_response.blocks[0].header->state_root.at(i) = 0xa;
        }
      }
```

launch kagome 
```
kagome --validator --chain examples/network/testchain.json --base-path examples/network/validating1 --port 11122 -lsync_protocol=debug
```

launch substrate
```
substrate --chain examples/network/testchain.json --base-pathexamples/network/polkadot-bob-node --port 11222 --validator --bob
```

Ensure that after second repeating request kagome reports a line like:
```
22.04.28 18:51:29.479486                   Debug     SyncProtocol  Read request from incoming /sup/sync/2 stream with …PKMnLY
22.04.28 18:51:29.481988                   Verbose   SyncProtocol  Block request is received from incoming /sup/sync/2 stream with …PKMnLY, fields=HBJ, from 0x8522…d295 desc, max 1
22.04.28 18:51:29.500041                   Warning   BlockAnnounceProtocol  Can't read block announce from …PKMnLY: Stream: reset by remote peer
22.04.28 18:51:29.505393                   Debug     SyncProtocol  Read request from incoming /sup/sync/2 stream with …PKMnLY
22.04.28 18:51:29.506490                   Verbose   SyncProtocol  Block request is received from incoming /sup/sync/2 stream with …PKMnLY, fields=HBJ, from 0x8522…d295 desc, max 1
22.04.28 18:51:29.506991                   Debug     SyncProtocol  Stream /sup/sync/2 to …PKMnLY reset due to repeating non-polite block request with fingerprint 3583919347386603160
```
and the next block request from the same peer appears not early than cooldown timeout:
```
22.04.28 18:52:29.350525                   Debug     SyncProtocol  Read request from incoming /sup/sync/2 stream with …PKMnLY
```

18:51:29 -> cooldown -> 18:52:29

