### PR TITLE
sign converted statement

### DIFF
--- a/core/parachain/availability/bitfield/signer.cpp
+++ b/core/parachain/availability/bitfield/signer.cpp
@@ -57,7 +57,7 @@ namespace kagome::parachain {
   }
 
   outcome::result<void> BitfieldSigner::sign(const ValidatorSigner &signer) {
-    auto &relay_parent = signer.context().relay_parent;
+    auto &relay_parent = signer.relayParent();
     scale::BitVec bitfield;
     OUTCOME_TRY(cores, parachain_api_->availability_cores(relay_parent));
     bitfield.bits.reserve(cores.size());

--- a/core/parachain/validator/signer.cpp
+++ b/core/parachain/validator/signer.cpp
@@ -18,26 +18,30 @@ namespace kagome::parachain {
       ValidatorIndex validator_index,
       SigningContext context,
       std::shared_ptr<crypto::Sr25519Keypair> keypair,
+      std::shared_ptr<crypto::Hasher> hasher,
       std::shared_ptr<crypto::Sr25519Provider> sr25519_provider)
       : validator_index_{validator_index},
         context_{context},
         keypair_{std::move(keypair)},
+        hasher_{std::move(hasher)},
         sr25519_provider_{std::move(sr25519_provider)} {}
 
   ValidatorSigner::ValidatorIndex ValidatorSigner::validatorIndex() const {
     return validator_index_;
   }
 
-  const SigningContext &ValidatorSigner::context() const {
-    return context_;
+  const primitives::BlockHash &ValidatorSigner::relayParent() const {
+    return context_.relay_parent;
   }
 
   ValidatorSignerFactory::ValidatorSignerFactory(
       std::shared_ptr<runtime::ParachainHost> parachain_api,
       std::shared_ptr<crypto::SessionKeys> session_keys,
+      std::shared_ptr<crypto::Hasher> hasher,
       std::shared_ptr<crypto::Sr25519Provider> sr25519_provider)
       : parachain_api_{std::move(parachain_api)},
         session_keys_{std::move(session_keys)},
+        hasher_{std::move(hasher)},
         sr25519_provider_{std::move(sr25519_provider)} {}
 
   outcome::result<std::optional<ValidatorSigner>> ValidatorSignerFactory::at(
@@ -58,6 +62,7 @@ namespace kagome::parachain {
         validator_index,
         context,
         keypair,
+        hasher_,
         sr25519_provider_,
     };
   }


### PR DESCRIPTION
### Referenced issues
- #1311

### Description of the Change
- `ValidatorSigner` converts `Statement` before signing.
- `candidateHash` will be reused in "parachain_processor.cpp".

### Benefits
Statement signed correctly

### Possible Drawbacks