### PR TITLE
Fix block tree queries

### DIFF
--- a/core/blockchain/block_tree.hpp
+++ b/core/blockchain/block_tree.hpp
@@ -143,16 +143,6 @@ namespace kagome::blockchain {
         const primitives::BlockHash &block,
         const primitives::Justification &justification) = 0;
 
-    /**
-     * Get a chain of blocks from the specified as a (\param block) up to the
-     * closest finalized one
-     * @param block to get a chain from
-     * @return chain of blocks in top-to-bottom order (from the last finalized
-     * block to the provided one) or error
-     */
-    virtual BlockHashVecRes getChainByBlock(
-        const primitives::BlockHash &block) const = 0;
-
     enum class GetChainDirection { ASCEND, DESCEND };
 
     /**
@@ -204,15 +194,6 @@ namespace kagome::blockchain {
     virtual bool hasDirectChain(
         const primitives::BlockHash &ancestor,
         const primitives::BlockHash &descendant) const = 0;
-
-    /**
-     * Get a longest path (chain of blocks) from the last finalized block down
-     * to the deepest leaf
-     * @return chain of blocks or error
-     *
-     * @note this function is equivalent to "getChainByBlock(deepestLeaf())"
-     */
-    virtual BlockHashVecRes longestPath() const = 0;
 
     /**
      * Get a deepest leaf of the tree

--- a/core/blockchain/block_tree.hpp
+++ b/core/blockchain/block_tree.hpp
@@ -164,26 +164,15 @@ namespace kagome::blockchain {
         const primitives::BlockHash &block, uint64_t maximum) const = 0;
 
     /**
-     * Get a chain of blocks
-     * @param top_block - block, which is at the top of the chain
-     * @param bottom_block - block, which is the bottom of the chain
-     * @return chain of blocks in top-to-bottom order or error
+     * Get a chain of blocks.
+     * Implies `hasDirectChain(ancestor, descendant)`.
+     * @param ancestor - block, which is closest to the genesis
+     * @param descendant - block, which is farthest from the genesis
+     * @return chain of blocks in ascending order or error
      */
     virtual BlockHashVecRes getChainByBlocks(
-        const primitives::BlockHash &top_block,
-        const primitives::BlockHash &bottom_block) const = 0;
-
-    /**
-     * Get a chain of blocks
-     * @param top_block - block, which is at the top of the chain
-     * @param bottom_block - block, which is the bottom of the chain
-     * @param max_count - maximum blocks in the chain
-     * @return chain of blocks in top-to-bottom order or error
-     */
-    virtual BlockHashVecRes getChainByBlocks(
-        const primitives::BlockHash &top_block,
-        const primitives::BlockHash &bottom_block,
-        uint32_t max_count) const = 0;
+        const primitives::BlockHash &ancestor,
+        const primitives::BlockHash &descendant) const = 0;
 
     /**
      * Check if one block is ancestor of second one (direct chain exists)

--- a/core/blockchain/impl/block_tree_impl.cpp
+++ b/core/blockchain/impl/block_tree_impl.cpp
@@ -917,12 +917,6 @@ namespace kagome::blockchain {
     return BlockTreeError::JUSTIFICATION_NOT_FOUND;
   }
 
-  BlockTreeImpl::BlockHashVecRes BlockTreeImpl::getChainByBlock(
-      const primitives::BlockHash &block) const {
-    return getChainByBlocks(
-        tree_->getMetadata().last_finalized.lock()->block_hash, block);
-  }
-
   BlockTree::BlockHashVecRes BlockTreeImpl::getBestChainFromBlock(
       const primitives::BlockHash &block, uint64_t maximum) const {
     auto block_number_res = header_repo_->getNumberByHash(block);
@@ -1213,11 +1207,6 @@ namespace kagome::blockchain {
     }
     KAGOME_PROFILE_END(search_finalized_chain)
     return true;
-  }
-
-  BlockTreeImpl::BlockHashVecRes BlockTreeImpl::longestPath() const {
-    auto &&[_, block_hash] = deepestLeaf();
-    return getChainByBlock(block_hash);
   }
 
   primitives::BlockInfo BlockTreeImpl::deepestLeaf() const {

--- a/core/blockchain/impl/block_tree_impl.cpp
+++ b/core/blockchain/impl/block_tree_impl.cpp
@@ -1163,6 +1163,9 @@ namespace kagome::blockchain {
     if (ancestor_node_ptr && descendant_node_ptr) {
       auto current_node = descendant_node_ptr;
       while (current_node != ancestor_node_ptr) {
+        if (current_node->depth <= ancestor_node_ptr->depth) {
+          return false;
+        }
         if (auto parent = current_node->parent; !parent.expired()) {
           current_node = parent.lock();
         } else {
@@ -1201,6 +1204,9 @@ namespace kagome::blockchain {
     while (current_hash != ancestor) {
       auto current_header_res = header_repo_->getBlockHeader(current_hash);
       if (!current_header_res) {
+        return false;
+      }
+      if (current_header_res.value().number <= ancestor_depth) {
         return false;
       }
       current_hash = current_header_res.value().parent_hash;

--- a/core/blockchain/impl/block_tree_impl.cpp
+++ b/core/blockchain/impl/block_tree_impl.cpp
@@ -953,20 +953,19 @@ namespace kagome::blockchain {
 
   BlockTree::BlockHashVecRes BlockTreeImpl::getDescendingChainToBlock(
       const primitives::BlockHash &to_block, uint64_t maximum) const {
-    std::deque<primitives::BlockHash> chain;
+    std::vector<primitives::BlockHash> chain;
 
     auto hash = to_block;
 
     // Try to retrieve from cached tree
     if (auto node = tree_->getRoot().findByHash(hash)) {
-      chain.emplace_back(hash);
       while (maximum > chain.size()) {
         auto parent = node->parent.lock();
         if (not parent) {
           hash = node->block_hash;
           break;
         }
-        chain.emplace_back(parent->block_hash);
+        chain.emplace_back(node->block_hash);
         node = parent;
       }
     }
@@ -986,14 +985,14 @@ namespace kagome::blockchain {
 
       chain.emplace_back(hash);
 
-      if (header.parent_hash == primitives::BlockHash{}) {
+      if (header.number == 0) {
         break;
       }
 
       hash = header.parent_hash;
     }
 
-    return std::vector<primitives::BlockHash>(chain.begin(), chain.end());
+    return chain;
   }
 
   BlockTreeImpl::BlockHashVecRes BlockTreeImpl::getChainByBlocks(

--- a/core/blockchain/impl/block_tree_impl.hpp
+++ b/core/blockchain/impl/block_tree_impl.hpp
@@ -111,10 +111,6 @@ namespace kagome::blockchain {
         const primitives::BlockHash &block_hash,
         const primitives::Justification &justification) override;
 
-    BlockHashVecRes getChainByBlocks(const primitives::BlockHash &top_block,
-                                     const primitives::BlockHash &bottom_block,
-                                     uint32_t max_count) const override;
-
     BlockHashVecRes getBestChainFromBlock(const primitives::BlockHash &block,
                                           uint64_t maximum) const override;
 
@@ -122,8 +118,8 @@ namespace kagome::blockchain {
         const primitives::BlockHash &block, uint64_t maximum) const override;
 
     BlockHashVecRes getChainByBlocks(
-        const primitives::BlockHash &top_block,
-        const primitives::BlockHash &bottom_block) const override;
+        const primitives::BlockHash &ancestor,
+        const primitives::BlockHash &descendant) const override;
 
     std::optional<primitives::Version> runtimeVersion() const override {
       return actual_runtime_version_;
@@ -179,15 +175,6 @@ namespace kagome::blockchain {
     outcome::result<primitives::BlockHash> walkBackUntilLess(
         const primitives::BlockHash &start,
         const primitives::BlockNumber &limit) const;
-
-    std::optional<std::vector<primitives::BlockHash>>
-    tryGetChainByBlocksFromCache(const primitives::BlockInfo &top_block,
-                                 const primitives::BlockInfo &bottom_block,
-                                 std::optional<uint32_t> max_count) const;
-
-    BlockHashVecRes getChainByBlocks(const primitives::BlockHash &top_block,
-                                     const primitives::BlockHash &bottom_block,
-                                     std::optional<uint32_t> max_count) const;
 
     /**
      * @returns the tree leaves sorted by their depth

--- a/core/blockchain/impl/block_tree_impl.hpp
+++ b/core/blockchain/impl/block_tree_impl.hpp
@@ -111,9 +111,6 @@ namespace kagome::blockchain {
         const primitives::BlockHash &block_hash,
         const primitives::Justification &justification) override;
 
-    BlockHashVecRes getChainByBlock(
-        const primitives::BlockHash &block) const override;
-
     BlockHashVecRes getChainByBlocks(const primitives::BlockHash &top_block,
                                      const primitives::BlockHash &bottom_block,
                                      uint32_t max_count) const override;
@@ -134,8 +131,6 @@ namespace kagome::blockchain {
 
     bool hasDirectChain(const primitives::BlockHash &ancestor,
                         const primitives::BlockHash &descendant) const override;
-
-    BlockHashVecRes longestPath() const override;
 
     primitives::BlockInfo deepestLeaf() const override;
 

--- a/core/consensus/babe/babe_lottery.hpp
+++ b/core/consensus/babe/babe_lottery.hpp
@@ -66,27 +66,6 @@ namespace kagome::consensus {
         primitives::BabeSlotNumber slot) const = 0;
 
     /**
-     * Compute randomness for the next epoch
-     * @param last_epoch_randomness - randomness of the last epoch
-     * @param new_epoch_number - index of the new epoch
-     * @return computed randomness
-     *
-     * @note must be called exactly ONCE per epoch, when it gets changed
-     */
-    virtual Randomness computeRandomness(
-        const Randomness &last_epoch_randomness,
-        EpochNumber new_epoch_number) = 0;
-
-    /**
-     * Submit a VRF value for this epoch
-     * @param value to be submitted
-     *
-     * @note concatenation of those values is participating in computation of
-     * the randomness for the next epoch
-     */
-    virtual void submitVRFValue(const crypto::VRFPreOutput &value) = 0;
-
-    /**
      * Compute the expected author for secondary slot
      * @param slot - slot to have secondary block produced
      * @param authorities_count - quantity of authorities in current epoch

--- a/core/consensus/babe/impl/babe_lottery_impl.cpp
+++ b/core/consensus/babe/impl/babe_lottery_impl.cpp
@@ -29,7 +29,6 @@ namespace kagome::consensus {
     BOOST_ASSERT(hasher_);
     BOOST_ASSERT(logger_);
     BOOST_ASSERT(configuration);
-    epoch_length_ = configuration->epoch_length;
     epoch_.epoch_number = std::numeric_limits<uint64_t>::max();
   }
 
@@ -89,43 +88,6 @@ namespace kagome::consensus {
 
     BOOST_ASSERT(res);
     return res.value();
-  }
-
-  Randomness BabeLotteryImpl::computeRandomness(
-      const Randomness &last_epoch_randomness, EpochNumber last_epoch_number) {
-    static std::unordered_set<EpochNumber> computed_epochs_randomnesses{};
-
-    // the function must never be called twice for the same epoch
-    BOOST_ASSERT(computed_epochs_randomnesses.insert(last_epoch_number).second);
-
-    // randomness || epoch_number || rho
-    Buffer new_randomness(
-        vrf_constants::OUTPUT_SIZE + 8 + last_epoch_vrf_values_.size() * 32, 0);
-
-    std::copy(last_epoch_randomness.begin(),
-              last_epoch_randomness.end(),
-              new_randomness.begin());
-
-    auto epoch_number_bytes = common::uint64_to_le_bytes(last_epoch_number);
-    std::copy(epoch_number_bytes.begin(),
-              epoch_number_bytes.end(),
-              new_randomness.begin() + vrf_constants::OUTPUT_SIZE);
-
-    auto new_vrf_value_begin =
-        new_randomness.begin() + vrf_constants::OUTPUT_SIZE + 8;
-    // NOLINTNEXTLINE
-    for (size_t i = 0; i < last_epoch_vrf_values_.size(); ++i) {
-      auto const &value_bytes = last_epoch_vrf_values_[i];
-      std::copy(value_bytes.begin(), value_bytes.end(), new_vrf_value_begin);
-      new_vrf_value_begin += 32;
-    }
-    last_epoch_vrf_values_.clear();
-
-    return hasher_->blake2b_256(new_randomness);
-  }
-
-  void BabeLotteryImpl::submitVRFValue(const crypto::VRFPreOutput &value) {
-    last_epoch_vrf_values_.push_back(value);
   }
 
   std::optional<primitives::AuthorityIndex>

--- a/core/consensus/babe/impl/babe_lottery_impl.hpp
+++ b/core/consensus/babe/impl/babe_lottery_impl.hpp
@@ -36,11 +36,6 @@ namespace kagome::consensus {
     crypto::VRFOutput slotVrfSignature(
         primitives::BabeSlotNumber slot) const override;
 
-    Randomness computeRandomness(const Randomness &last_epoch_randomness,
-                                 EpochNumber last_epoch_number) override;
-
-    void submitVRFValue(const crypto::VRFPreOutput &value) override;
-
     std::optional<primitives::AuthorityIndex> secondarySlotAuthor(
         primitives::BabeSlotNumber slot,
         primitives::AuthorityListSize authorities_count,
@@ -49,10 +44,7 @@ namespace kagome::consensus {
    private:
     std::shared_ptr<crypto::VRFProvider> vrf_provider_;
     std::shared_ptr<crypto::Hasher> hasher_;
-    EpochLength epoch_length_;
 
-    /// also known as "rho" (greek letter) in the spec
-    std::vector<crypto::VRFPreOutput> last_epoch_vrf_values_;
     log::Logger logger_;
 
     EpochDescriptor epoch_;

--- a/test/core/blockchain/block_tree_test.cpp
+++ b/test/core/blockchain/block_tree_test.cpp
@@ -683,36 +683,6 @@ TEST_F(BlockTreeTest, TreeNode_applyToChain_exitTokenWorks) {
 
 /**
  * @given block tree with at least three blocks inside
- * @when asking for chain from the lowest block to the closest finalized one
- * @then chain from that block to the last finalized one is returned
- */
-TEST_F(BlockTreeTest, GetChainByBlockOnly) {
-  // GIVEN
-  BlockHeader header1{.parent_hash = kFinalizedBlockInfo.hash,
-                      .number = kFinalizedBlockInfo.number + 1,
-                      .digest = {PreRuntime{}}};
-  BlockBody body1{{Buffer{0x55, 0x55}}};
-  Block block1{header1, body1};
-  auto hash1 = addBlock(block1);
-
-  BlockHeader header2{.parent_hash = hash1,
-                      .number = header1.number + 1,
-                      .digest = {Consensus{}}};
-  BlockBody body2{{Buffer{0x55, 0x55}}};
-  Block block2{header2, body2};
-  auto hash2 = addBlock(block2);
-
-  std::vector<BlockHash> expected_chain{kFinalizedBlockInfo.hash, hash1, hash2};
-
-  // WHEN
-  ASSERT_OUTCOME_SUCCESS(chain, block_tree_->getChainByBlock(hash2))
-
-  // THEN
-  ASSERT_EQ(chain, expected_chain);
-}
-
-/**
- * @given block tree with at least three blocks inside
  * @when asking for chain from the given block to top
  * @then expected chain is returned
  */

