### PR TITLE
Fix state root

### DIFF
--- a/core/runtime/common/trie_storage_provider_impl.cpp
+++ b/core/runtime/common/trie_storage_provider_impl.cpp
@@ -41,6 +41,7 @@ namespace kagome::runtime {
              "Setting storage provider to ephemeral batch with root {}",
              state_root.toHex());
     OUTCOME_TRY(batch, trie_storage_->getEphemeralBatchAt(state_root));
+    persistent_batch_.reset();
     current_batch_ = std::move(batch);
     return outcome::success();
   }


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- `TrieStorageProviderImpl` reused by `RuntimeInstancesPool` didn't clear `persistent_batch_`, so `forceCommit` returned wrong root

https://github.com/soramitsu/kagome/blob/ff91cec93517a5a270d4a13ed35b57bce0b9ca90/core/runtime/common/trie_storage_provider_impl.cpp#L102-L105

### Benefits
- State root is always computed correctly

### Possible Drawbacks

