### PR TITLE
Support for version tags with prefix v

### DIFF
--- a/get_version.sh
+++ b/get_version.sh
@@ -20,7 +20,7 @@ if [ -x "$(which git 2>/dev/null)" ] && [ -d ".git" ]; then
       DESCR=$HEAD-0-g$HEAD
     fi
 
-    TAG_IN_MASTER=$(echo $DESCR | sed "s/\(.*\)-\([0-9]\+\)\-g\w\+/\1/")
+    TAG_IN_MASTER=$(echo $DESCR | sed "s/v\?\(.*\)-\([0-9]\+\)\-g\w\+/\1/")
     TAG_TO_FORK_DISTANCE=$(echo $DESCR | sed "s/\(.*\)-\([0-9]\+\)\-g\w\+/\2/")
 
     BRANCH=$(git branch --show-current)


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change

polkadot.js expects version being reported as semver. But version tags in git are usually provided with prefix 'v' (like v0.0.7).
This fix adds support for such tags.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs <!-- Optional -->

<!-- Explain what other alternates were considered and why the proposed version was selected -->
