### PR TITLE
Fix authority manager initialization during fast sync

### DIFF
--- a/core/runtime/common/runtime_environment_factory.cpp
+++ b/core/runtime/common/runtime_environment_factory.cpp
@@ -99,7 +99,7 @@ namespace kagome::runtime {
     } else {
       if (auto res = env.storage_provider->setToEphemeralAt(storage_state_);
           !res) {
-        parent_factory->logger_->debug(
+        parent_factory->logger_->error(
             "Failed to set the storage state to hash {:l} when initializing a "
             "runtime environment; Reason: {}",
             storage_state_,

--- a/core/runtime/common/runtime_environment_factory.cpp
+++ b/core/runtime/common/runtime_environment_factory.cpp
@@ -99,7 +99,7 @@ namespace kagome::runtime {
     } else {
       if (auto res = env.storage_provider->setToEphemeralAt(storage_state_);
           !res) {
-        parent_factory->logger_->error(
+        parent_factory->logger_->debug(
             "Failed to set the storage state to hash {:l} when initializing a "
             "runtime environment; Reason: {}",
             storage_state_,


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
Authority manager tried to access the runtime storage without checking if it's possible.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Kagome works properly when restarting fast sync.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None expected.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->
