### PR TITLE
Propagate transaction once

### DIFF
--- a/core/transaction_pool/impl/transaction_pool_impl.cpp
+++ b/core/transaction_pool/impl/transaction_pool_impl.cpp
@@ -97,7 +97,7 @@ namespace kagome::transaction_pool {
       primitives::TransactionSource source, primitives::Extrinsic extrinsic) {
     OUTCOME_TRY(tx, constructTransaction(source, extrinsic));
 
-    if (tx.should_propagate) {
+    if (tx.should_propagate && !imported_txs_.count(tx.hash)) {
       tx_transmitter_->propagateTransactions(gsl::make_span(std::vector{tx}));
     }
     auto hash = tx.hash;


### PR DESCRIPTION
Don't propagate transaction if it's already propagated.  
Caused infinite propagation.