### PR TITLE
Increase allowed open file count

### DIFF
--- a/core/common/CMakeLists.txt
+++ b/core/common/CMakeLists.txt
@@ -31,6 +31,15 @@ target_link_libraries(blob
     )
 kagome_install(blob)
 
+add_library(fd_limit
+    fd_limit.hpp
+    fd_limit.cpp
+    )
+target_link_libraries(fd_limit
+    Boost::boost
+    logger
+    )
+
 add_library(mp_utils
     mp_utils.cpp
     mp_utils.hpp

--- a/core/common/fd_limit.cpp
+++ b/core/common/fd_limit.cpp
@@ -1,0 +1,63 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "common/fd_limit.hpp"
+
+#include <sys/resource.h>
+#include <algorithm>
+#include <boost/iterator/counting_iterator.hpp>
+
+#include "log/logger.hpp"
+
+namespace kagome::common {
+  auto log = log::createLogger("FdLimit", log::defaultGroupName);
+
+  bool getFdLimit(rlimit &r) {
+    if (getrlimit(RLIMIT_NOFILE, &r) != 0) {
+      SL_WARN(log,
+              "Error: getrlimit(RLIMIT_NOFILE) errno={} {}",
+              errno,
+              strerror(errno));
+      return false;
+    }
+    return true;
+  }
+
+  bool setFdLimit(const rlimit &r) {
+    return setrlimit(RLIMIT_NOFILE, &r) == 0;
+  }
+
+  void setFdLimit(size_t limit) {
+    rlimit r{};
+    if (!getFdLimit(r)) {
+      return;
+    }
+    if (r.rlim_max == RLIM_INFINITY) {
+      SL_DEBUG(log, "current={} max=unlimited", r.rlim_cur);
+    } else {
+      SL_DEBUG(log, "current={} max={}", r.rlim_cur, r.rlim_max);
+    }
+    if (limit <= r.rlim_cur) {
+      return;
+    }
+    rlim_t current = r.rlim_cur;
+    r.rlim_cur = limit;
+    if (!setFdLimit(r)) {
+      std::upper_bound(boost::counting_iterator{current},
+                       boost::counting_iterator{rlim_t{limit}},
+                       nullptr,
+                       [&](std::nullptr_t, rlim_t current) {
+                         r.rlim_cur = current;
+                         return !setFdLimit(r);
+                       });
+    }
+    if (!getFdLimit(r)) {
+      return;
+    }
+    if (r.rlim_cur != current) {
+      SL_DEBUG(log, "changed current={}", r.rlim_cur);
+    }
+  }
+}  // namespace kagome::common

--- a/core/common/fd_limit.hpp
+++ b/core/common/fd_limit.hpp
@@ -1,0 +1,15 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_COMMON_FD_LIMIT_HPP
+#define KAGOME_COMMON_FD_LIMIT_HPP
+
+#include <cstdlib>
+
+namespace kagome::common {
+  void setFdLimit(size_t limit);
+}  // namespace kagome::common
+
+#endif  // KAGOME_COMMON_FD_LIMIT_HPP

--- a/node/CMakeLists.txt
+++ b/node/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(kagome
     Boost::program_options
     kagome_application
     app_config
+    fd_limit
     p2p::p2p_identify
     p2p::p2p_ping
     )

--- a/node/main.cpp
+++ b/node/main.cpp
@@ -12,6 +12,7 @@
 
 #include "application/impl/app_configuration_impl.hpp"
 #include "application/impl/kagome_application_impl.hpp"
+#include "common/fd_limit.hpp"
 #include "log/configurator.hpp"
 #include "log/logger.hpp"
 
@@ -42,6 +43,8 @@ int main(int argc, const char **argv) {
   auto logger = kagome::log::createLogger("AppConfiguration",
                                           kagome::log::defaultGroupName);
   AppConfigurationImpl configuration{logger};
+
+  kagome::common::setFdLimit(SIZE_MAX);
 
   if (configuration.initializeFromArgs(argc, argv)) {
     kagome::log::tuneLoggingSystem(configuration.log());


### PR DESCRIPTION
### Description of the Change
- Adds `setFdLimit` (uses `setrlimit`).
- Calls `setFdLimit` from `node/kagome`.

### Benefits
Resolves some "too many open files" errors.

### Possible Drawbacks
- May add config option to limit open files count.
- May add `ifdef` checks for `setrlimit`.
