### PR TITLE
Babe config repository

### DIFF
--- a/core/blockchain/impl/block_storage_impl.cpp
+++ b/core/blockchain/impl/block_storage_impl.cpp
@@ -55,26 +55,6 @@ namespace kagome::blockchain {
       OUTCOME_TRY(block_storage->setBlockTreeLeaves({genesis_block_hash}));
     }
 
-    // Fallback way to init block tree leaves list on existed storage
-    // TODO(xDimon): After deploy of this change, and using on existing DB,
-    //  this code block should be removed
-    if (block_storage->getBlockTreeLeaves()
-        == outcome::failure(BlockStorageError::BLOCK_TREE_LEAVES_NOT_FOUND)) {
-      using namespace common::literals;
-      OUTCOME_TRY(last_finalized_block_hash_opt,
-                  storage->tryLoad(":kagome:last_finalized_block_hash"_buf));
-      if (not last_finalized_block_hash_opt.has_value()) {
-        return BlockStorageError::FINALIZED_BLOCK_NOT_FOUND;
-      }
-      auto &hash = last_finalized_block_hash_opt.value();
-
-      primitives::BlockHash last_finalized_block_hash;
-      std::copy(hash.begin(), hash.end(), last_finalized_block_hash.begin());
-
-      OUTCOME_TRY(
-          block_storage->setBlockTreeLeaves({last_finalized_block_hash}));
-    }
-
     return block_storage;
   }
 

--- a/core/blockchain/impl/block_tree_impl.cpp
+++ b/core/blockchain/impl/block_tree_impl.cpp
@@ -147,6 +147,16 @@ namespace kagome::blockchain {
 
     OUTCOME_TRY(last_finalized_block_info, storage->getLastFinalized());
 
+    // call chain_events_engine->notify to init babe_config_repo preventive
+    auto finalized_block_header_res =
+        storage->getBlockHeader(last_finalized_block_info.hash);
+    BOOST_ASSERT_MSG(finalized_block_header_res.has_value()
+                         and finalized_block_header_res.value().has_value(),
+                     "Initialized block tree must be have finalized block");
+    chain_events_engine->notify(
+        primitives::events::ChainEventType::kFinalizedHeads,
+        finalized_block_header_res.value().value());
+
     std::optional<consensus::EpochNumber> curr_epoch_number;
 
     // First, look up slot number of block number 1

--- a/core/blockchain/impl/block_tree_impl.hpp
+++ b/core/blockchain/impl/block_tree_impl.hpp
@@ -37,7 +37,9 @@
 namespace kagome::application {
   class AppStateManager;
 }
-
+namespace kagome::consensus::babe {
+  class BabeConfigRepository;
+}
 namespace kagome::storage::changes_trie {
   class ChangesTracker;
 }
@@ -62,7 +64,7 @@ namespace kagome::blockchain {
             extrinsic_event_key_repo,
         std::shared_ptr<runtime::Core> runtime_core,
         std::shared_ptr<storage::changes_trie::ChangesTracker> changes_tracker,
-        std::shared_ptr<primitives::BabeConfiguration> babe_configuration,
+        std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo,
         std::shared_ptr<consensus::BabeUtil> babe_util,
         std::shared_ptr<const class JustificationStoragePolicy>
             justification_storage_policy);

--- a/core/consensus/babe/babe_config_repository.hpp
+++ b/core/consensus/babe/babe_config_repository.hpp
@@ -1,0 +1,28 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_CONSENSUS_BABE_BABECONFIGREPOSITORY
+#define KAGOME_CONSENSUS_BABE_BABECONFIGREPOSITORY
+
+#include "primitives/babe_configuration.hpp"
+
+namespace kagome::consensus::babe {
+
+  /// Keeps actual babe configuration
+  class BabeConfigRepository {
+   public:
+    virtual ~BabeConfigRepository() = default;
+
+    /// Returns actual babe configuration, obtaining it from runtime if needed
+    /// @return actual babe configuration
+    virtual const primitives::BabeConfiguration &config();
+
+    /// Invalidates internally cached config, to enforce take in from runtime
+    virtual void invalidate();
+  };
+
+}  // namespace kagome::consensus::babe
+
+#endif  // KAGOME_CONSENSUS_BABE_BABECONFIGREPOSITORY

--- a/core/consensus/babe/babe_config_repository.hpp
+++ b/core/consensus/babe/babe_config_repository.hpp
@@ -17,10 +17,7 @@ namespace kagome::consensus::babe {
 
     /// Returns actual babe configuration, obtaining it from runtime if needed
     /// @return actual babe configuration
-    virtual const primitives::BabeConfiguration &config();
-
-    /// Invalidates internally cached config, to enforce take in from runtime
-    virtual void invalidate();
+    virtual const primitives::BabeConfiguration &config() = 0;
   };
 
 }  // namespace kagome::consensus::babe

--- a/core/consensus/babe/impl/CMakeLists.txt
+++ b/core/consensus/babe/impl/CMakeLists.txt
@@ -77,6 +77,13 @@ target_link_libraries(consistency_keeper
     block_storage_error
     )
 
