### PR TITLE
cmake: link missing primitives library to core_api

### DIFF
--- a/core/runtime/runtime_api/impl/CMakeLists.txt
+++ b/core/runtime/runtime_api/impl/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 add_library(core_api core.cpp)
-target_link_libraries(core_api executor)
+target_link_libraries(core_api executor primitives)
 kagome_install(core_api)
 
 add_library(account_nonce_api account_nonce_api.cpp)


### PR DESCRIPTION
### Motivation

Our CI currently fails with the following linking error:

```
/usr/bin/ld: /home/runner/.hunter/_Base/6524c01/84437e3/2662c0c/Install/lib/kagome/libcore_api.a(core.cpp.o): in function `scale::ScaleDecoderStream& kagome::primitives::operator>><scale::ScaleDecoderStream, void>(scale::ScaleDecoderStream&, kagome::primitives::Version&)':
core.cpp:(.text._ZN6kagome10primitivesrsIN5scale18ScaleDecoderStreamEvEERT_S5_RNS0_7VersionE[_ZN6kagome10primitivesrsIN5scale18ScaleDecoderStreamEvEERT_S5_RNS0_7VersionE]+0x1d2): undefined reference to `kagome::primitives::detail::coreVersionFromApis(std::vector<std::pair<kagome::common::Blob<8ul>, unsigned int>, std::allocator<std::pair<kagome::common::Blob<8ul>, unsigned int> > > const&)'
```

### Description of the Change

Because `core_api` uses the scale version decoder implemented in `primitives`, it needs to be linked to that implementation. This PR makes sure this is communicated via the exported package configuration that CMake provides.

### Benefits

Dependency is correctly defined, CMake can do the correct thing.