### PR TITLE
Soralog error code

### DIFF
--- a/core/api/service/impl/api_service_impl.cpp
+++ b/core/api/service/impl/api_service_impl.cpp
@@ -84,8 +84,7 @@ namespace {
       if (response.has_value())
         std::forward<F>(f)(response.value());
       else
-        logger->error("process Json data failed => {}",
-                      response.error().message());
+        logger->error("process Json data failed => {}", response.error());
     });
   }
   inline void sendEvent(std::shared_ptr<JRpcServer> server,
@@ -339,7 +338,7 @@ namespace kagome::api {
               "Request block header of the last finalized "
               "failed with error: "
               "{}",
-              header.error().message());
+              header.error());
         }
         return static_cast<PubsubSubscriptionId>(id);
       });
@@ -380,7 +379,7 @@ namespace kagome::api {
         } else {
           logger_->error(
               "Request block header of the deepest leaf failed with error: {}",
-              header.error().message());
+              header.error());
         }
         return static_cast<PubsubSubscriptionId>(id);
       });

--- a/core/api/transport/impl/ws/ws_session.cpp
+++ b/core/api/transport/impl/ws/ws_session.cpp
@@ -124,8 +124,8 @@ namespace kagome::api {
 
   void WsSession::onAccept(boost::system::error_code ec) {
     if (ec) {
-      auto error_message =
-          (ec == WsError::closed) ? "connection was closed" : ec.message();
+      auto error_message = (ec == WsError::closed) ? "connection was closed"
+                                                   : "unknown error occurred";
       reportError(ec, error_message);
       stop();
       return;
@@ -137,8 +137,8 @@ namespace kagome::api {
   void WsSession::onRead(boost::system::error_code ec,
                          std::size_t bytes_transferred) {
     if (ec) {
-      auto error_message =
-          (ec == WsError::closed) ? "connection was closed" : ec.message();
+      auto error_message = (ec == WsError::closed) ? "connection was closed"
+                                                   : "unknown error occurred";
       reportError(ec, error_message);
       stop();
       return;

--- a/core/api/transport/impl/ws/ws_session.cpp
+++ b/core/api/transport/impl/ws/ws_session.cpp
@@ -187,11 +187,7 @@ namespace kagome::api {
 
   void WsSession::reportError(boost::system::error_code ec,
                               std::string_view message) {
-    SL_ERROR(logger_,
-             "error occurred: {}, code: {}, message: {}",
-             message,
-             ec,
-             ec.message());
+    SL_ERROR(logger_, "error occurred: {}, message: {}", message, ec);
   }
 
 }  // namespace kagome::api

--- a/core/application/impl/app_configuration_impl.cpp
+++ b/core/application/impl/app_configuration_impl.cpp
@@ -660,7 +660,7 @@ namespace kagome::application {
                  "Telemetry endpoint '{}' cannot be interpreted as a valid "
                  "multiaddress and was skipped due to error: {}",
                  uri_part,
-                 ma_res.error().message());
+                 ma_res.error());
         return std::nullopt;
       }
 
@@ -956,8 +956,8 @@ namespace kagome::application {
       for (auto &addr_str : boot_nodes) {
         auto ma_res = libp2p::multi::Multiaddress::create(addr_str);
         if (not ma_res.has_value()) {
-          auto err_msg = "Bootnode '" + addr_str
-                         + "' is invalid: " + ma_res.error().message();
+          auto err_msg = fmt::format(
+              "Bootnode '{}' is invalid: {}", addr_str, ma_res.error());
           SL_ERROR(logger_, "{}", err_msg);
           std::cout << err_msg << std::endl;
           return false;
@@ -979,8 +979,8 @@ namespace kagome::application {
     if (node_key.has_value()) {
       auto key_res = crypto::Ed25519PrivateKey::fromHex(node_key.value());
       if (not key_res.has_value()) {
-        auto err_msg = "Node key '" + node_key.value()
-                       + "' is invalid: " + key_res.error().message();
+        auto err_msg = fmt::format(
+            "Node key '{}' is invalid: {}", node_key.value(), key_res.error());
         SL_ERROR(logger_, "{}", err_msg);
         std::cout << err_msg << std::endl;
         return false;
@@ -1017,7 +1017,7 @@ namespace kagome::application {
                    "Address {} passed as value to {} is invalid: {}",
                    s,
                    param_name,
-                   ma_res.error().message());
+                   ma_res.error());
           return false;
         }
         output_field.emplace_back(std::move(ma_res.value()));
@@ -1054,7 +1054,7 @@ namespace kagome::application {
               "Cannot construct IPv6 listen multiaddress from port {}. Error: "
               "{}",
               p2p_port_,
-              ma_res.error().message());
+              ma_res.error());
         } else {
           SL_INFO(logger_,
                   "Automatically added IPv6 listen address {}",
@@ -1073,7 +1073,7 @@ namespace kagome::application {
               "Cannot construct IPv4 listen multiaddress from port {}. Error: "
               "{}",
               p2p_port_,
-              ma_res.error().message());
+              ma_res.error());
         } else {
           SL_INFO(logger_,
                   "Automatically added IPv4 listen address {}",
@@ -1223,7 +1223,7 @@ namespace kagome::application {
           SL_ERROR(logger_,
                    "Failed to purge cache in {} ['{}']",
                    runtimeCacheDirPath(),
-                   ec.message());
+                   ec);
         }
       }
     }

--- a/core/application/impl/kagome_application_impl.cpp
+++ b/core/application/impl/kagome_application_impl.cpp
@@ -73,7 +73,7 @@ namespace kagome::application {
     if (not res) {
       logger_->critical("Error initializing chain directory {}: {}",
                         chain_path.native(),
-                        res.error().message());
+                        res.error());
       exit(EXIT_FAILURE);
     }
 

--- a/core/network/impl/synchronizer_impl.cpp
+++ b/core/network/impl/synchronizer_impl.cpp
@@ -430,7 +430,7 @@ namespace kagome::network {
                  lower,
                  upper - 1,
                  peer_id,
-                 outcome::result<void>(Error::DUPLICATE_REQUEST).error());
+                 make_error_code(Error::DUPLICATE_REQUEST));
       handler(Error::DUPLICATE_REQUEST);
       return;
     }
@@ -600,7 +600,7 @@ namespace kagome::network {
                "Can't load blocks from {} beginning block {}: {}",
                peer_id,
                from,
-               outcome::result<void>(Error::DUPLICATE_REQUEST).error());
+               make_error_code(Error::DUPLICATE_REQUEST));
       if (handler) handler(Error::DUPLICATE_REQUEST);
       return;
     }
@@ -830,7 +830,7 @@ namespace kagome::network {
                "Can't load justification from {} for block {}: {}",
                peer_id,
                target_block,
-               outcome::result<void>(Error::DUPLICATE_REQUEST).error());
+               make_error_code(Error::DUPLICATE_REQUEST));
       if (handler) {
         handler(Error::DUPLICATE_REQUEST);
       }

