### PR TITLE
stream engine fixes

### DIFF
--- a/core/network/impl/peer_manager_impl.cpp
+++ b/core/network/impl/peer_manager_impl.cpp
@@ -546,7 +546,7 @@ namespace kagome::network {
     BOOST_ASSERT_MSG(block_announce_protocol,
                      "Router did not provide block announce protocol");
 
-    if (not stream_engine_->isAlive(peer_info.id, block_announce_protocol)) {
+    if (stream_engine_->reserveOutgoing(peer_info.id, block_announce_protocol)) {
       block_announce_protocol->newOutgoingStream(
           peer_info,
           [wp = weak_from_this(),

--- a/core/network/impl/peer_manager_impl.cpp
+++ b/core/network/impl/peer_manager_impl.cpp
@@ -558,6 +558,7 @@ namespace kagome::network {
               return;
             }
 
+            self->stream_engine_->dropReserveOutgoing(peer_id, protocol);
             if (not stream_res.has_value()) {
               self->log_->warn("Unable to create stream {} with {}: {}",
                                protocol->protocol(),
@@ -630,8 +631,8 @@ namespace kagome::network {
     BOOST_ASSERT_MSG(transaction_protocol,
                      "Router did not provide propagate transaction protocol");
 
-    stream_engine_->add(peer_id, grandpa_protocol);
-    stream_engine_->add(peer_id, transaction_protocol);
+    stream_engine_->reserveStreams(peer_id, grandpa_protocol);
+    stream_engine_->reserveStreams(peer_id, transaction_protocol);
   }
 
   bool PeerManagerImpl::isSelfPeer(const PeerId &peer_id) const {

--- a/core/network/impl/protocols/grandpa_protocol.cpp
+++ b/core/network/impl/protocols/grandpa_protocol.cpp
@@ -39,7 +39,7 @@ namespace kagome::network {
 
   bool GrandpaProtocol::start() {
     auto stream = std::make_shared<LoopbackStream>(own_info_, io_context_);
-    auto res = stream_engine_->add(stream, shared_from_this());
+    auto res = stream_engine_->addBidirectional(stream, shared_from_this());
     if (not res.has_value()) {
       return false;
     }

--- a/core/network/impl/stream_engine.hpp
+++ b/core/network/impl/stream_engine.hpp
@@ -243,7 +243,6 @@ namespace kagome::network {
       BOOST_ASSERT(protocol != nullptr);
 
       forEachPeer([&](const auto &peer_id, auto &proto_map) {
-        // check here under shared access
         if (predicate(peer_id)) {
           forProtocol(proto_map, protocol, [&](auto &descr) {
             if (descr.hasActiveOutgoing())

--- a/core/network/impl/stream_engine.hpp
+++ b/core/network/impl/stream_engine.hpp
@@ -342,9 +342,9 @@ namespace kagome::network {
       BOOST_ASSERT(stream != nullptr);
 
       auto read_writer =
-          std::make_shared<ScaleMessageReadWriter>(std::move(stream));
+          std::make_shared<ScaleMessageReadWriter>(stream);
       read_writer->write(
-          *msg, [wp(weak_from_this()), peer_id, protocol, msg](auto &&res) {
+          *msg, [wp(weak_from_this()), peer_id, protocol, msg, stream](auto &&res) {
             if (auto self = wp.lock()) {
               if (res.has_value()) {
                 SL_TRACE(self->logger_,
@@ -357,6 +357,7 @@ namespace kagome::network {
                          protocol->protocol(),
                          peer_id,
                          res.error().message());
+                stream->reset();
               }
             }
           });

--- a/core/network/impl/sync_protocol_observer_impl.cpp
+++ b/core/network/impl/sync_protocol_observer_impl.cpp
@@ -68,21 +68,17 @@ namespace kagome::network {
     if (response.blocks.empty()) {
       SL_DEBUG(log_, "Return response id={}: no blocks", request_id);
     } else if (response.blocks.size() == 1) {
-      SL_DEBUG(
-          log_,
-          "Return response id={}: {}, count 1",
-          request_id,
-          primitives::BlockInfo(response.blocks.front().header.value().number,
-                                response.blocks.front().hash));
+        SL_DEBUG(
+            log_,
+            "Return response id={}: {}, count 1",
+            request_id, response.blocks.front().hash);
     } else {
       SL_DEBUG(
           log_,
           "Return response id={}: from {} to {}, count {}",
           request_id,
-          primitives::BlockInfo(response.blocks.front().header.value().number,
-                                response.blocks.front().hash),
-          primitives::BlockInfo(response.blocks.back().header.value().number,
-                                response.blocks.back().hash),
+          response.blocks.front().hash,
+          response.blocks.back().hash,
           response.blocks.size());
     }
 

--- a/core/utils/safe_object.hpp
+++ b/core/utils/safe_object.hpp
@@ -1,4 +1,10 @@
-#pragma once
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_SAFE_OBJECT_HPP
+#define KAGOME_SAFE_OBJECT_HPP
 
 // clang-format off
 /**
@@ -46,3 +52,5 @@ struct SafeObject {
   T t_;
   mutable M cs_;
 };
+
+#endif  // KAGOME_SAFE_OBJECT_HPP

--- a/core/utils/safe_object.hpp
+++ b/core/utils/safe_object.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+// clang-format off
+/**
+ * Protected object wrapper. Allow read-write access.
+ * @tparam T object type
+ * Example:
+ * @code
+ *  SafeObject<std::string> obj("1");
+ *  bool const is_one_att1 =
+ *      obj.sharedAccess([](auto const &str) {
+ *          return str == "1";
+ *      });
+ *  obj.exclusiveAccess([](auto &str) {
+ *      str = "2";
+ *  });
+ *  bool const is_one_att2 =
+ *      obj.sharedAccess([](auto const &str) {
+ *          return str == "1";
+ *      });
+ *
+ * std::cout <<
+ *   "Attempt 1: " << is_one_att1 << std::endl <<
+ *   "Attempt 2: " << is_one_att2;
+ * @endcode
+ */
+// clang-format on
+template <typename T, typename M = std::shared_mutex>
+struct SafeObject {
+  template <typename... Args>
+  SafeObject(Args &&... args) : t_(std::forward<Args>(args)...) {}
+
+  template <typename F>
+  inline auto exclusiveAccess(F &&f) {
+    std::unique_lock lock(cs_);
+    return std::forward<F>(f)(t_);
+  }
+
+  template <typename F>
+  inline auto sharedAccess(F &&f) const {
+    std::shared_lock lock(cs_);
+    return std::forward<F>(f)(t_);
+  }
+
+ private:
+  T t_;
+  mutable M cs_;
+};


### PR DESCRIPTION
### Description of the Change
1. Fixes multiple ```block-announce``` outgoing streams because of race condition.
2. Disables multiple outgoing streams because of ```updateStream``` not synchronized with external ```newOutgoingStream```.
3. Blocks not synchronized access to ```streams_``` object.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Improves stability avoiding multiple outgoing block-announces to the remote peer.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
1. We still need to redesign ```stream_engine```, ```protocols``` and ```peer_manager``` with less interinfluence.
2. Avoid using ```stream->reset()```. Use ```stream->close()``` instead.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
