### PR TITLE
minideb --gdb-index

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -44,7 +44,7 @@ hunter_config(
 
 hunter_config(
     wavm
-    VERSION 1.0.5
+    VERSION 1.0.6
     CMAKE_ARGS
       TESTING=OFF
       WAVM_ENABLE_FUZZ_TARGETS=OFF

--- a/cmake/Hunter/hunter-gate-url.cmake
+++ b/cmake/Hunter/hunter-gate-url.cmake
@@ -1,6 +1,6 @@
 
 HunterGate(
-  URL  "https://github.com/soramitsu/soramitsu-hunter/archive/refs/tags/v0.23.257-soramitsu34.zip"
-  SHA1 "f136380ef45a9874278e8fb8e17d1e69dc9f10f4"
+  URL  "https://github.com/soramitsu/soramitsu-hunter/archive/refs/tags/v0.23.257-soramitsu35.zip"
+  SHA1 "d0ca69603681f322884c6066161b0dea09af4905"
   LOCAL
 )


### PR DESCRIPTION
### Referenced issues
### Description of the Change
Update wavm to remove --gdb-index

### Benefits
Minideb builds

### Possible Drawbacks