### PR TITLE
Fix empty peer id

### DIFF
--- a/core/network/impl/peer_manager_impl.cpp
+++ b/core/network/impl/peer_manager_impl.cpp
@@ -404,16 +404,17 @@ namespace kagome::network {
 
   void PeerManagerImpl::disconnectFromPeer(const PeerId &peer_id) {
     auto it = active_peers_.find(peer_id);
+    if (peer_id == own_peer_info_.id) {
+      return;
+    }
     if (it != active_peers_.end()) {
       SL_DEBUG(log_, "Disconnect from peer {}", peer_id);
       stream_engine_->del(peer_id);
+      peer_states_.erase(peer_id);
+      host_.disconnect(peer_id);
       active_peers_.erase(it);
       sync_peer_num_->set(active_peers_.size());
       SL_DEBUG(log_, "Remained {} active peers", active_peers_.size());
-    }
-    if (peer_id != own_peer_info_.id) {
-      peer_states_.erase(peer_id);
-      host_.disconnect(peer_id);
     }
   }
 


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

-
### Description of the Change

We had situation when we could obtain iterator from active_peers_ containing `peer_id`. Then we are trying to disconnect from this `peer_id` by passing it by reference into `disconnectFromPeer`
https://github.com/soramitsu/kagome/blob/a731d2683a7a8514989fc880ca605ddd14f1cea8/core/network/impl/peer_manager_impl.cpp#L270-L281

However inside `disconnectFromPeer` we again obtain same iterator and erase it from active peers. At this moment reference to `peer_id` becoming nullptr. Later it is being used in lines 415-416 which leads to segmentation fault.
https://github.com/soramitsu/kagome/blob/a731d2683a7a8514989fc880ca605ddd14f1cea8/core/network/impl/peer_manager_impl.cpp#L270-L281

### Benefits

Bug is fixed

### Possible Drawbacks 

Logic of disconnect from peer was slightly changed