--- a/test/core/blockchain/block_tree_test.cpp
+++ b/test/core/blockchain/block_tree_test.cpp
@@ -738,7 +738,7 @@ TEST_F(BlockTreeTest, GetChainByBlockDescending) {
   EXPECT_CALL(*header_repo_, getBlockHeader({kFinalizedBlockInfo.hash}))
       .WillOnce(Return(BlockTreeError::HEADER_NOT_FOUND));
 
-  std::vector<BlockHash> expected_chain{hash2, hash1, kFinalizedBlockInfo.hash};
+  std::vector<BlockHash> expected_chain{hash2, hash1};
 
   // WHEN
   ASSERT_OUTCOME_SUCCESS(chain,

--- a/test/mock/core/blockchain/block_tree_mock.hpp
+++ b/test/mock/core/blockchain/block_tree_mock.hpp
@@ -91,13 +91,6 @@ namespace kagome::blockchain {
                 (const primitives::BlockHash &, const primitives::BlockHash &),
                 (const, override));
 
-    MOCK_METHOD(BlockHashVecRes,
-                getChainByBlocks,
-                (const primitives::BlockHash &,
-                 const primitives::BlockHash &,
-                 const uint32_t),
-                (const, override));
-
     MOCK_METHOD(bool,
                 hasDirectChain,
                 (const primitives::BlockHash &, const primitives::BlockHash &),

--- a/test/mock/core/blockchain/block_tree_mock.hpp
+++ b/test/mock/core/blockchain/block_tree_mock.hpp
@@ -77,11 +77,6 @@ namespace kagome::blockchain {
                 (override));
 
     MOCK_METHOD(BlockHashVecRes,
-                getChainByBlock,
-                (const primitives::BlockHash &),
-                (const, override));
-
-    MOCK_METHOD(BlockHashVecRes,
                 getBestChainFromBlock,
                 (const primitives::BlockHash &, uint64_t),
                 (const, override));
@@ -114,8 +109,6 @@ namespace kagome::blockchain {
                  const std::optional<primitives::BlockNumber> &),
                 (const, override));
 
-    MOCK_METHOD(BlockHashVecRes, longestPath, (), (const, override));
-
     MOCK_METHOD(primitives::BlockInfo, deepestLeaf, (), (const, override));
 
     MOCK_METHOD(std::vector<primitives::BlockHash>,
@@ -129,8 +122,6 @@ namespace kagome::blockchain {
                 (const, override));
 
     MOCK_METHOD(primitives::BlockInfo, getLastFinalized, (), (const, override));
-
-    MOCK_METHOD(outcome::result<void>, prune, (), ());
 
     MOCK_METHOD(outcome::result<consensus::EpochDigest>,
                 getEpochDigest,

--- a/test/mock/core/consensus/babe_lottery_mock.hpp
+++ b/test/mock/core/consensus/babe_lottery_mock.hpp
@@ -32,16 +32,6 @@ namespace kagome::consensus {
                 (primitives::BabeSlotNumber),
                 (const, override));
 
-    MOCK_METHOD(Randomness,
-                computeRandomness,
-                (const Randomness &, EpochNumber),
-                (override));
-
-    MOCK_METHOD(void,
-                submitVRFValue,
-                (const crypto::VRFPreOutput &),
-                (override));
-
     MOCK_METHOD(std::optional<primitives::AuthorityIndex>,
                 secondarySlotAuthor,
                 (primitives::BabeSlotNumber,


### PR DESCRIPTION
### Referenced issues
### Description of the Change
- Remove unused babe lottery and block tree code.
- Fix descending blocks query and test.
- Check forks earlier in `hasDirectChain`.
- Simplify and fix ascending blocks queries, because they are just descending blocks queries with reversed result.

### Benefits
- Fixes wrong block requests near fork (kagome responded with wrong block).

### Possible Drawbacks 
### Usage Examples or Tests
### Alternate Designs

