### PR TITLE
Save lp2p key

### DIFF
--- a/core/crypto/crypto_store/crypto_store_impl.cpp
+++ b/core/crypto/crypto_store/crypto_store_impl.cpp
@@ -238,8 +238,7 @@ namespace kagome::crypto {
     return ed25519KeyToLibp2pKeypair(kp);
   }
 
-  libp2p::crypto::KeyPair CryptoStoreImpl::ed25519KeyToLibp2pKeypair(
-      const Ed25519Keypair &kp) const {
+  libp2p::crypto::KeyPair ed25519KeyToLibp2pKeypair(const Ed25519Keypair &kp) {
     const auto &secret_key = kp.secret_key;
     const auto &public_key = kp.public_key;
     libp2p::crypto::PublicKey lp2p_public{

--- a/core/crypto/crypto_store/crypto_store_impl.hpp
+++ b/core/crypto/crypto_store/crypto_store_impl.hpp
@@ -32,6 +32,8 @@ namespace kagome::crypto {
     WRONG_PUBLIC_KEY,
   };
 
+  libp2p::crypto::KeyPair ed25519KeyToLibp2pKeypair(const Ed25519Keypair &kp);
+
   /// TODO(Harrm) Add policies to emit a warning when found a keypair
   /// with incompatible type and algorithm (e. g. ed25519 BABE keypair,
   /// whereas BABE has to be sr25519 only) or when trying to generate more
@@ -184,9 +186,6 @@ namespace kagome::crypto {
       }
       return it->second;
     }
-
-    libp2p::crypto::KeyPair ed25519KeyToLibp2pKeypair(
-        const Ed25519Keypair &kp) const;
 
     mutable std::unordered_map<KeyTypeId, KeyCache<EcdsaSuite>> ecdsa_caches_;
     mutable std::unordered_map<KeyTypeId, KeyCache<Ed25519Suite>> ed_caches_;


### PR DESCRIPTION
### Referenced issues
https://github.com/soramitsu/kagome/issues/1072

### Description of the Change
Try to save generated lp2p key.

### Benefits
Peer id preserved across restarts.

### Possible Drawbacks 
### Usage Examples or Tests
### Alternate Designs