### PR TITLE
Fix wrong parsing of --max-blocks-in-response

### DIFF
--- a/core/application/impl/app_configuration_impl.cpp
+++ b/core/application/impl/app_configuration_impl.cpp
@@ -602,7 +602,7 @@ namespace kagome::application {
         ("out-peers", po::value<uint32_t>()->default_value(25), "number of outgoing connections we're trying to maintain")
         ("in-peers", po::value<uint32_t>()->default_value(25), "maximum number of inbound full nodes peers")
         ("in-peers-light", po::value<uint32_t>()->default_value(100), "maximum number of inbound light nodes peers")
-        ("max-blocks-in-response", po::value<int>(), "max block per response while syncing")
+        ("max-blocks-in-response", po::value<uint32_t>(), "max block per response while syncing")
         ("name", po::value<std::string>(), "the human-readable name for this node")
         ("telemetry-url", po::value<std::vector<std::string>>()->multitoken(),
                           "the URL of the telemetry server to connect to and verbosity level (0-9),\n"

--- a/test/core/application/app_config_test.cpp
+++ b/test/core/application/app_config_test.cpp
@@ -565,3 +565,21 @@ TEST_F(AppConfigurationTest, MultipleTelemetryCliArgs) {
   ASSERT_TRUE(app_config_->initializeFromArgs(std::size(args), (char **)args));
   ASSERT_EQ(app_config_->telemetryEndpoints(), reference);
 }
+
+/**
+ * @given initialized instance of AppConfigurationImpl
+ * @when --max-blocks-in-response is specified
+ * @then the correct value is parsed
+ */
+TEST_F(AppConfigurationTest, MaxBlocksInResponse) {
+  char const *args[] = {"/path/",
+                        "--chain",
+                        chain_path.native().c_str(),
+                        "--base-path",
+                        base_path.native().c_str(),
+                        "--max-blocks-in-response",
+                        "122"};
+  ASSERT_TRUE(app_config_->initializeFromArgs(std::size(args), (char **)args));
+
+  ASSERT_EQ(app_config_->maxBlocksInResponse(), 122);
+}


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

Resolves #1193

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change

No more failure while `--max-blocks-in-response` is specified

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Correct Behavior

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

None

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->

```
app_config_test
kagome --chain polkadot.json --base-path polkadot-node-1 --name kagome-kamil-1 --max-blocks-in-response 43
```