--- a/core/outcome/outcome.hpp
+++ b/core/outcome/outcome.hpp
@@ -38,7 +38,7 @@ struct fmt::formatter<std::error_code> {
       -> decltype(ctx.out()) {
     // ctx.out() is an output iterator to write to.
 
-    return format_to(ctx.out(), ec.message());
+    return format_to(ctx.out(), "{}", ec.message());
   }
 };
 
@@ -66,12 +66,12 @@ struct fmt::formatter<outcome::result<Result, Failure>> {
 
     if (res.has_value()) {
       if constexpr (not std::is_void_v<Result>) {
-        return format_to(ctx.out(), res.value());
+        return format_to(ctx.out(), "{}", res.value());
       } else {
         return format_to(ctx.out(), "<success>");
       }
     } else {
-      return format_to(ctx.out(), res.error().message());
+      return format_to(ctx.out(), "{}", res.error());
     }
   }
 };

--- a/test/testutil/outcome.hpp
+++ b/test/testutil/outcome.hpp
@@ -153,22 +153,22 @@
     }                                                    \
   }
 
-#define ASSERT_OUTCOME_ERROR(_expression_, _error_)                       \
-  {                                                                       \
-    auto &&result = (_expression_);                                       \
-    if (result.has_error()) {                                             \
-      if (result != outcome::failure(_error_)) {                          \
-        GTEST_FATAL_FAILURE_("Outcome of: " #_expression_)                \
-            << "  Actual:   Error '" << result.error().message() << "'\n" \
-            << "Expected:   Error '"                                      \
-            << outcome::result<void>(_error_).error().message() << "'";   \
-      }                                                                   \
-    } else {                                                              \
-      GTEST_FATAL_FAILURE_("Outcome of: " #_expression_)                  \
-          << "  Actual:   Success\n"                                      \
-          << "Expected:   Error '"                                        \
-          << outcome::result<void>(_error_).error().message() << "'";     \
-    }                                                                     \
+#define ASSERT_OUTCOME_ERROR(_expression_, _error_)                        \
+  {                                                                        \
+    auto &&result = (_expression_);                                        \
+    if (result.has_error()) {                                              \
+      if (result != outcome::failure(_error_)) {                           \
+        GTEST_FATAL_FAILURE_("Outcome of: " #_expression_)                 \
+            << "  Actual:   Error '" << result.error().message() << "'\n"  \
+            << "Expected:   Error '" << make_error_code(_error_).message() \
+            << "'";                                                        \
+      }                                                                    \
+    } else {                                                               \
+      GTEST_FATAL_FAILURE_("Outcome of: " #_expression_)                   \
+          << "  Actual:   Success\n"                                       \
+          << "Expected:   Error '" << make_error_code(_error_).message()   \
+          << "'";                                                          \
+    }                                                                      \
   }
 
 #define EXPECT_OUTCOME_SUCCESS(_result_, _expression_)                  \
@@ -187,20 +187,19 @@
         << "Expected:   Some error";                      \
   }
 
-#define EXPECT_OUTCOME_ERROR(_result_, _expression_, _error_)             \
-  [[maybe_unused]] auto &&_result_ = (_expression_);                      \
-  if (_result_.has_error()) {                                             \
-    if (_result_ != outcome::failure(_error_)) {                          \
-      GTEST_NONFATAL_FAILURE_("Outcome of: " #_expression_)               \
-          << "  Actual:   Error '" << _result_.error().message() << "'\n" \
-          << "Expected:   Error '"                                        \
-          << outcome::result<void>(_error_).error().message() << "'";     \
-    }                                                                     \
-  } else {                                                                \
-    GTEST_NONFATAL_FAILURE_("Outcome of: " #_expression_)                 \
-        << "  Actual:   Success\n"                                        \
-        << "Expected:   Error '"                                          \
-        << outcome::result<void>(_error_).error().message() << "'";       \
+#define EXPECT_OUTCOME_ERROR(_result_, _expression_, _error_)                  \
+  [[maybe_unused]] auto &&_result_ = (_expression_);                           \
+  if (_result_.has_error()) {                                                  \
+    if (_result_ != outcome::failure(_error_)) {                               \
+      GTEST_NONFATAL_FAILURE_("Outcome of: " #_expression_)                    \
+          << "  Actual:   Error '" << _result_.error().message() << "'\n"      \
+          << "Expected:   Error '" << make_error_code(_error_).message()       \
+          << "'";                                                              \
+    }                                                                          \
+  } else {                                                                     \
+    GTEST_NONFATAL_FAILURE_("Outcome of: " #_expression_)                      \
+        << "  Actual:   Success\n"                                             \
+        << "Expected:   Error '" << make_error_code(_error_).message() << "'"; \
   }
 
 #endif  // KAGOME_GTEST_OUTCOME_UTIL_HPP


### PR DESCRIPTION
### Referenced issues
### Description of the Change
Implemented formatter for outcome to use them directly: `SL_DEBUG(log, "Error: {}", res.error());` (without `.message()`).

### Benefits
Simplify review and reduce size of #1410

### Possible Drawbacks 
