### PR TITLE
Improves in grandpa

### DIFF
--- a/core/network/impl/peer_manager_impl.cpp
+++ b/core/network/impl/peer_manager_impl.cpp
@@ -627,7 +627,7 @@ namespace kagome::network {
               auto &r_info = r_info_opt.value();
               auto &o_info = o_info_opt.value();
 
-              if (r_info.best_block.number == o_info.best_block.number) {
+              if (r_info.best_block.number <= o_info.best_block.number) {
                 auto grandpa_protocol = self->router_->getGrandpaProtocol();
                 BOOST_ASSERT_MSG(grandpa_protocol,
                                  "Router did not provide grandpa protocol");

--- a/core/network/impl/peer_manager_impl.cpp
+++ b/core/network/impl/peer_manager_impl.cpp
@@ -564,13 +564,15 @@ namespace kagome::network {
       block_announce_protocol->newOutgoingStream(
           peer_info,
           [wp = weak_from_this(),
-           peer_id = peer_info.id,
+           peer_info,
            protocol = block_announce_protocol,
            connection](auto &&stream_res) {
             auto self = wp.lock();
             if (not self) {
               return;
             }
+
+            auto &peer_id = peer_info.id;
 
             self->stream_engine_->dropReserveOutgoing(peer_id, protocol);
             if (not stream_res.has_value()) {
@@ -617,6 +619,22 @@ namespace kagome::network {
 
             self->reserveStreams(peer_id);
             self->startPingingPeer(peer_id);
+
+            // Establish outgoing grandpa stream if node synced
+            auto r_info_opt = self->getPeerState(peer_id);
+            auto o_info_opt = self->getPeerState(self->own_peer_info_.id);
+            if (r_info_opt.has_value() and o_info_opt.has_value()) {
+              auto &r_info = r_info_opt.value();
+              auto &o_info = o_info_opt.value();
+
+              if (r_info.best_block.number == o_info.best_block.number) {
+                auto grandpa_protocol = self->router_->getGrandpaProtocol();
+                BOOST_ASSERT_MSG(grandpa_protocol,
+                                 "Router did not provide grandpa protocol");
+                grandpa_protocol->newOutgoingStream(peer_info,
+                                                    [](const auto &...) {});
+              }
+            }
           });
     } else {
       SL_DEBUG(log_,
@@ -630,7 +648,7 @@ namespace kagome::network {
         host_.getPeerRepository().getAddressRepository().getAddresses(peer_id);
     if (addresses_res.has_value()) {
       auto &addresses = addresses_res.value();
-      PeerInfo peer_info{.id = peer_id, .addresses = std::move(addresses)};
+      peer_info.addresses = std::move(addresses);
       kademlia_->addPeer(peer_info, false);
     }
   }

--- a/core/network/impl/protocols/grandpa_protocol.hpp
+++ b/core/network/impl/protocols/grandpa_protocol.hpp
@@ -112,8 +112,11 @@ namespace kagome::network {
     std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
     const libp2p::peer::Protocol protocol_;
 
-    std::set<std::tuple<libp2p::peer::PeerId, CatchUpRequest::Fingerprint>>
-        recent_catchup_requests_;
+    std::set<std::tuple<consensus::grandpa::RoundNumber,
+                        consensus::grandpa::MembershipCounter>>
+        recent_catchup_requests_by_round_;
+
+    std::set<libp2p::peer::PeerId> recent_catchup_requests_by_peer_;
 
     log::Logger log_ = log::createLogger("GrandpaProtocol", "grandpa_protocol");
   };


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues
Relates to #1260 

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
Create outgoing grandpa stream at block-announce stream just established and node is already synced.
Send initial neighbor-message instead broadcast.
Not send catch-up request to round, if it has already send.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Less lags of finalization