+add_library(babe_config_repository
+    babe_config_repository_impl.cpp
+    )
+target_link_libraries(babe_config_repository
+    primitives
+    )
+
 add_library(babe
     babe_impl.cpp
     babe_impl.hpp

--- a/core/consensus/babe/impl/babe_config_repository_impl.cpp
+++ b/core/consensus/babe/impl/babe_config_repository_impl.cpp
@@ -1,0 +1,75 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "babe_config_repository_impl.hpp"
+
+#include "application/app_state_manager.hpp"
+#include "crypto/hasher.hpp"
+#include "primitives/block_header.hpp"
+#include "runtime/runtime_api/babe_api.hpp"
+#include "scale.hpp"
+
+namespace kagome::consensus::babe {
+
+  BabeConfigRepositoryImpl::BabeConfigRepositoryImpl(
+      const std::shared_ptr<application::AppStateManager> &app_state_manager,
+      std::shared_ptr<runtime::BabeApi> babe_api,
+      std::shared_ptr<crypto::Hasher> hasher,
+
+      primitives::events::ChainSubscriptionEnginePtr chain_events_engine,
+      primitives::BlockHash genesis_block_hash)
+      : babe_api_(std::move(babe_api)),
+        hasher_(std::move(hasher)),
+        chain_sub_([&] {
+          BOOST_ASSERT(chain_events_engine != nullptr);
+          return std::make_shared<primitives::events::ChainEventSubscriber>(
+              chain_events_engine);
+        }()),
+        block_hash_(std::move(genesis_block_hash)),
+        valid_(false) {
+    BOOST_ASSERT(babe_api_ != nullptr);
+    BOOST_ASSERT(hasher_ != nullptr);
+
+    BOOST_ASSERT(app_state_manager != nullptr);
+    app_state_manager->atPrepare([this] { return prepare(); });
+  }
+
+  bool BabeConfigRepositoryImpl::prepare() {
+    chain_sub_->subscribe(chain_sub_->generateSubscriptionSetId(),
+                          primitives::events::ChainEventType::kFinalizedHeads);
+    chain_sub_->setCallback([wp = weak_from_this()](
+                                subscription::SubscriptionSetId,
+                                auto &&,
+                                primitives::events::ChainEventType type,
+                                const primitives::events::ChainEventParams
+                                    &event) {
+      if (type != primitives::events::ChainEventType::kFinalizedHeads) {
+        return;
+      }
+      if (auto self = wp.lock()) {
+        auto hash = self->hasher_->blake2b_256(
+            scale::encode(
+                boost::get<primitives::events::HeadsEventParams>(event).get())
+                .value());
+        self->block_hash_ = hash;
+        self->valid_ = false;
+      }
+    });
+
+    return true;
+  }
+
+  const primitives::BabeConfiguration &BabeConfigRepositoryImpl::config() {
+    if (not valid_) {
+      auto babe_config_res = babe_api_->configuration(block_hash_);
+      if (babe_config_res.has_value()) {
+        babe_configuration_ = std::move(babe_config_res.value());
+        valid_ = true;
+      }
+    }
+    return babe_configuration_;
+  }
+
+}  // namespace kagome::consensus::babe

--- a/core/consensus/babe/impl/babe_config_repository_impl.hpp
+++ b/core/consensus/babe/impl/babe_config_repository_impl.hpp
@@ -7,6 +7,7 @@
 #define KAGOME_CONSENSUS_BABE_BABECONFIGREPOSITORYIMPL
 
 #include "consensus/babe/babe_config_repository.hpp"
+#include "primitives/block_header.hpp"
 #include "primitives/event_types.hpp"
 
 namespace kagome::application {
@@ -30,7 +31,7 @@ namespace kagome::consensus::babe {
         std::shared_ptr<runtime::BabeApi> babe_api,
         std::shared_ptr<crypto::Hasher> hasher,
         primitives::events::ChainSubscriptionEnginePtr,
-        primitives::BlockHash genesis_block_hash);
+        const primitives::GenesisBlockHeader &genesis_block_header);
 
     const primitives::BabeConfiguration &config() override;
 
@@ -42,7 +43,7 @@ namespace kagome::consensus::babe {
     std::shared_ptr<primitives::events::ChainEventSubscriber> chain_sub_;
     primitives::BlockHash block_hash_;
 
-    mutable primitives::BabeConfiguration babe_configuration_;
+    mutable primitives::BabeConfiguration babe_configuration_{};
     bool valid_;
   };
 

--- a/core/consensus/babe/impl/babe_config_repository_impl.hpp
+++ b/core/consensus/babe/impl/babe_config_repository_impl.hpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_CONSENSUS_BABE_BABECONFIGREPOSITORYIMPL
+#define KAGOME_CONSENSUS_BABE_BABECONFIGREPOSITORYIMPL
+
+#include "consensus/babe/babe_config_repository.hpp"
+#include "primitives/event_types.hpp"
+
+namespace kagome::application {
+  class AppStateManager;
+}
+namespace kagome::crypto {
+  class Hasher;
+}
+namespace kagome::runtime {
+  class BabeApi;
+}
+
+namespace kagome::consensus::babe {
+
+  class BabeConfigRepositoryImpl final
+      : public BabeConfigRepository,
+        public std::enable_shared_from_this<BabeConfigRepositoryImpl> {
+   public:
+    BabeConfigRepositoryImpl(
+        const std::shared_ptr<application::AppStateManager> &app_state_manager,
+        std::shared_ptr<runtime::BabeApi> babe_api,
+        std::shared_ptr<crypto::Hasher> hasher,
+        primitives::events::ChainSubscriptionEnginePtr,
+        primitives::BlockHash genesis_block_hash);
+
+    const primitives::BabeConfiguration &config() override;
+
+    bool prepare();
+
+   private:
+    std::shared_ptr<runtime::BabeApi> babe_api_;
+    std::shared_ptr<crypto::Hasher> hasher_;
+    std::shared_ptr<primitives::events::ChainEventSubscriber> chain_sub_;
+    primitives::BlockHash block_hash_;
+
+    mutable primitives::BabeConfiguration babe_configuration_;
+    bool valid_;
+  };
+
+}  // namespace kagome::consensus::babe
+
+#endif  // KAGOME_CONSENSUS_BABE_BABECONFIGREPOSITORYIMPL

--- a/core/consensus/babe/impl/babe_impl.hpp
+++ b/core/consensus/babe/impl/babe_impl.hpp
@@ -45,7 +45,11 @@ namespace kagome::runtime {
 }
 
 namespace kagome::consensus::babe {
+  class BabeConfigRepository;
   class ConsistencyKeeper;
+}  // namespace kagome::consensus::babe
+
+namespace kagome::consensus::babe {
 
   inline const auto kTimestampId =
       primitives::InherentIdentifier::fromString("timstap0").value();
@@ -65,25 +69,26 @@ namespace kagome::consensus::babe {
     /**
      * Create an instance of Babe implementation
      */
-    BabeImpl(const application::AppConfiguration &app_config,
-             std::shared_ptr<application::AppStateManager> app_state_manager,
-             std::shared_ptr<BabeLottery> lottery,
-             std::shared_ptr<primitives::BabeConfiguration> configuration,
-             std::shared_ptr<authorship::Proposer> proposer,
-             std::shared_ptr<blockchain::BlockTree> block_tree,
-             std::shared_ptr<network::BlockAnnounceTransmitter>
-                 block_announce_transmitter,
-             std::shared_ptr<crypto::Sr25519Provider> sr25519_provider,
-             const std::shared_ptr<crypto::Sr25519Keypair> &keypair,
-             std::shared_ptr<clock::SystemClock> clock,
-             std::shared_ptr<crypto::Hasher> hasher,
-             std::unique_ptr<clock::Timer> timer,
-             std::shared_ptr<authority::AuthorityUpdateObserver>
-                 authority_update_observer,
-             std::shared_ptr<network::Synchronizer> synchronizer,
-             std::shared_ptr<BabeUtil> babe_util,
-             std::shared_ptr<runtime::OffchainWorkerApi> offchain_worker_api,
-             std::shared_ptr<babe::ConsistencyKeeper> consistency_keeper);
+    BabeImpl(
+        const application::AppConfiguration &app_config,
+        std::shared_ptr<application::AppStateManager> app_state_manager,
+        std::shared_ptr<BabeLottery> lottery,
+        std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo,
+        std::shared_ptr<authorship::Proposer> proposer,
+        std::shared_ptr<blockchain::BlockTree> block_tree,
+        std::shared_ptr<network::BlockAnnounceTransmitter>
+            block_announce_transmitter,
+        std::shared_ptr<crypto::Sr25519Provider> sr25519_provider,
+        const std::shared_ptr<crypto::Sr25519Keypair> &keypair,
+        std::shared_ptr<clock::SystemClock> clock,
+        std::shared_ptr<crypto::Hasher> hasher,
+        std::unique_ptr<clock::Timer> timer,
+        std::shared_ptr<authority::AuthorityUpdateObserver>
+            authority_update_observer,
+        std::shared_ptr<network::Synchronizer> synchronizer,
+        std::shared_ptr<BabeUtil> babe_util,
+        std::shared_ptr<runtime::OffchainWorkerApi> offchain_worker_api,
+        std::shared_ptr<babe::ConsistencyKeeper> consistency_keeper);
 
     ~BabeImpl() override = default;
 
@@ -159,7 +164,7 @@ namespace kagome::consensus::babe {
 
     const application::AppConfiguration &app_config_;
     std::shared_ptr<BabeLottery> lottery_;
-    std::shared_ptr<primitives::BabeConfiguration> babe_configuration_;
+    std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo_;
     std::shared_ptr<authorship::Proposer> proposer_;
     std::shared_ptr<blockchain::BlockTree> block_tree_;
     std::shared_ptr<network::BlockAnnounceTransmitter>

--- a/core/consensus/babe/impl/babe_lottery_impl.cpp
+++ b/core/consensus/babe/impl/babe_lottery_impl.cpp
@@ -20,7 +20,7 @@ namespace kagome::consensus {
 
   BabeLotteryImpl::BabeLotteryImpl(
       std::shared_ptr<crypto::VRFProvider> vrf_provider,
-      std::shared_ptr<primitives::BabeConfiguration> configuration,
+      std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo,
       std::shared_ptr<crypto::Hasher> hasher)
       : vrf_provider_{std::move(vrf_provider)},
         hasher_{std::move(hasher)},
@@ -28,7 +28,7 @@ namespace kagome::consensus {
     BOOST_ASSERT(vrf_provider_);
     BOOST_ASSERT(hasher_);
     BOOST_ASSERT(logger_);
-    BOOST_ASSERT(configuration);
+    BOOST_ASSERT(babe_config_repo);
     epoch_.epoch_number = std::numeric_limits<uint64_t>::max();
   }
 

--- a/core/consensus/babe/impl/babe_lottery_impl.hpp
+++ b/core/consensus/babe/impl/babe_lottery_impl.hpp
@@ -15,12 +15,17 @@
 #include "log/logger.hpp"
 #include "primitives/babe_configuration.hpp"
 
+namespace kagome::consensus::babe {
+  class BabeConfigRepository;
+}
+
 namespace kagome::consensus {
+
   class BabeLotteryImpl : public BabeLottery {
    public:
     BabeLotteryImpl(
         std::shared_ptr<crypto::VRFProvider> vrf_provider,
-        std::shared_ptr<primitives::BabeConfiguration> configuration,
+        std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo,
         std::shared_ptr<crypto::Hasher> hasher);
 
     void changeEpoch(const EpochDescriptor &epoch,

--- a/core/consensus/babe/impl/babe_util_impl.hpp
+++ b/core/consensus/babe/impl/babe_util_impl.hpp
@@ -12,12 +12,16 @@
 #include "primitives/babe_configuration.hpp"
 #include "storage/buffer_map_types.hpp"
 
+namespace kagome::consensus::babe {
+  class BabeConfigRepository;
+}
+
 namespace kagome::consensus {
 
   class BabeUtilImpl final : public BabeUtil {
    public:
     BabeUtilImpl(
-        std::shared_ptr<primitives::BabeConfiguration> babe_configuration,
+        std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo,
         const BabeClock &clock);
 
     BabeSlotNumber syncEpoch(
@@ -39,7 +43,7 @@ namespace kagome::consensus {
    private:
     BabeSlotNumber getFirstBlockSlotNumber();
 
-    std::shared_ptr<primitives::BabeConfiguration> babe_configuration_;
+    std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo_;
     const BabeClock &clock_;
 
     std::optional<BabeSlotNumber> first_block_slot_number_;

--- a/core/consensus/babe/impl/block_appender_impl.hpp
+++ b/core/consensus/babe/impl/block_appender_impl.hpp
@@ -21,10 +21,12 @@
 #include "primitives/babe_configuration.hpp"
 #include "primitives/block_header.hpp"
 
+namespace kagome::consensus::babe {
+  class BabeConfigRepository;
+  class ConsistencyKeeper;
+}  // namespace kagome::consensus::babe
+
 namespace kagome::consensus {
-  namespace babe {
-    class ConsistencyKeeper;
-  }
 
   class BlockAppenderImpl
       : public BlockAppender,
@@ -34,7 +36,7 @@ namespace kagome::consensus {
 
     BlockAppenderImpl(
         std::shared_ptr<blockchain::BlockTree> block_tree,
-        std::shared_ptr<primitives::BabeConfiguration> configuration,
+        std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo,
         std::shared_ptr<BlockValidator> block_validator,
         std::shared_ptr<grandpa::Environment> grandpa_environment,
         std::shared_ptr<crypto::Hasher> hasher,
@@ -51,7 +53,7 @@ namespace kagome::consensus {
 
    private:
     std::shared_ptr<blockchain::BlockTree> block_tree_;
-    std::shared_ptr<primitives::BabeConfiguration> babe_configuration_;
+    std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo_;
     std::shared_ptr<BlockValidator> block_validator_;
     std::shared_ptr<grandpa::Environment> grandpa_environment_;
     std::shared_ptr<crypto::Hasher> hasher_;

--- a/core/consensus/babe/impl/block_executor_impl.cpp
+++ b/core/consensus/babe/impl/block_executor_impl.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 
 #include "blockchain/block_tree_error.hpp"
+#include "consensus/babe/babe_config_repository.hpp"
 #include "consensus/babe/consistency_keeper.hpp"
 #include "consensus/babe/impl/babe_digests_util.hpp"
 #include "consensus/babe/impl/threshold_util.hpp"
@@ -42,7 +43,7 @@ namespace kagome::consensus {
   BlockExecutorImpl::BlockExecutorImpl(
       std::shared_ptr<blockchain::BlockTree> block_tree,
       std::shared_ptr<runtime::Core> core,
-      std::shared_ptr<primitives::BabeConfiguration> configuration,
+      std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo,
       std::shared_ptr<BlockValidator> block_validator,
       std::shared_ptr<grandpa::Environment> grandpa_environment,
       std::shared_ptr<transaction_pool::TransactionPool> tx_pool,
@@ -54,7 +55,7 @@ namespace kagome::consensus {
       std::shared_ptr<babe::ConsistencyKeeper> consistency_keeper)
       : block_tree_{std::move(block_tree)},
         core_{std::move(core)},
-        babe_configuration_{std::move(configuration)},
+        babe_config_repo_{std::move(babe_config_repo)},
         block_validator_{std::move(block_validator)},
         grandpa_environment_{std::move(grandpa_environment)},
         tx_pool_{std::move(tx_pool)},
@@ -67,7 +68,7 @@ namespace kagome::consensus {
         telemetry_{telemetry::createTelemetryService()} {
     BOOST_ASSERT(block_tree_ != nullptr);
     BOOST_ASSERT(core_ != nullptr);
-    BOOST_ASSERT(babe_configuration_ != nullptr);
+    BOOST_ASSERT(babe_config_repo_ != nullptr);
     BOOST_ASSERT(block_validator_ != nullptr);
     BOOST_ASSERT(grandpa_environment_ != nullptr);
     BOOST_ASSERT(tx_pool_ != nullptr);
@@ -198,7 +199,9 @@ namespace kagome::consensus {
              epoch_number,
              this_block_epoch_descriptor.randomness);
 
-    auto threshold = calculateThreshold(babe_configuration_->leadership_rate,
+    const auto &babe_config = babe_config_repo_->config();
+
+    auto threshold = calculateThreshold(babe_config.leadership_rate,
                                         this_block_epoch_descriptor.authorities,
                                         babe_header.authority_index);
 

--- a/core/consensus/babe/impl/block_executor_impl.hpp
+++ b/core/consensus/babe/impl/block_executor_impl.hpp
@@ -29,10 +29,12 @@ namespace kagome::runtime {
   class OffchainWorkerApi;
 };
 
+namespace kagome::consensus::babe {
+  class BabeConfigRepository;
+  class ConsistencyKeeper;
+}  // namespace kagome::consensus::babe
+
 namespace kagome::consensus {
-  namespace babe {
-    class ConsistencyKeeper;
-  }
 
   class BlockExecutorImpl
       : public BlockExecutor,
@@ -43,7 +45,7 @@ namespace kagome::consensus {
     BlockExecutorImpl(
         std::shared_ptr<blockchain::BlockTree> block_tree,
         std::shared_ptr<runtime::Core> core,
-        std::shared_ptr<primitives::BabeConfiguration> configuration,
+        std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo,
         std::shared_ptr<BlockValidator> block_validator,
         std::shared_ptr<grandpa::Environment> grandpa_environment,
         std::shared_ptr<transaction_pool::TransactionPool> tx_pool,
@@ -63,7 +65,7 @@ namespace kagome::consensus {
    private:
     std::shared_ptr<blockchain::BlockTree> block_tree_;
     std::shared_ptr<runtime::Core> core_;
-    std::shared_ptr<primitives::BabeConfiguration> babe_configuration_;
+    std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo_;
     std::shared_ptr<BlockValidator> block_validator_;
     std::shared_ptr<grandpa::Environment> grandpa_environment_;
     std::shared_ptr<transaction_pool::TransactionPool> tx_pool_;

--- a/core/consensus/validation/babe_block_validator.hpp
+++ b/core/consensus/validation/babe_block_validator.hpp
@@ -28,6 +28,10 @@ namespace kagome::crypto {
 }
 
 namespace kagome::consensus {
+  namespace babe {
+    class BabeConfigRepository;
+  }
+
   /**
    * Validation of blocks in BABE system. Based on the algorithm described here:
    * https://research.web3.foundation/en/latest/polkadot/BABE/Babe/#2-normal-phase
@@ -50,7 +54,7 @@ namespace kagome::consensus {
         std::shared_ptr<crypto::Hasher> hasher,
         std::shared_ptr<crypto::VRFProvider> vrf_provider,
         std::shared_ptr<crypto::Sr25519Provider> sr25519_provider,
-        std::shared_ptr<primitives::BabeConfiguration> configuration);
+        std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo);
 
     enum class ValidationError {
       NO_AUTHORITIES = 1,
@@ -110,7 +114,7 @@ namespace kagome::consensus {
     std::shared_ptr<crypto::VRFProvider> vrf_provider_;
     std::shared_ptr<crypto::Sr25519Provider> sr25519_provider_;
 
-    std::shared_ptr<primitives::BabeConfiguration> configuration_;
+    std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo_;
     log::Logger log_;
   };
 }  // namespace kagome::consensus

--- a/core/injector/CMakeLists.txt
+++ b/core/injector/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(application_injector
     babe
     babe_api
     babe_lottery
+    babe_config_repository
     synchronizer
     babe_util
     binaryen_executor_factory

--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -436,41 +436,6 @@ namespace {
     return initialized.value();
   }
 
-//  sptr<primitives::BabeConfiguration> get_babe_configuration(
-//      primitives::BlockHash const &block_hash,
-//      sptr<runtime::BabeApi> babe_api) {
-//    static auto initialized =
-//        std::optional<sptr<primitives::BabeConfiguration>>(std::nullopt);
-//    if (initialized) {
-//      return initialized.value();
-//    }
-//
-//    auto log = log::createLogger("Injector", "injector");
-//
-//    auto configuration_res = babe_api->configuration(block_hash);
-//    if (not configuration_res) {
-//      if (configuration_res
-//          == outcome::failure(runtime::RuntimeEnvironmentFactory::Error::
-//                                  FAILED_TO_SET_STORAGE_STATE)) {
-//        SL_CRITICAL(log,
-//                    "State for block {} has not found. "
-//                    "Try to launch with `--sync Fast' CLI arg",
-//                    block_hash);
-//      }
-//      common::raise(configuration_res.error());
-//    }
-//
-//    auto configuration = std::make_shared<primitives::BabeConfiguration>(
-//        std::move(configuration_res.value()));
-//
-//    for (const auto &authority : configuration->genesis_authorities) {
-//      SL_DEBUG(log, "Babe authority: {:l}", authority.id.id);
-//    }
-//
-//    initialized.emplace(std::move(configuration));
-//    return initialized.value();
-//  }
-
   sptr<crypto::KeyFileStorage> get_key_file_storage(
       application::AppConfiguration const &config,
       sptr<application::ChainSpec> chain_spec) {
@@ -990,17 +955,6 @@ namespace {
     return initialized.value();
   }
 
-//  template <typename Injector>
-//  primitives::BlockHash get_last_finalized_hash(const Injector &injector) {
-//    auto storage = injector.template create<sptr<blockchain::BlockStorage>>();
-//    if (auto last = storage->getLastFinalized(); last.has_value()) {
-//      return last.value().hash;
-//    } else {
-//      throw std::runtime_error("Cannot lookup last finalized block: "
-//                               + last.error().message());
-//    }
-//  };
-
   template <typename... Ts>
   auto makeApplicationInjector(const application::AppConfiguration &config,
                                Ts &&...args) {
@@ -1197,25 +1151,6 @@ namespace {
         di::bind<clock::SystemClock>.template to<clock::SystemClockImpl>(),
         di::bind<clock::SteadyClock>.template to<clock::SteadyClockImpl>(),
         di::bind<clock::Timer>.template to<clock::BasicWaitableTimer>(),
-//        di::bind<clock::SystemClock::Duration>.to([](const auto &injector) {
-//          auto conf =
-//              injector.template create<sptr<primitives::BabeConfiguration>>();
-//          return conf->slot_duration;
-//        }),
-//        di::bind<primitives::BabeConfiguration>.to([](auto const &injector) {
-//          // need it to add genesis block if it's not there
-//          auto babe_api = injector.template create<sptr<runtime::BabeApi>>();
-//          if (injector.template create<application::AppConfiguration const &>()
-//                  .syncMethod()
-//              == application::AppConfiguration::SyncMethod::Fast) {
-//            auto genesis_block_header =
-//                injector
-//                    .template create<sptr<primitives::GenesisBlockHeader>>();
-//            return get_babe_configuration(genesis_block_header->hash, babe_api);
-//          }
-//          static auto last_finalized_hash = get_last_finalized_hash(injector);
-//          return get_babe_configuration(last_finalized_hash, babe_api);
-//        }),
         di::bind<network::Synchronizer>.template to<network::SynchronizerImpl>(),
         di::bind<consensus::grandpa::Environment>.template to<consensus::grandpa::EnvironmentImpl>(),
         di::bind<consensus::BlockValidator>.template to<consensus::BabeBlockValidator>(),

--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -605,9 +605,9 @@ namespace {
         injector.template create<std::shared_ptr<runtime::Core>>();
     auto changes_tracker = injector.template create<
         std::shared_ptr<storage::changes_trie::ChangesTracker>>();
-    auto babe_configuration =
+    auto babe_config_repo =
         injector
-            .template create<std::shared_ptr<primitives::BabeConfiguration>>();
+            .template create<std::shared_ptr<consensus::babe::BabeConfigRepository>>();
     auto babe_util =
         injector.template create<std::shared_ptr<consensus::BabeUtil>>();
     auto justification_storage_policy = injector.template create<
@@ -623,7 +623,7 @@ namespace {
         std::move(ext_events_key_repo),
         std::move(runtime_core),
         std::move(changes_tracker),
-        std::move(babe_configuration),
+        std::move(babe_config_repo),
         std::move(babe_util),
         std::move(justification_storage_policy));
 
@@ -695,7 +695,7 @@ namespace {
     auto block_executor = std::make_shared<consensus::BlockExecutorImpl>(
         injector.template create<sptr<blockchain::BlockTree>>(),
         injector.template create<sptr<runtime::Core>>(),
-        injector.template create<sptr<primitives::BabeConfiguration>>(),
+        injector.template create<sptr<consensus::babe::BabeConfigRepository>>(),
         injector.template create<sptr<consensus::BlockValidator>>(),
         injector.template create<sptr<consensus::grandpa::Environment>>(),
         injector.template create<sptr<transaction_pool::TransactionPool>>(),
@@ -1387,7 +1387,7 @@ namespace {
         injector.template create<const application::AppConfiguration &>(),
         injector.template create<sptr<application::AppStateManager>>(),
         injector.template create<sptr<consensus::BabeLottery>>(),
-        injector.template create<sptr<primitives::BabeConfiguration>>(),
+        injector.template create<sptr<consensus::babe::BabeConfigRepository>>(),
         injector.template create<sptr<authorship::Proposer>>(),
         injector.template create<sptr<blockchain::BlockTree>>(),
         injector.template create<sptr<network::BlockAnnounceTransmitter>>(),

--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -4,7 +4,6 @@
  */
 
 #include "injector/application_injector.hpp"
-#include "crypto/hasher.hpp"
 
 #define BOOST_DI_CFG_DIAGNOSTICS_LEVEL 2
 #define BOOST_DI_CFG_CTOR_LIMIT_SIZE \
@@ -63,6 +62,7 @@
 #include "consensus/authority/authority_update_observer.hpp"
 #include "consensus/authority/impl/authority_manager_impl.hpp"
 #include "consensus/authority/impl/schedule_node.hpp"
+#include "consensus/babe/impl/babe_config_repository_impl.hpp"
 #include "consensus/babe/impl/babe_impl.hpp"
 #include "consensus/babe/impl/babe_lottery_impl.hpp"
 #include "consensus/babe/impl/babe_util_impl.hpp"
@@ -436,40 +436,40 @@ namespace {
     return initialized.value();
   }
 
-  sptr<primitives::BabeConfiguration> get_babe_configuration(
-      primitives::BlockHash const &block_hash,
-      sptr<runtime::BabeApi> babe_api) {
-    static auto initialized =
-        std::optional<sptr<primitives::BabeConfiguration>>(std::nullopt);
-    if (initialized) {
-      return initialized.value();
-    }
-
-    auto log = log::createLogger("Injector", "injector");
-
-    auto configuration_res = babe_api->configuration(block_hash);
-    if (not configuration_res) {
-      if (configuration_res
-          == outcome::failure(runtime::RuntimeEnvironmentFactory::Error::
-                                  FAILED_TO_SET_STORAGE_STATE)) {
-        SL_CRITICAL(log,
-                    "State for block {} has not found. "
-                    "Try to launch with `--sync Fast' CLI arg",
-                    block_hash);
-      }
-      common::raise(configuration_res.error());
-    }
-
-    auto configuration = std::make_shared<primitives::BabeConfiguration>(
-        std::move(configuration_res.value()));
-
-    for (const auto &authority : configuration->genesis_authorities) {
-      SL_DEBUG(log, "Babe authority: {:l}", authority.id.id);
-    }
-
-    initialized.emplace(std::move(configuration));
-    return initialized.value();
-  }
+//  sptr<primitives::BabeConfiguration> get_babe_configuration(
+//      primitives::BlockHash const &block_hash,
+//      sptr<runtime::BabeApi> babe_api) {
+//    static auto initialized =
+//        std::optional<sptr<primitives::BabeConfiguration>>(std::nullopt);
+//    if (initialized) {
+//      return initialized.value();
+//    }
+//
+//    auto log = log::createLogger("Injector", "injector");
+//
+//    auto configuration_res = babe_api->configuration(block_hash);
+//    if (not configuration_res) {
+//      if (configuration_res
+//          == outcome::failure(runtime::RuntimeEnvironmentFactory::Error::
+//                                  FAILED_TO_SET_STORAGE_STATE)) {
+//        SL_CRITICAL(log,
+//                    "State for block {} has not found. "
+//                    "Try to launch with `--sync Fast' CLI arg",
+//                    block_hash);
+//      }
+//      common::raise(configuration_res.error());
+//    }
+//
+//    auto configuration = std::make_shared<primitives::BabeConfiguration>(
+//        std::move(configuration_res.value()));
+//
+//    for (const auto &authority : configuration->genesis_authorities) {
+//      SL_DEBUG(log, "Babe authority: {:l}", authority.id.id);
+//    }
+//
+//    initialized.emplace(std::move(configuration));
+//    return initialized.value();
+//  }
 
   sptr<crypto::KeyFileStorage> get_key_file_storage(
       application::AppConfiguration const &config,
@@ -990,16 +990,16 @@ namespace {
     return initialized.value();
   }
 
-  template <typename Injector>
-  primitives::BlockHash get_last_finalized_hash(const Injector &injector) {
-    auto storage = injector.template create<sptr<blockchain::BlockStorage>>();
-    if (auto last = storage->getLastFinalized(); last.has_value()) {
-      return last.value().hash;
-    } else {
-      throw std::runtime_error("Cannot lookup last finalized block: "
-                               + last.error().message());
-    }
-  };
+//  template <typename Injector>
+//  primitives::BlockHash get_last_finalized_hash(const Injector &injector) {
+//    auto storage = injector.template create<sptr<blockchain::BlockStorage>>();
+//    if (auto last = storage->getLastFinalized(); last.has_value()) {
+//      return last.value().hash;
+//    } else {
+//      throw std::runtime_error("Cannot lookup last finalized block: "
+//                               + last.error().message());
+//    }
+//  };
 
   template <typename... Ts>
   auto makeApplicationInjector(const application::AppConfiguration &config,
@@ -1197,25 +1197,25 @@ namespace {
         di::bind<clock::SystemClock>.template to<clock::SystemClockImpl>(),
         di::bind<clock::SteadyClock>.template to<clock::SteadyClockImpl>(),
         di::bind<clock::Timer>.template to<clock::BasicWaitableTimer>(),
-        di::bind<clock::SystemClock::Duration>.to([](const auto &injector) {
-          auto conf =
-              injector.template create<sptr<primitives::BabeConfiguration>>();
-          return conf->slot_duration;
-        }),
-        di::bind<primitives::BabeConfiguration>.to([](auto const &injector) {
-          // need it to add genesis block if it's not there
-          auto babe_api = injector.template create<sptr<runtime::BabeApi>>();
-          if (injector.template create<application::AppConfiguration const &>()
-                  .syncMethod()
-              == application::AppConfiguration::SyncMethod::Fast) {
-            auto genesis_block_header =
-                injector
-                    .template create<sptr<primitives::GenesisBlockHeader>>();
-            return get_babe_configuration(genesis_block_header->hash, babe_api);
-          }
-          static auto last_finalized_hash = get_last_finalized_hash(injector);
-          return get_babe_configuration(last_finalized_hash, babe_api);
-        }),
+//        di::bind<clock::SystemClock::Duration>.to([](const auto &injector) {
+//          auto conf =
+//              injector.template create<sptr<primitives::BabeConfiguration>>();
+//          return conf->slot_duration;
+//        }),
+//        di::bind<primitives::BabeConfiguration>.to([](auto const &injector) {
+//          // need it to add genesis block if it's not there
+//          auto babe_api = injector.template create<sptr<runtime::BabeApi>>();
+//          if (injector.template create<application::AppConfiguration const &>()
+//                  .syncMethod()
+//              == application::AppConfiguration::SyncMethod::Fast) {
+//            auto genesis_block_header =
+//                injector
+//                    .template create<sptr<primitives::GenesisBlockHeader>>();
+//            return get_babe_configuration(genesis_block_header->hash, babe_api);
+//          }
+//          static auto last_finalized_hash = get_last_finalized_hash(injector);
+//          return get_babe_configuration(last_finalized_hash, babe_api);
+//        }),
         di::bind<network::Synchronizer>.template to<network::SynchronizerImpl>(),
         di::bind<consensus::grandpa::Environment>.template to<consensus::grandpa::EnvironmentImpl>(),
         di::bind<consensus::BlockValidator>.template to<consensus::BabeBlockValidator>(),
@@ -1315,6 +1315,7 @@ namespace {
         di::bind<telemetry::TelemetryService>.template to<telemetry::TelemetryServiceImpl>(),
         di::bind<consensus::babe::ConsistencyKeeper>.template to<consensus::babe::ConsistencyKeeperImpl>(),
         di::bind<api::InternalApi>.template to<api::InternalApiImpl>(),
+        di::bind<consensus::babe::BabeConfigRepository>.template to<consensus::babe::BabeConfigRepositoryImpl>(),
 
         // user-defined overrides...
         std::forward<decltype(args)>(args)...);

--- a/test/core/blockchain/block_storage_test.cpp
+++ b/test/core/blockchain/block_storage_test.cpp
@@ -114,9 +114,7 @@ TEST_F(BlockStorageTest, CreateWithExistingGenesis) {
   EXPECT_CALL(*storage, contains(_)).WillOnce(Return(outcome::success(true)));
   EXPECT_CALL(*storage, tryLoad(_))
       // trying to get header of block number 0 (genesis block)
-      .WillOnce(Return(Buffer{genesis_block_hash}))
-      // trying leaves of block tree
-      .WillOnce(Return(Buffer{}));
+      .WillOnce(Return(Buffer{genesis_block_hash}));
 
   ASSERT_OUTCOME_SUCCESS_TRY(
       BlockStorageImpl::create(root_hash, storage, hasher));

--- a/test/core/blockchain/block_tree_test.cpp
+++ b/test/core/blockchain/block_tree_test.cpp
@@ -137,12 +137,12 @@ struct BlockTreeTest : public testing::Test {
 
     EXPECT_CALL(*changes_tracker_, onBlockAdded(_)).WillRepeatedly(Return());
 
-    babe_config_ = std::make_shared<primitives::BabeConfiguration>();
-    babe_config_->slot_duration = 60ms;
-    babe_config_->randomness.fill(0);
-    babe_config_->genesis_authorities = {primitives::Authority{{}, 1}};
-    babe_config_->leadership_rate = {1, 4};
-    babe_config_->epoch_length = 2;
+    babe_config_repo_ = std::make_shared<primitives::BabeConfiguration>();
+    babe_config_repo_->slot_duration = 60ms;
+    babe_config_repo_->randomness.fill(0);
+    babe_config_repo_->genesis_authorities = {primitives::Authority{{}, 1}};
+    babe_config_repo_->leadership_rate = {1, 4};
+    babe_config_repo_->epoch_length = 2;
 
     babe_util_ = std::make_shared<BabeUtilMock>();
     EXPECT_CALL(*babe_util_, syncEpoch(_)).WillRepeatedly(Return(1));
@@ -157,7 +157,7 @@ struct BlockTreeTest : public testing::Test {
                                         extrinsic_event_key_repo,
                                         runtime_core_,
                                         changes_tracker_,
-                                        babe_config_,
+                                        babe_config_repo_,
                                         babe_util_,
                                         justification_storage_policy_)
                       .value();
@@ -253,7 +253,7 @@ struct BlockTreeTest : public testing::Test {
   std::shared_ptr<storage::changes_trie::ChangesTrackerMock> changes_tracker_ =
       std::make_shared<storage::changes_trie::ChangesTrackerMock>();
 
-  std::shared_ptr<primitives::BabeConfiguration> babe_config_;
+  std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo_;
   std::shared_ptr<BabeUtilMock> babe_util_;
 
   std::shared_ptr<JustificationStoragePolicyMock>

--- a/test/core/consensus/babe/babe_test.cpp
+++ b/test/core/consensus/babe/babe_test.cpp
@@ -19,6 +19,7 @@
 #include "mock/core/clock/clock_mock.hpp"
 #include "mock/core/clock/timer_mock.hpp"
 #include "mock/core/consensus/authority/authority_update_observer_mock.hpp"
+#include "mock/core/consensus/babe/babe_config_repository_mock.hpp"
 #include "mock/core/consensus/babe/babe_util_mock.hpp"
 #include "mock/core/consensus/babe/block_executor_mock.hpp"
 #include "mock/core/consensus/babe/consistency_keeper_mock.hpp"
@@ -40,6 +41,7 @@
 
 using namespace kagome;
 using namespace consensus;
+using namespace babe;
 using namespace authority;
 using namespace application;
 using namespace blockchain;
@@ -113,13 +115,16 @@ class BabeTest : public testing::Test {
     io_context_ = std::make_shared<boost::asio::io_context>();
 
     // add initialization logic
-    babe_config_repo_ = std::make_shared<primitives::BabeConfiguration>();
-    babe_config_repo_->slot_duration = 60ms;
-    babe_config_repo_->randomness.fill(0);
-    babe_config_repo_->genesis_authorities = {
+    babe_config_.slot_duration = 60ms;
+    babe_config_.randomness.fill(0);
+    babe_config_.genesis_authorities = {
         primitives::Authority{{keypair_->public_key}, 1}};
-    babe_config_repo_->leadership_rate = {1, 4};
-    babe_config_repo_->epoch_length = 2;
+    babe_config_.leadership_rate = {1, 4};
+    babe_config_.epoch_length = 2;
+
+    babe_config_repo_ = std::make_shared<BabeConfigRepositoryMock>();
+    ON_CALL(*babe_config_repo_, config())
+        .WillByDefault(ReturnRef(babe_config_));
 
     babe_util_ = std::make_shared<BabeUtilMock>();
     EXPECT_CALL(*babe_util_, slotToEpoch(_)).WillRepeatedly(Return(0));
@@ -131,8 +136,8 @@ class BabeTest : public testing::Test {
     consistency_keeper_ = std::make_shared<babe::ConsistencyKeeperMock>();
 
     expected_epoch_digest = {
-        .authorities = babe_config_repo_->genesis_authorities,
-        .randomness = babe_config_repo_->randomness,
+        .authorities = babe_config_.genesis_authorities,
+        .randomness = babe_config_.randomness,
     };
 
     EXPECT_CALL(*block_tree_, getEpochDigest(_, _)).WillRepeatedly([this] {
@@ -200,7 +205,8 @@ class BabeTest : public testing::Test {
   testutil::TimerMock *timer_;
   std::shared_ptr<AuthorityUpdateObserverMock>
       grandpa_authority_update_observer_;
-  std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo_;
+  primitives::BabeConfiguration babe_config_;
+  std::shared_ptr<BabeConfigRepositoryMock> babe_config_repo_;
   std::shared_ptr<BabeUtilMock> babe_util_;
   std::shared_ptr<runtime::OffchainWorkerApiMock> offchain_worker_api_;
   std::shared_ptr<babe::ConsistencyKeeperMock> consistency_keeper_;

--- a/test/core/consensus/babe/babe_test.cpp
+++ b/test/core/consensus/babe/babe_test.cpp
@@ -113,13 +113,13 @@ class BabeTest : public testing::Test {
     io_context_ = std::make_shared<boost::asio::io_context>();
 
     // add initialization logic
-    babe_config_ = std::make_shared<primitives::BabeConfiguration>();
-    babe_config_->slot_duration = 60ms;
-    babe_config_->randomness.fill(0);
-    babe_config_->genesis_authorities = {
+    babe_config_repo_ = std::make_shared<primitives::BabeConfiguration>();
+    babe_config_repo_->slot_duration = 60ms;
+    babe_config_repo_->randomness.fill(0);
+    babe_config_repo_->genesis_authorities = {
         primitives::Authority{{keypair_->public_key}, 1}};
-    babe_config_->leadership_rate = {1, 4};
-    babe_config_->epoch_length = 2;
+    babe_config_repo_->leadership_rate = {1, 4};
+    babe_config_repo_->epoch_length = 2;
 
     babe_util_ = std::make_shared<BabeUtilMock>();
     EXPECT_CALL(*babe_util_, slotToEpoch(_)).WillRepeatedly(Return(0));
@@ -131,8 +131,8 @@ class BabeTest : public testing::Test {
     consistency_keeper_ = std::make_shared<babe::ConsistencyKeeperMock>();
 
     expected_epoch_digest = {
-        .authorities = babe_config_->genesis_authorities,
-        .randomness = babe_config_->randomness,
+        .authorities = babe_config_repo_->genesis_authorities,
+        .randomness = babe_config_repo_->randomness,
     };
 
     EXPECT_CALL(*block_tree_, getEpochDigest(_, _)).WillRepeatedly([this] {
@@ -152,7 +152,7 @@ class BabeTest : public testing::Test {
     babe_ = std::make_shared<babe::BabeImpl>(app_config_,
                                              app_state_manager_,
                                              lottery_,
-                                             babe_config_,
+                                             babe_config_repo_,
                                              proposer_,
                                              block_tree_,
                                              block_announce_transmitter_,
@@ -200,7 +200,7 @@ class BabeTest : public testing::Test {
   testutil::TimerMock *timer_;
   std::shared_ptr<AuthorityUpdateObserverMock>
       grandpa_authority_update_observer_;
-  std::shared_ptr<primitives::BabeConfiguration> babe_config_;
+  std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo_;
   std::shared_ptr<BabeUtilMock> babe_util_;
   std::shared_ptr<runtime::OffchainWorkerApiMock> offchain_worker_api_;
   std::shared_ptr<babe::ConsistencyKeeperMock> consistency_keeper_;

--- a/test/core/consensus/babe/babe_util_test.cpp
+++ b/test/core/consensus/babe/babe_util_test.cpp
@@ -8,15 +8,18 @@
 
 #include "consensus/babe/impl/babe_util_impl.hpp"
 #include "mock/core/clock/clock_mock.hpp"
+#include "mock/core/consensus/babe/babe_config_repository_mock.hpp"
 #include "primitives/babe_configuration.hpp"
 #include "testutil/prepare_loggers.hpp"
 
 using namespace kagome;
 using namespace clock;
 using namespace consensus;
+using namespace babe;
 
 using std::chrono_literals::operator""ms;
 using testing::Return;
+using testing::ReturnRef;
 
 class BabeUtilTest : public testing::Test {
  public:
@@ -25,14 +28,20 @@ class BabeUtilTest : public testing::Test {
   }
 
   void SetUp() override {
-    babe_config_repo_ = std::make_shared<primitives::BabeConfiguration>();
-    babe_config_repo_->slot_duration = 6000ms;
-    babe_config_repo_->epoch_length = 2;
+    babe_config_.slot_duration = 6000ms;
+    babe_config_.epoch_length = 2;
+
+    babe_config_repo_ =
+        std::make_shared<consensus::babe::BabeConfigRepositoryMock>();
+    ON_CALL(*babe_config_repo_, config())
+        .WillByDefault(ReturnRef(babe_config_));
+
     clock_ = std::make_shared<SystemClockMock>();
     babe_util_ = std::make_shared<BabeUtilImpl>(babe_config_repo_, *clock_);
   }
 
-  std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo_;
+  primitives::BabeConfiguration babe_config_;
+  std::shared_ptr<BabeConfigRepositoryMock> babe_config_repo_;
   std::shared_ptr<SystemClockMock> clock_;
   std::shared_ptr<BabeUtil> babe_util_;
 };
@@ -46,6 +55,6 @@ TEST_F(BabeUtilTest, getCurrentSlot) {
   auto time = std::chrono::system_clock::now();
   EXPECT_CALL(*clock_, now()).Times(1).WillOnce(Return(time));
   EXPECT_EQ(static_cast<BabeSlotNumber>(time.time_since_epoch()
-                                        / babe_config_repo_->slot_duration),
+                                        / babe_config_.slot_duration),
             babe_util_->getCurrentSlot());
 }

--- a/test/core/consensus/babe/babe_util_test.cpp
+++ b/test/core/consensus/babe/babe_util_test.cpp
@@ -25,14 +25,14 @@ class BabeUtilTest : public testing::Test {
   }
 
   void SetUp() override {
-    babe_config_ = std::make_shared<primitives::BabeConfiguration>();
-    babe_config_->slot_duration = 6000ms;
-    babe_config_->epoch_length = 2;
+    babe_config_repo_ = std::make_shared<primitives::BabeConfiguration>();
+    babe_config_repo_->slot_duration = 6000ms;
+    babe_config_repo_->epoch_length = 2;
     clock_ = std::make_shared<SystemClockMock>();
-    babe_util_ = std::make_shared<BabeUtilImpl>(babe_config_, *clock_);
+    babe_util_ = std::make_shared<BabeUtilImpl>(babe_config_repo_, *clock_);
   }
 
-  std::shared_ptr<primitives::BabeConfiguration> babe_config_;
+  std::shared_ptr<consensus::babe::BabeConfigRepository> babe_config_repo_;
   std::shared_ptr<SystemClockMock> clock_;
   std::shared_ptr<BabeUtil> babe_util_;
 };
@@ -46,6 +46,6 @@ TEST_F(BabeUtilTest, getCurrentSlot) {
   auto time = std::chrono::system_clock::now();
   EXPECT_CALL(*clock_, now()).Times(1).WillOnce(Return(time));
   EXPECT_EQ(static_cast<BabeSlotNumber>(time.time_since_epoch()
-                                        / babe_config_->slot_duration),
+                                        / babe_config_repo_->slot_duration),
             babe_util_->getCurrentSlot());
 }

--- a/test/core/consensus/babe_lottery_test.cpp
+++ b/test/core/consensus/babe_lottery_test.cpp
@@ -9,6 +9,7 @@
 #include "common/mp_utils.hpp"
 #include "consensus/babe/impl/babe_lottery_impl.hpp"
 #include "consensus/validation/prepare_transcript.hpp"
+#include "mock/core/consensus/babe/babe_config_repository_mock.hpp"
 #include "mock/core/crypto/hasher_mock.hpp"
 #include "mock/core/crypto/vrf_provider_mock.hpp"
 #include "testutil/prepare_loggers.hpp"
@@ -16,6 +17,7 @@
 using namespace kagome;
 using namespace crypto;
 using namespace consensus;
+using namespace babe;
 using namespace common;
 using namespace primitives;
 
@@ -35,17 +37,21 @@ struct BabeLotteryTest : public testing::Test {
 
   std::shared_ptr<VRFProviderMock> vrf_provider_ =
       std::make_shared<VRFProviderMock>();
-  std::shared_ptr<BabeConfiguration> babe_config_ =
-      std::make_shared<BabeConfiguration>(BabeConfiguration{
-          .epoch_length = 3,
-          .leadership_rate = {},
-          .genesis_authorities = {},
-          .randomness = {},
-          .allowed_slots = {},
-      });
+
+  BabeConfiguration babe_config_{
+      .epoch_length = 3,
+      .leadership_rate = {},
+      .genesis_authorities = {},
+      .randomness = {},
+      .allowed_slots = {},
+  };
+
+  std::shared_ptr<BabeConfigRepositoryMock> babe_config_repo_ =
+      std::make_shared<BabeConfigRepositoryMock>();
+
   std::shared_ptr<HasherMock> hasher_ = std::make_shared<HasherMock>();
 
-  BabeLotteryImpl lottery_{vrf_provider_, babe_config_, hasher_};
+  BabeLotteryImpl lottery_{vrf_provider_, babe_config_repo_, hasher_};
 
   EpochDescriptor current_epoch_;
 
@@ -72,7 +78,7 @@ TEST_F(BabeLotteryTest, SlotsLeadership) {
   vrf_outputs.push_back({uint256_to_le_bytes(3749373), {}});
   vrf_outputs.push_back({uint256_to_le_bytes(1057472095), {}});
 
-  for (size_t i = 0; i < babe_config_->epoch_length; ++i) {
+  for (size_t i = 0; i < babe_config_.epoch_length; ++i) {
     primitives::Transcript transcript;
     prepareTranscript(transcript, randomness_, i, current_epoch_.epoch_number);
 

--- a/test/core/consensus/validation/block_validator_test.cpp
+++ b/test/core/consensus/validation/block_validator_test.cpp
@@ -9,6 +9,7 @@
 #include "consensus/babe/impl/babe_digests_util.hpp"
 #include "consensus/validation/babe_block_validator.hpp"
 #include "mock/core/blockchain/block_tree_mock.hpp"
+#include "mock/core/consensus/babe/babe_config_repository_mock.hpp"
 #include "mock/core/crypto/hasher_mock.hpp"
 #include "mock/core/crypto/sr25519_provider_mock.hpp"
 #include "mock/core/crypto/vrf_provider_mock.hpp"
@@ -22,6 +23,7 @@
 using namespace kagome;
 using namespace blockchain;
 using namespace consensus;
+using namespace babe;
 using namespace runtime;
 using namespace common;
 using namespace crypto;
@@ -90,14 +92,15 @@ class BlockValidatorTest : public testing::Test {
       std::make_shared<VRFProviderMock>();
   std::shared_ptr<Sr25519ProviderMock> sr25519_provider_ =
       std::make_shared<Sr25519ProviderMock>();
+  std::shared_ptr<BabeConfigRepositoryMock> babe_config_repo_ =
+      std::make_shared<BabeConfigRepositoryMock>();
 
-  BabeBlockValidator validator_{
-      tree_,
-      tx_queue_,
-      hasher_,
-      vrf_provider_,
-      sr25519_provider_,
-      std::make_shared<primitives::BabeConfiguration>()};
+  BabeBlockValidator validator_{tree_,
+                                tx_queue_,
+                                hasher_,
+                                vrf_provider_,
+                                sr25519_provider_,
+                                babe_config_repo_};
 
   // fields for block
   Hash256 parent_hash_ =

--- a/test/mock/core/consensus/babe/babe_config_repository_mock.hpp
+++ b/test/mock/core/consensus/babe/babe_config_repository_mock.hpp
@@ -1,0 +1,22 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_CONSENSUS_BABE_BABECONFIGREPOSITORYMOCK
+#define KAGOME_CONSENSUS_BABE_BABECONFIGREPOSITORYMOCK
+
+#include "consensus/babe/babe_config_repository.hpp"
+
+#include <gmock/gmock.h>
+
+namespace kagome::consensus::babe {
+
+  class BabeConfigRepositoryMock : public BabeConfigRepository {
+   public:
+    MOCK_METHOD(const primitives::BabeConfiguration &, config, (), (override));
+  };
+
+}  // namespace kagome::consensus::babe
+
+#endif  // KAGOME_CONSENSUS_BABE_BABECONFIGREPOSITORYMOCK


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues
Resolves #1345 

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
Implemented using of babe config over babe config repository. As result babe config is obtaining on demand. Config from last finalized block (from genesis in some cases) is using. It helps to avoid crash if runtime inaccessible for target block. 

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
No crash in that exceptional cases.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Sometimes might be done one extra wasm compilation.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->
Existing tests is adapted.
