### PR TITLE
parachain availability store

### DIFF
--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -108,6 +108,7 @@
 #include "offchain/impl/offchain_worker_impl.hpp"
 #include "offchain/impl/offchain_worker_pool_impl.hpp"
 #include "outcome/outcome.hpp"
+#include "parachain/availability/store/store_impl.hpp"
 #include "parachain/validator/parachain_observer.hpp"
 #include "parachain/validator/parachain_processor.hpp"
 #include "runtime/binaryen/binaryen_memory_provider.hpp"
@@ -1182,6 +1183,7 @@ namespace {
         di::bind<storage::changes_trie::ChangesTracker>.template to<storage::changes_trie::StorageChangesTrackerImpl>(),
         bind_by_lambda<network::StateProtocolObserver>(get_state_observer_impl),
         bind_by_lambda<network::SyncProtocolObserver>(get_sync_observer_impl),
+        di::bind<parachain::AvailabilityStore>.template to<parachain::AvailabilityStoreImpl>(),
         di::bind<parachain::ParachainObserverImpl>.to([](auto const &injector) {
           return get_parachain_observer_impl(injector);
         }),

--- a/core/network/types/collator_messages.hpp
+++ b/core/network/types/collator_messages.hpp
@@ -19,10 +19,6 @@
 #include "scale/tie.hpp"
 #include "storage/trie/types.hpp"
 
-/*
- *
-
- * */
 namespace kagome::network {
   using Signature = crypto::Sr25519Signature;
   using ParachainId = uint32_t;
@@ -31,6 +27,8 @@ namespace kagome::network {
   using UpwardMessage = common::Buffer;
   using ParachainRuntime = common::Buffer;
   using HeadData = common::Buffer;
+  using CandidateHash = primitives::BlockHash;
+  using ChunkProof = std::vector<common::Buffer>;
 
   /// NU element.
   using Dummy = std::tuple<>;
@@ -59,6 +57,18 @@ namespace kagome::network {
     ParachainId para_id;            /// Parachain Id.
     Signature signature;  /// Signature of the collator using the PeerId of the
                           /// collators node.
+  };
+
+  /// A chunk of erasure-encoded block data.
+  struct ErasureChunk {
+    SCALE_TIE(3);
+
+    /// The erasure-encoded chunk of data belonging to the candidate block.
+    common::Buffer chunk;
+    /// The index of this erasure-encoded chunk of data.
+    ValidatorIndex index;
+    /// Proof for this chunk's branch in the Merkle tree.
+    ChunkProof proof;
   };
 
   /**

--- a/core/parachain/CMakeLists.txt
+++ b/core/parachain/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 add_library(validator_parachain
+    availability/store/store_impl.cpp
     validator/impl/parachain_observer.cpp
     validator/impl/parachain_processor.cpp
     )

--- a/core/parachain/availability/store/store.hpp
+++ b/core/parachain/availability/store/store.hpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_PARACHAIN_AVAILABILITY_STORE_STORE_HPP
+#define KAGOME_PARACHAIN_AVAILABILITY_STORE_STORE_HPP
+
+#include <optional>
+
+#include "network/types/collator_messages.hpp"
+#include "runtime/runtime_api/parachain_host_types.hpp"
+
+namespace kagome::parachain {
+  /// Stores ErasureChunk, PoV and PersistedValidationData
+  class AvailabilityStore {
+   public:
+    using CandidateHash = network::CandidateHash;
+    using ValidatorIndex = network::ValidatorIndex;
+    using ErasureChunk = network::ErasureChunk;
+    using ParachainBlock = network::ParachainBlock;
+    using PersistedValidationData = runtime::PersistedValidationData;
+
+    virtual ~AvailabilityStore() = 0;
+
+    /// Has ErasureChunk
+    virtual bool hasChunk(const CandidateHash &candidate_hash,
+                          ValidatorIndex index) = 0;
+    /// Has PoV
+    virtual bool hasPov(const CandidateHash &candidate_hash) = 0;
+    /// Has PersistedValidationData
+    virtual bool hasData(const CandidateHash &candidate_hash) = 0;
+    /// Get ErasureChunk
+    virtual std::optional<ErasureChunk> getChunk(
+        const CandidateHash &candidate_hash, ValidatorIndex index) = 0;
+    /// Get PoV
+    virtual std::optional<ParachainBlock> getPov(
+        const CandidateHash &candidate_hash) = 0;
+    /// Store ErasureChunk
+    virtual void putChunk(const CandidateHash &candidate_hash,
+                          const ErasureChunk &chunk) = 0;
+    /// Store PoV
+    virtual void putPov(const CandidateHash &candidate_hash,
+                        const ParachainBlock &pov) = 0;
+    /// Store PersistedValidationData
+    virtual void putData(const CandidateHash &candidate_hash,
+                         const PersistedValidationData &data) = 0;
+  };
+}  // namespace kagome::parachain
+
+#endif  // KAGOME_PARACHAIN_AVAILABILITY_STORE_STORE_HPP

--- a/core/parachain/availability/store/store_impl.cpp
+++ b/core/parachain/availability/store/store_impl.cpp
@@ -1,0 +1,71 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "parachain/availability/store/store_impl.hpp"
+
+namespace kagome::parachain {
+  bool AvailabilityStoreImpl::hasChunk(const CandidateHash &candidate_hash,
+                                       ValidatorIndex index) {
+    auto it = per_candidate_.find(candidate_hash);
+    if (it == per_candidate_.end()) {
+      return false;
+    }
+    return it->second.chunks.count(index) != 0;
+  }
+
+  bool AvailabilityStoreImpl::hasPov(const CandidateHash &candidate_hash) {
+    auto it = per_candidate_.find(candidate_hash);
+    if (it == per_candidate_.end()) {
+      return false;
+    }
+    return it->second.pov.has_value();
+  }
+
+  bool AvailabilityStoreImpl::hasData(const CandidateHash &candidate_hash) {
+    auto it = per_candidate_.find(candidate_hash);
+    if (it == per_candidate_.end()) {
+      return false;
+    }
+    return it->second.data.has_value();
+  }
+
+  std::optional<AvailabilityStore::ErasureChunk>
+  AvailabilityStoreImpl::getChunk(const CandidateHash &candidate_hash,
+                                  ValidatorIndex index) {
+    auto it = per_candidate_.find(candidate_hash);
+    if (it == per_candidate_.end()) {
+      return std::nullopt;
+    }
+    auto it2 = it->second.chunks.find(index);
+    if (it2 == it->second.chunks.end()) {
+      return std::nullopt;
+    }
+    return it2->second;
+  }
+
+  std::optional<AvailabilityStore::ParachainBlock>
+  AvailabilityStoreImpl::getPov(const CandidateHash &candidate_hash) {
+    auto it = per_candidate_.find(candidate_hash);
+    if (it == per_candidate_.end()) {
+      return std::nullopt;
+    }
+    return it->second.pov;
+  }
+
+  void AvailabilityStoreImpl::putChunk(const CandidateHash &candidate_hash,
+                                       const ErasureChunk &chunk) {
+    per_candidate_[candidate_hash].chunks[chunk.index] = chunk;
+  }
+
+  void AvailabilityStoreImpl::putPov(const CandidateHash &candidate_hash,
+                                     const ParachainBlock &pov) {
+    per_candidate_[candidate_hash].pov = pov;
+  }
+
+  void AvailabilityStoreImpl::putData(const CandidateHash &candidate_hash,
+                                      const PersistedValidationData &data) {
+    per_candidate_[candidate_hash].data = data;
+  }
+}  // namespace kagome::parachain

--- a/core/parachain/availability/store/store_impl.hpp
+++ b/core/parachain/availability/store/store_impl.hpp
@@ -1,0 +1,44 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_PARACHAIN_AVAILABILITY_STORE_STORE_IMPL_HPP
+#define KAGOME_PARACHAIN_AVAILABILITY_STORE_STORE_IMPL_HPP
+
+#include "parachain/availability/store/store.hpp"
+
+#include <unordered_map>
+
+namespace kagome::parachain {
+  class AvailabilityStoreImpl : public AvailabilityStore {
+   public:
+    ~AvailabilityStoreImpl() override = default;
+
+    bool hasChunk(const CandidateHash &candidate_hash,
+                  ValidatorIndex index) override;
+    bool hasPov(const CandidateHash &candidate_hash) override;
+    bool hasData(const CandidateHash &candidate_hash) override;
+    std::optional<ErasureChunk> getChunk(const CandidateHash &candidate_hash,
+                                         ValidatorIndex index) override;
+    std::optional<ParachainBlock> getPov(
+        const CandidateHash &candidate_hash) override;
+    void putChunk(const CandidateHash &candidate_hash,
+                  const ErasureChunk &chunk) override;
+    void putPov(const CandidateHash &candidate_hash,
+                const ParachainBlock &pov) override;
+    void putData(const CandidateHash &candidate_hash,
+                 const PersistedValidationData &data) override;
+
+   private:
+    struct PerCandidate {
+      std::unordered_map<ValidatorIndex, ErasureChunk> chunks;
+      std::optional<ParachainBlock> pov;
+      std::optional<PersistedValidationData> data;
+    };
+
+    std::unordered_map<CandidateHash, PerCandidate> per_candidate_;
+  };
+}  // namespace kagome::parachain
+
+#endif  // KAGOME_PARACHAIN_AVAILABILITY_STORE_STORE_IMPL_HPP


### PR DESCRIPTION
### Referenced issues
- https://github.com/soramitsu/kagome/issues/1311

### Description of the Change
Add availability store interface.

### Benefits
- Store chunks, pov and data.
- Interface will be used by multiple components (candidate backing, availability distribution, ...).

### Possible Drawbacks
- Implement pruning later.

### Usage Examples or Tests

### Alternate Designs
- Will read/write database later.