### PR TITLE
Removed 'to' field from block request

### DIFF
--- a/core/network/adapters/protobuf_block_request.hpp
+++ b/core/network/adapters/protobuf_block_request.hpp
@@ -41,11 +41,6 @@ namespace kagome::network {
             msg.set_number(&n, sizeof(n));
           });
 
-      // Note: request.to is not used in substrate
-      if (t.to.has_value()) {
-        msg.set_to_block(t.to->toString());
-      }
-
       msg.set_direction(static_cast<::api::v1::Direction>(t.direction));
 
       if (t.max.has_value()) {
@@ -87,12 +82,6 @@ namespace kagome::network {
 
         default:
           return AdaptersError::UNEXPECTED_VARIANT;
-      }
-
-      if (not msg.to_block().empty()) {
-        OUTCOME_TRY(to_block,
-                    primitives::BlockHash::fromString(msg.to_block()));
-        out.to.emplace(to_block);
       }
 
       if (msg.max_blocks() > 0) {

--- a/core/network/impl/protocols/sync_protocol_impl.cpp
+++ b/core/network/impl/protocols/sync_protocol_impl.cpp
@@ -240,10 +240,6 @@ namespace kagome::network {
           logmsg += fmt::format(", from {}", from);
         });
 
-        if (block_request.to.has_value()) {
-          logmsg += fmt::format(" to {}", block_request.to.value());
-        }
-
         logmsg +=
             block_request.direction == Direction::ASCENDING ? " anc" : " desc";
 
@@ -434,10 +430,6 @@ namespace kagome::network {
       visit_in_place(block_request.from, [&](const auto &from) {
         logmsg += fmt::format(" from {}", from);
       });
-
-      if (block_request.to.has_value()) {
-        logmsg += fmt::format(" to {}", block_request.to.value());
-      }
 
       logmsg +=
           block_request.direction == Direction::ASCENDING ? " anc" : " desc";

--- a/core/network/impl/synchronizer_impl.cpp
+++ b/core/network/impl/synchronizer_impl.cpp
@@ -418,7 +418,6 @@ namespace kagome::network {
 
     network::BlocksRequest request{network::BlockAttribute::HEADER,
                                    hint,
-                                   std::nullopt,
                                    network::Direction::ASCENDING,
                                    1};
 
@@ -592,7 +591,6 @@ namespace kagome::network {
 
     network::BlocksRequest request{attributesForSync(sync_method_),
                                    from.hash,
-                                   std::nullopt,
                                    network::Direction::ASCENDING,
                                    std::nullopt};
 
@@ -825,7 +823,6 @@ namespace kagome::network {
     BlocksRequest request{
         BlockAttribute::HEADER | BlockAttribute::JUSTIFICATION,
         target_block.hash,
-        std::nullopt,
         Direction::ASCENDING,
         limit};
 

--- a/core/network/protobuf/api.v1.proto
+++ b/core/network/protobuf/api.v1.proto
@@ -23,8 +23,6 @@ message BlockRequest {
 		// Start with given block number.
 		bytes number = 3;
 	}
-	// End at this block. An implementation defined maximum is used when unspecified.
-	bytes to_block = 4; // optional
 	// Sequence direction.
 	Direction direction = 5;
 	// Maximum number of blocks to return. An implementation defined maximum is used when unspecified.

--- a/core/network/types/blocks_request.hpp
+++ b/core/network/types/blocks_request.hpp
@@ -25,9 +25,6 @@ namespace kagome::network {
     BlockAttributes fields{};
     /// start from this block
     primitives::BlockId from{};
-    /// end at this block; an implementation defined maximum is used when
-    /// unspecified
-    std::optional<primitives::BlockHash> to{};
     /// sequence direction
     Direction direction{};
     /// maximum number of blocks to return; an implementation defined maximum is
@@ -57,11 +54,6 @@ struct std::hash<kagome::network::BlocksRequest> {
 
     boost::hash_combine(
         result, std::hash<kagome::primitives::BlockId>()(blocks_request.from));
-
-    boost::hash_combine(
-        result,
-        std::hash<std::optional<kagome::primitives::BlockHash>>()(
-            blocks_request.to));
 
     boost::hash_combine(
         result,

--- a/test/core/network/sync_protocol_observer_test.cpp
+++ b/test/core/network/sync_protocol_observer_test.cpp
@@ -71,7 +71,6 @@ TEST_F(SynchronizerTest, ProcessRequest) {
   // GIVEN
   BlocksRequest received_request{BlocksRequest::kBasicAttributes,
                                  block3_hash_,
-                                 std::nullopt,
                                  Direction::ASCENDING,
                                  std::nullopt};
 

--- a/test/core/network/types/protobuf_block_request_test.cpp
+++ b/test/core/network/types/protobuf_block_request_test.cpp
@@ -29,12 +29,6 @@ struct ProtobufBlockRequestAdapterTest : public ::testing::Test {
         BlockHash::fromHex("11111403ba5b6a3f3bd0b0604ce439a78244"
                            "c7d43b127ec35cd8325602dd47fd"));
     request.from = hash_from;
-
-    EXPECT_OUTCOME_TRUE(
-        hash_to,
-        BlockHash::fromHex("22221403ba5b6a3f3bd0b0604ce439a78244"
-                           "c7d43b127ec35cd8325602dd47fd"));
-    request.to = hash_to;
   }
 
   BlocksRequest request;
@@ -58,5 +52,4 @@ TEST_F(ProtobufBlockRequestAdapterTest, Serialization) {
   ASSERT_EQ(r2.max, request.max);
   ASSERT_EQ(r2.fields, request.fields);
   ASSERT_EQ(r2.from, request.from);
-  ASSERT_EQ(r2.to, request.to);
 }


### PR DESCRIPTION
Signed-off-by: Dmitriy Khaustov aka xDimon <khaustov.dm@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues
Resolves #1365 

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
Removed 'to' field from block request

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->
