### PR TITLE
graceful close duplicate incoming notification stream

### DIFF
--- a/core/network/impl/stream_engine.hpp
+++ b/core/network/impl/stream_engine.hpp
@@ -417,7 +417,11 @@ namespace kagome::network {
       bool replaced = false;
       // Reset previous stream if any
       if (dst) {
-        dst->reset();
+        if (direction == Direction::INCOMING) {
+          dst->close([](outcome::result<void>) {});
+        } else {
+          dst->reset();
+        }
         replaced = true;
       }
 


### PR DESCRIPTION
### Referenced issues
- https://github.com/soramitsu/kagome/issues/1218

### Description of the Change
Sometimes polkadot duplicates streams.
Graceful close incoming streams instead of reset (which interrupts reading).

### Benefits
Don't miss incoming messages.

### Possible Drawbacks
### Usage Examples or Tests
### Alternate Designs