### PR TITLE
Context stop fixup

### DIFF
--- a/core/parachain/validator/impl/parachain_processor.cpp
+++ b/core/parachain/validator/impl/parachain_processor.cpp
@@ -85,10 +85,11 @@ namespace kagome::parachain {
   }
 
   void ParachainProcessorImpl::stop() {
-    BOOST_ASSERT(context_);
-    BOOST_ASSERT(work_guard_);
     work_guard_.reset();
-    context_->stop();
+    if (context_) {
+      context_->stop();
+      context_.reset();
+    }
     for (auto &worker : workers_) {
       if (worker) {
         BOOST_ASSERT(worker->joinable());


### PR DESCRIPTION
### Description
Fixes assertion that context should exists on parachain processor stop call.