### PR TITLE
Fix returning nullptr in select round

### DIFF
--- a/core/consensus/grandpa/impl/grandpa_impl.cpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.cpp
@@ -243,7 +243,7 @@ namespace kagome::consensus::grandpa {
       round = round->getPreviousRound();
     }
 
-    return round;
+    return round == nullptr ? std::nullopt : std::make_optional(round);
   }
 
   outcome::result<MovableRoundState> GrandpaImpl::getLastCompletedRound()


### PR DESCRIPTION
Signed-off-by: kamilsa <kamilsa16@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

Issues was introduced in #1165 
### Description of the Change
```cpp
std::optional<std::shared_ptr<VotingRound>> GrandpaImpl::selectRound(
      RoundNumber round_number, std::optional<MembershipCounter> voter_set_id)
```
Select round function could return nullptr which resulted in returning nullptr that was wrapped by std optional. This in turn resulted in invalid handling of this optional in external function as we assumed that if optional contained shared ptr it could not be nullptr

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

One less failing case

