### PR TITLE
fix connection leak

### DIFF
--- a/core/network/impl/peer_manager_impl.cpp
+++ b/core/network/impl/peer_manager_impl.cpp
@@ -270,6 +270,8 @@ namespace kagome::network {
 
     align_timer_.cancel();
 
+    clearClosedPingingConnections();
+
     // disconnect from peers with negative reputation
     using PriorityType = int32_t;
     using ItemType = std::pair<PriorityType, PeerId>;
@@ -457,6 +459,7 @@ namespace kagome::network {
                peer_id);
       return;
     }
+    clearClosedPingingConnections();
     auto [_, is_emplaced] = pinging_connections_.emplace(conn);
     if (not is_emplaced) {
       // Pinging is already going
@@ -789,4 +792,14 @@ namespace kagome::network {
              last_active_peers.size());
   }
 
+  void PeerManagerImpl::clearClosedPingingConnections() {
+    for (auto it = pinging_connections_.begin();
+         it != pinging_connections_.end();) {
+      if ((**it).isClosed()) {
+        it = pinging_connections_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
 }  // namespace kagome::network

--- a/core/network/impl/peer_manager_impl.hpp
+++ b/core/network/impl/peer_manager_impl.hpp
@@ -159,6 +159,8 @@ namespace kagome::network {
     /// node start
     void storeActivePeers();
 
+    void clearClosedPingingConnections();
+
     std::shared_ptr<application::AppStateManager> app_state_manager_;
     libp2p::Host &host_;
     std::shared_ptr<libp2p::protocol::Identify> identify_;


### PR DESCRIPTION
### Referenced issues
### Description of the Change
Remove closed connections

### Benefits
- Fixes connection leak

### Possible Drawbacks 
### Usage Examples or Tests
### Alternate Designs
- May store `weak_ptr` ([but can't use `unordered_set`](https://stackoverflow.com/a/30922307)).