### PR TITLE
Protect pending resources with mutexes

### DIFF
--- a/core/api/transport/impl/ws/ws_session.hpp
+++ b/core/api/transport/impl/ws/ws_session.hpp
@@ -153,6 +153,7 @@ namespace kagome::api {
     boost::beast::flat_buffer rbuffer_;  ///< read buffer
     boost::beast::flat_buffer wbuffer_;  ///< write buffer
 
+    std::mutex cs_;
     std::queue<std::string> pending_responses_;
 
     std::atomic_bool writing_in_progress_ = false;


### PR DESCRIPTION
Signed-off-by: kamilsa <kamilsa16@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

None

### Description of the Change

pending_resources_ field could be accessed from different threads which may lead to failures. This PR fixes that
### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

More stable work of syncing node with connected polkadot js app
