### PR TITLE
dev accounts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   MacOS:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -26,7 +26,7 @@ hunter_config(
 
 hunter_config(
     soralog
-    VERSION 0.1.3
+    VERSION 0.1.4
     KEEP_PACKAGE_SOURCES
 )
 
@@ -44,7 +44,7 @@ hunter_config(
 
 hunter_config(
     wavm
-    VERSION 1.0.4
+    VERSION 1.0.5
     CMAKE_ARGS
       TESTING=OFF
       WAVM_ENABLE_FUZZ_TARGETS=OFF
@@ -53,4 +53,3 @@ hunter_config(
       WAVM_BUILD_TESTS=OFF
     KEEP_PACKAGE_SOURCES
 )
-

--- a/cmake/Hunter/hunter-gate-url.cmake
+++ b/cmake/Hunter/hunter-gate-url.cmake
@@ -1,6 +1,6 @@
 
 HunterGate(
-  URL  "https://github.com/soramitsu/soramitsu-hunter/archive/refs/tags/v0.23.257-soramitsu31.zip"
-  SHA1 "a13dcf6dae9e926441715e67c409838630f6f3e0"
+  URL  "https://github.com/soramitsu/soramitsu-hunter/archive/refs/tags/v0.23.257-soramitsu33.zip"
+  SHA1 "8e7052df7f20840e1f3823aea35a9daf917eb8e8"
   LOCAL
 )

--- a/core/application/app_configuration.hpp
+++ b/core/application/app_configuration.hpp
@@ -246,6 +246,11 @@ namespace kagome::application {
      * @return enum constant of the chosen storage backend
      */
     virtual StorageBackend storageBackend() const = 0;
+
+    /**
+     * Optional phrase to use dev account (e.g. Alice and Bob)
+     */
+    virtual std::optional<std::string> devMnemonicPhrase() const = 0;
   };
 
 }  // namespace kagome::application

--- a/core/application/app_configuration.hpp
+++ b/core/application/app_configuration.hpp
@@ -250,7 +250,7 @@ namespace kagome::application {
     /**
      * Optional phrase to use dev account (e.g. Alice and Bob)
      */
-    virtual std::optional<std::string> devMnemonicPhrase() const = 0;
+    virtual std::optional<std::string_view> devMnemonicPhrase() const = 0;
   };
 
 }  // namespace kagome::application

--- a/core/application/impl/app_configuration_impl.cpp
+++ b/core/application/impl/app_configuration_impl.cpp
@@ -163,15 +163,16 @@ namespace {
 
   auto &devAccounts() {
     static auto &dev = kagome::crypto::DevMnemonicPhrase::get();
-    static const std::map<std::string, std::pair<std::string, std::string>>
-        accounts{
-            {"alice", {"Alice", dev.alice}},
-            {"bob", {"Bob", dev.bob}},
-            {"charlie", {"Charlie", dev.charlie}},
-            {"dave", {"Dave", dev.dave}},
-            {"eve", {"Eve", dev.eve}},
-            {"ferdie", {"Ferdie", dev.ferdie}},
-        };
+    static const std::
+        array<std::tuple<const char *, std::string_view, std::string_view>, 6>
+            accounts{
+                std::tuple("alice", "Alice", dev.alice),
+                std::tuple("bob", "Bob", dev.bob),
+                std::tuple("charlie", "Charlie", dev.charlie),
+                std::tuple("dave", "Dave", dev.dave),
+                std::tuple("eve", "Eve", dev.eve),
+                std::tuple("ferdie", "Ferdie", dev.ferdie),
+            };
     return accounts;
   }
 }  // namespace
@@ -770,8 +771,8 @@ namespace kagome::application {
 
     // clang-format on
 
-    for (auto &account : devAccounts()) {
-      development_desc.add_options()(account.first.c_str(), po::bool_switch());
+    for (auto &[flag, name, dev] : devAccounts()) {
+      development_desc.add_options()(flag, po::bool_switch());
     }
 
     po::variables_map vm;
@@ -883,17 +884,16 @@ namespace kagome::application {
     }
 
     std::optional<std::string> dev_account_flag;
-    for (auto &[flag, account] : devAccounts()) {
+    for (auto &[flag, name, dev] : devAccounts()) {
       if (auto val = find_argument<bool>(vm, flag); val && *val) {
         if (dev_account_flag) {
-          auto &_flag = flag;
           SL_ERROR(
-              logger_, "--{} conflicts with --{}", _flag, *dev_account_flag);
+              logger_, "--{} conflicts with --{}", flag, *dev_account_flag);
           return false;
         }
         dev_account_flag = flag;
-        node_name_ = account.first;
-        dev_mnemonic_phrase_ = account.second;
+        node_name_ = name;
+        dev_mnemonic_phrase_ = dev;
       }
     }
 

--- a/core/application/impl/app_configuration_impl.cpp
+++ b/core/application/impl/app_configuration_impl.cpp
@@ -163,16 +163,16 @@ namespace {
 
   auto &devAccounts() {
     static auto &dev = kagome::crypto::DevMnemonicPhrase::get();
-    static const std::
-        array<std::tuple<const char *, std::string_view, std::string_view>, 6>
-            accounts{
-                std::tuple("alice", "Alice", dev.alice),
-                std::tuple("bob", "Bob", dev.bob),
-                std::tuple("charlie", "Charlie", dev.charlie),
-                std::tuple("dave", "Dave", dev.dave),
-                std::tuple("eve", "Eve", dev.eve),
-                std::tuple("ferdie", "Ferdie", dev.ferdie),
-            };
+    using Account =
+        std::tuple<const char *, std::string_view, std::string_view>;
+    static const std::array<Account, 6> accounts{
+        Account{"alice", "Alice", dev.alice},
+        Account{"bob", "Bob", dev.bob},
+        Account{"charlie", "Charlie", dev.charlie},
+        Account{"dave", "Dave", dev.dave},
+        Account{"eve", "Eve", dev.eve},
+        Account{"ferdie", "Ferdie", dev.ferdie},
+    };
     return accounts;
   }
 }  // namespace

--- a/core/application/impl/app_configuration_impl.hpp
+++ b/core/application/impl/app_configuration_impl.hpp
@@ -185,8 +185,11 @@ namespace kagome::application {
     StorageBackend storageBackend() const override {
       return storage_backend_;
     }
-    std::optional<std::string> devMnemonicPhrase() const override {
-      return dev_mnemonic_phrase_;
+    std::optional<std::string_view> devMnemonicPhrase() const override {
+      if (dev_mnemonic_phrase_) {
+        return *dev_mnemonic_phrase_;
+      }
+      return std::nullopt;
     }
 
    private:

--- a/core/application/impl/app_configuration_impl.hpp
+++ b/core/application/impl/app_configuration_impl.hpp
@@ -185,6 +185,9 @@ namespace kagome::application {
     StorageBackend storageBackend() const override {
       return storage_backend_;
     }
+    std::optional<std::string> devMnemonicPhrase() const override {
+      return dev_mnemonic_phrase_;
+    }
 
    private:
     void parse_general_segment(const rapidjson::Value &val);
@@ -322,6 +325,7 @@ namespace kagome::application {
     bool subcommand_chain_info_;
     std::optional<primitives::BlockId> recovery_state_;
     StorageBackend storage_backend_ = StorageBackend::RocksDB;
+    std::optional<std::string> dev_mnemonic_phrase_;
   };
 
 }  // namespace kagome::application

--- a/core/crypto/crypto_store/crypto_store_impl.cpp
+++ b/core/crypto/crypto_store/crypto_store_impl.cpp
@@ -219,7 +219,7 @@ namespace kagome::crypto {
     const auto &contents = lookup_res.value();
     BOOST_ASSERT(ED25519_SEED_LENGTH == contents.size()
                  or 2 * ED25519_SEED_LENGTH == contents.size());  // hex
-    kagome::common::Hash256 seed;
+    Ed25519Seed seed;
     if (ED25519_SEED_LENGTH == contents.size()) {
       OUTCOME_TRY(
           _seed,

--- a/core/crypto/crypto_store/crypto_store_impl.hpp
+++ b/core/crypto/crypto_store/crypto_store_impl.hpp
@@ -16,6 +16,7 @@
 #include "crypto/bip39/mnemonic.hpp"
 #include "crypto/crypto_store.hpp"
 #include "crypto/crypto_store/crypto_suites.hpp"
+#include "crypto/crypto_store/dev_mnemonic_phrase.hpp"
 #include "crypto/crypto_store/key_cache.hpp"
 #include "crypto/crypto_store/key_file_storage.hpp"
 #include "log/logger.hpp"
@@ -154,6 +155,9 @@ namespace kagome::crypto {
     outcome::result<typename CryptoSuite::Keypair> generateKeypair(
         std::string_view mnemonic_phrase, const CryptoSuite &suite) {
       using Seed = typename CryptoSuite::Seed;
+      if (auto seed = DevMnemonicPhrase::get().find<Seed>(mnemonic_phrase)) {
+        return suite.generateKeypair(seed.value());
+      }
       OUTCOME_TRY(bip_seed, bip39_provider_->generateSeed(mnemonic_phrase));
       if (bip_seed.size() < Seed::size()) {
         return CryptoStoreError::WRONG_SEED_SIZE;

--- a/core/crypto/crypto_store/dev_mnemonic_phrase.hpp
+++ b/core/crypto/crypto_store/dev_mnemonic_phrase.hpp
@@ -21,32 +21,34 @@ namespace kagome::crypto {
     std::map<std::string, std::pair<Ed25519Seed, Sr25519Seed>, std::less<>>
         precomputed;
 
-    DevMnemonicPhrase() {
-      alice = precompute(
-          "//Alice",
-          "abf8e5bdbe30c65656c0a3cbd181ff8a56294a69dfedd27982aace4a76909115",
-          "e5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a");
-      bob = precompute(
-          "//Bob",
-          "3b7b60af2abcd57ba401ab398f84f4ca54bd6b2140d2503fbcf3286535fe3ff1",
-          "398f0c28f98885e046333d4a41c19cee4c37368a9832c6502f6cfd182e2aef89");
-      charlie = precompute(
-          "//Charlie",
-          "072c02fa1409dc37e03a4ed01703d4a9e6bba9c228a49a00366e9630a97cba7c",
-          "bc1ede780f784bb6991a585e4f6e61522c14e1cae6ad0895fb57b9a205a8f938");
-      dave = precompute(
-          "//Dave",
-          "771f47d3caf8a2ee40b0719e1c1ecbc01d73ada220cf08df12a00453ab703738",
-          "868020ae0687dda7d57565093a69090211449845a7e11453612800b663307246");
-      eve = precompute(
-          "//Eve",
-          "bef5a3cd63dd36ab9792364536140e5a0cce6925969940c431934de056398556",
-          "786ad0e2df456fe43dd1f91ebca22e235bc162e0bb8d53c633e8c85b2af68b7a");
-      ferdie = precompute(
-          "//Ferdie",
-          "1441e38eb309b66e9286867a5cd05902b05413eb9723a685d4d77753d73d0a1d",
-          "42438b7883391c05512a938e36c2df0131e088b3756d6aa7a755fbff19d2f842");
-    }
+    // clang-format off
+    DevMnemonicPhrase() :
+        alice{precompute("//Alice",
+            "abf8e5bdbe30c65656c0a3cbd181ff8a56294a69dfedd27982aace4a76909115",
+            "e5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a"
+        )},
+        bob{precompute("//Bob",
+            "3b7b60af2abcd57ba401ab398f84f4ca54bd6b2140d2503fbcf3286535fe3ff1",
+            "398f0c28f98885e046333d4a41c19cee4c37368a9832c6502f6cfd182e2aef89"
+        )},
+        charlie{precompute("//Charlie",
+            "072c02fa1409dc37e03a4ed01703d4a9e6bba9c228a49a00366e9630a97cba7c",
+            "bc1ede780f784bb6991a585e4f6e61522c14e1cae6ad0895fb57b9a205a8f938"
+        )},
+        dave{precompute("//Dave",
+            "771f47d3caf8a2ee40b0719e1c1ecbc01d73ada220cf08df12a00453ab703738",
+            "868020ae0687dda7d57565093a69090211449845a7e11453612800b663307246"
+        )},
+        eve{precompute("//Eve",
+            "bef5a3cd63dd36ab9792364536140e5a0cce6925969940c431934de056398556",
+            "786ad0e2df456fe43dd1f91ebca22e235bc162e0bb8d53c633e8c85b2af68b7a"
+        )},
+        ferdie{precompute("//Ferdie",
+            "1441e38eb309b66e9286867a5cd05902b05413eb9723a685d4d77753d73d0a1d",
+            "42438b7883391c05512a938e36c2df0131e088b3756d6aa7a755fbff19d2f842"
+        )}
+    {}
+    // clang-format on
 
     std::string precompute(std::string_view junctions,
                            std::string_view ed25519_seed,
@@ -84,12 +86,12 @@ namespace kagome::crypto {
       return std::nullopt;
     }
 
-    std::string alice;
-    std::string bob;
-    std::string charlie;
-    std::string dave;
-    std::string eve;
-    std::string ferdie;
+    const std::string alice;
+    const std::string bob;
+    const std::string charlie;
+    const std::string dave;
+    const std::string eve;
+    const std::string ferdie;
   };
 }  // namespace kagome::crypto
 

--- a/core/crypto/crypto_store/dev_mnemonic_phrase.hpp
+++ b/core/crypto/crypto_store/dev_mnemonic_phrase.hpp
@@ -1,0 +1,96 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_CRYPTO_DEV_MNEMONIC_PHRASE_HPP
+#define KAGOME_CRYPTO_DEV_MNEMONIC_PHRASE_HPP
+
+#include <map>
+#include <optional>
+
+#include "crypto/ed25519_types.hpp"
+#include "crypto/sr25519_types.hpp"
+
+namespace kagome::crypto {
+  class DevMnemonicPhrase {
+    static constexpr std::string_view kWords =
+        "bottom drive obey lake curtain smoke basket hold race lonely fit walk";
+
+    // junctions are not supported yet
+    std::map<std::string, std::pair<Ed25519Seed, Sr25519Seed>, std::less<>>
+        precomputed;
+
+    DevMnemonicPhrase() {
+      alice = precompute(
+          "//Alice",
+          "abf8e5bdbe30c65656c0a3cbd181ff8a56294a69dfedd27982aace4a76909115",
+          "e5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a");
+      bob = precompute(
+          "//Bob",
+          "3b7b60af2abcd57ba401ab398f84f4ca54bd6b2140d2503fbcf3286535fe3ff1",
+          "398f0c28f98885e046333d4a41c19cee4c37368a9832c6502f6cfd182e2aef89");
+      charlie = precompute(
+          "//Charlie",
+          "072c02fa1409dc37e03a4ed01703d4a9e6bba9c228a49a00366e9630a97cba7c",
+          "bc1ede780f784bb6991a585e4f6e61522c14e1cae6ad0895fb57b9a205a8f938");
+      dave = precompute(
+          "//Dave",
+          "771f47d3caf8a2ee40b0719e1c1ecbc01d73ada220cf08df12a00453ab703738",
+          "868020ae0687dda7d57565093a69090211449845a7e11453612800b663307246");
+      eve = precompute(
+          "//Eve",
+          "bef5a3cd63dd36ab9792364536140e5a0cce6925969940c431934de056398556",
+          "786ad0e2df456fe43dd1f91ebca22e235bc162e0bb8d53c633e8c85b2af68b7a");
+      ferdie = precompute(
+          "//Ferdie",
+          "1441e38eb309b66e9286867a5cd05902b05413eb9723a685d4d77753d73d0a1d",
+          "42438b7883391c05512a938e36c2df0131e088b3756d6aa7a755fbff19d2f842");
+    }
+
+    std::string precompute(std::string_view junctions,
+                           std::string_view ed25519_seed,
+                           std ::string_view sr25519_seed) {
+      std::string mnemonic_phrase{kWords};
+      mnemonic_phrase += junctions;
+      precomputed[mnemonic_phrase] = {
+          Ed25519Seed::fromHex(ed25519_seed).value(),
+          Sr25519Seed::fromHex(sr25519_seed).value(),
+      };
+      return mnemonic_phrase;
+    }
+
+   public:
+    static const DevMnemonicPhrase &get() {
+      static const DevMnemonicPhrase self;
+      return self;
+    }
+
+    template <typename Seed>
+    std::optional<Seed> find(std::string_view mnemonic_phrase) const {
+      if constexpr (std::is_same_v<
+                        Seed,
+                        Ed25519Seed> || std::is_same_v<Seed, Sr25519Seed>) {
+        auto it = precomputed.find(mnemonic_phrase);
+        if (it != precomputed.end()) {
+          if constexpr (std::is_same_v<Seed, Ed25519Seed>) {
+            return it->second.first;
+          }
+          if constexpr (std::is_same_v<Seed, Sr25519Seed>) {
+            return it->second.second;
+          }
+        }
+      }
+      return std::nullopt;
+    }
+
+    std::string alice;
+    std::string bob;
+    std::string charlie;
+    std::string dave;
+    std::string eve;
+    std::string ferdie;
+  };
+}  // namespace kagome::crypto
+
+#endif  // KAGOME_CRYPTO_DEV_MNEMONIC_PHRASE_HPP

--- a/core/crypto/ed25519_types.hpp
+++ b/core/crypto/ed25519_types.hpp
@@ -37,6 +37,9 @@ KAGOME_BLOB_STRICT_TYPEDEF(kagome::crypto,
 KAGOME_BLOB_STRICT_TYPEDEF(kagome::crypto,
                            Ed25519Signature,
                            constants::ed25519::SIGNATURE_SIZE);
+KAGOME_BLOB_STRICT_TYPEDEF(kagome::crypto,
+                           Ed25519Seed,
+                           constants::ed25519::SEED_SIZE);
 
 namespace kagome::crypto {
 
@@ -47,8 +50,6 @@ namespace kagome::crypto {
     bool operator==(const Ed25519Keypair &other) const;
     bool operator!=(const Ed25519Keypair &other) const;
   };
-
-  using Ed25519Seed = common::Blob<constants::ed25519::SEED_SIZE>;
 
   struct Ed25519KeypairAndSeed : Ed25519Keypair {
     Ed25519Seed seed;

--- a/core/crypto/sr25519_types.hpp
+++ b/core/crypto/sr25519_types.hpp
@@ -81,10 +81,11 @@ KAGOME_BLOB_STRICT_TYPEDEF(kagome::crypto,
 KAGOME_BLOB_STRICT_TYPEDEF(kagome::crypto,
                            Sr25519Signature,
                            constants::sr25519::SIGNATURE_SIZE);
+KAGOME_BLOB_STRICT_TYPEDEF(kagome::crypto,
+                           Sr25519Seed,
+                           constants::sr25519::SEED_SIZE);
 
 namespace kagome::crypto {
-  using Sr25519Seed = common::Blob<constants::sr25519::SEED_SIZE>;
-
   struct Sr25519Keypair {
     Sr25519SecretKey secret_key;
     Sr25519PublicKey public_key;

--- a/core/injector/get_peer_keypair.hpp
+++ b/core/injector/get_peer_keypair.hpp
@@ -28,8 +28,8 @@ namespace kagome::injector {
     if (app_config.nodeKey()) {
       log->info("Will use LibP2P keypair from config or 'node-key' CLI arg");
 
-      auto provided_keypair =
-          crypto_provider.generateKeypair(app_config.nodeKey().value());
+      auto provided_keypair = crypto_provider.generateKeypair(
+          crypto::Ed25519Seed{app_config.nodeKey().value()});
       BOOST_ASSERT(provided_keypair.secret_key == app_config.nodeKey().value());
 
       auto key_pair = std::make_shared<libp2p::crypto::KeyPair>(

--- a/test/core/crypto/crypto_store/crypto_store_test.cpp
+++ b/test/core/crypto/crypto_store/crypto_store_test.cpp
@@ -37,6 +37,7 @@ using kagome::crypto::Ed25519PrivateKey;
 using kagome::crypto::Ed25519Provider;
 using kagome::crypto::Ed25519ProviderImpl;
 using kagome::crypto::Ed25519PublicKey;
+using kagome::crypto::Ed25519Seed;
 using kagome::crypto::Ed25519Suite;
 using kagome::crypto::KeyTypeId;
 using kagome::crypto::KnownKeyTypeId;
@@ -47,6 +48,7 @@ using kagome::crypto::Sr25519Provider;
 using kagome::crypto::Sr25519ProviderImpl;
 using kagome::crypto::Sr25519PublicKey;
 using kagome::crypto::Sr25519SecretKey;
+using kagome::crypto::Sr25519Seed;
 using kagome::crypto::Sr25519Suite;
 
 static CryptoStoreImpl::Path crypto_store_test_directory =
@@ -181,8 +183,8 @@ TEST_F(CryptoStoreTest, generateEd25519KeypairSeedSuccess) {
       err, crypto_store->findEd25519Keypair(key_type, ed_pair.public_key));
   ASSERT_EQ(err, CryptoStoreError::KEY_NOT_FOUND);
 
-  EXPECT_OUTCOME_TRUE(pair,
-                      crypto_store->generateEd25519Keypair(key_type, seed));
+  EXPECT_OUTCOME_TRUE(
+      pair, crypto_store->generateEd25519Keypair(key_type, Ed25519Seed{seed}));
   ASSERT_EQ(pair, ed_pair);
 
   // check that created pair is now contained in memory
@@ -204,8 +206,8 @@ TEST_F(CryptoStoreTest, generateSr25519KeypairSeedSuccess) {
       err, crypto_store->findSr25519Keypair(key_type, sr_pair.public_key));
   ASSERT_EQ(err, CryptoStoreError::KEY_NOT_FOUND);
 
-  EXPECT_OUTCOME_TRUE(pair,
-                      crypto_store->generateSr25519Keypair(key_type, seed));
+  EXPECT_OUTCOME_TRUE(
+      pair, crypto_store->generateSr25519Keypair(key_type, Sr25519Seed{seed}));
   ASSERT_EQ(pair, sr_pair);
 
   // check that created pair is now contained in memory

--- a/test/core/host_api/crypto_extension_test.cpp
+++ b/test/core/host_api/crypto_extension_test.cpp
@@ -49,6 +49,7 @@ using kagome::crypto::Ed25519PrivateKey;
 using kagome::crypto::Ed25519Provider;
 using kagome::crypto::Ed25519ProviderImpl;
 using kagome::crypto::Ed25519PublicKey;
+using kagome::crypto::Ed25519Seed;
 using kagome::crypto::Ed25519Signature;
 using kagome::crypto::Hasher;
 using kagome::crypto::HasherImpl;
@@ -61,6 +62,7 @@ using kagome::crypto::Sr25519Provider;
 using kagome::crypto::Sr25519ProviderImpl;
 using kagome::crypto::Sr25519PublicKey;
 using kagome::crypto::Sr25519SecretKey;
+using kagome::crypto::Sr25519Seed;
 using kagome::crypto::Sr25519Signature;
 using kagome::crypto::secp256k1::Secp256k1VerifyError;
 using kagome::runtime::Memory;
@@ -140,10 +142,10 @@ class CryptoExtensionTest : public ::testing::Test {
     std::optional<std::string> optional_mnemonic(mnemonic);
     mnemonic_buffer.put(scale::encode(optional_mnemonic).value());
 
-    sr25519_keypair = sr25519_provider_->generateKeypair(seed);
+    sr25519_keypair = sr25519_provider_->generateKeypair(Sr25519Seed{seed});
     sr25519_signature = sr25519_provider_->sign(sr25519_keypair, input).value();
 
-    ed25519_keypair = ed25519_provider_->generateKeypair(seed);
+    ed25519_keypair = ed25519_provider_->generateKeypair(Ed25519Seed{seed});
     ed25519_signature = ed25519_provider_->sign(ed25519_keypair, input).value();
 
     secp_message_hash =

--- a/test/core/runtime/executor_test.cpp
+++ b/test/core/runtime/executor_test.cpp
@@ -74,7 +74,6 @@ class ExecutorTest : public testing::Test {
       kagome::storage::trie::RootHash const &next_storage_state) {
     static Buffer enc_args;
     enc_args = Buffer{scale::encode(arg1, arg2).value()};
-    const PtrSize ARGS_LOCATION{1, 2};
     const PtrSize RESULT_LOCATION{3, 4};
 
     Buffer enc_res{scale::encode(res).value()};
@@ -144,7 +143,6 @@ class ExecutorTest : public testing::Test {
       int res) {
     static Buffer enc_args;
     enc_args = Buffer{scale::encode(arg1, arg2).value()};
-    const PtrSize ARGS_LOCATION{1, 2};
     const PtrSize RESULT_LOCATION{3, 4};
     Buffer enc_res{scale::encode(res).value()};
     EXPECT_CALL(*memory_, loadN(RESULT_LOCATION.ptr, RESULT_LOCATION.size))

--- a/test/mock/core/application/app_configuration_mock.hpp
+++ b/test/mock/core/application/app_configuration_mock.hpp
@@ -114,7 +114,10 @@ namespace kagome::application {
                 (),
                 (const, override));
 
-    MOCK_METHOD(AppConfiguration::SyncMethod, syncMethod, (), (const, override));
+    MOCK_METHOD(AppConfiguration::SyncMethod,
+                syncMethod,
+                (),
+                (const, override));
 
     MOCK_METHOD(AppConfiguration::RuntimeExecutionMethod,
                 runtimeExecMethod,
@@ -150,6 +153,11 @@ namespace kagome::application {
     MOCK_METHOD(bool, isTelemetryEnabled, (), (const, override));
 
     MOCK_METHOD(StorageBackend, storageBackend, (), (const, override));
+
+    MOCK_METHOD(std::optional<std::string>,
+                devMnemonicPhrase,
+                (),
+                (const, override));
   };
 
 }  // namespace kagome::application

--- a/test/mock/core/application/app_configuration_mock.hpp
+++ b/test/mock/core/application/app_configuration_mock.hpp
@@ -154,7 +154,7 @@ namespace kagome::application {
 
     MOCK_METHOD(StorageBackend, storageBackend, (), (const, override));
 
-    MOCK_METHOD(std::optional<std::string>,
+    MOCK_METHOD(std::optional<std::string_view>,
                 devMnemonicPhrase,
                 (),
                 (const, override));


### PR DESCRIPTION
### Referenced issues
### Description of the Change
Support `--alice`, `--bob`, `--charlie`, `--dave`, `--eve`, `--ferdie` flags from `substrate`.

### Benefits
Don't need keystore for testing.

### Possible Drawbacks 
### Usage Examples or Tests
- `examples/first_kagome_chain` with `--alice`.
- `examples/network` with `--alice` and `--bob`.
- `examples/network_x4` with `--alice`, `--bob`, `--charlie` and `--dave`.

### Alternate Designs
- bip39 junctions are not supported yet