### PR TITLE
Update size constraints

### DIFF
--- a/core/runtime/wavm/intrinsics/intrinsic_module.hpp
+++ b/core/runtime/wavm/intrinsics/intrinsic_module.hpp
@@ -19,7 +19,7 @@ namespace kagome::runtime::wavm {
    public:
     static inline const WAVM::IR::MemoryType kIntrinsicMemoryType{
         WAVM::IR::MemoryType(
-            false, WAVM::IR::IndexType::i32, {20, UINT64_MAX})};
+            false, WAVM::IR::IndexType::i32, {21, UINT64_MAX})};
     static constexpr std::string_view kIntrinsicMemoryName = "Runtime Memory";
 
     explicit IntrinsicModule(std::shared_ptr<CompartmentWrapper> compartment)


### PR DESCRIPTION
Signed-off-by: kamilsa <kamilsa16@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

Resolves #1192 

### Description of the Change

We can see that after block [9280179](https://polkadot.subscan.io/block/9280179) where runtime upgrade happened the new constraint for memory import was introduced:

```
(import "env" "memory" (memory (;0;) 21))
```

Before it was:

```
(import "env" "memory" (memory (;0;) 20))
```

Because of that the condition https://github.com/WAVM/WAVM/blob/master/Lib/Runtime/Runtime.cpp#L116 failed which caused this assert to fail: https://github.com/WAVM/WAVM/blob/master/Lib/Runtime/Linker.cpp#L160

This caused an issue with compilation of this runtime upgrade using wavm.

This PR fixes that

### Benefits

WAVM is working again

### Possible Drawbacks 

In future we may end up with similar bug if new constraint for memory will be introduced. To avoid such issues we should resolve issue #1194
