### PR TITLE
Refactor storage interface

### DIFF
--- a/core/api/service/child_state/impl/child_state_api_impl.cpp
+++ b/core/api/service/child_state/impl/child_state_api_impl.cpp
@@ -51,8 +51,7 @@ namespace kagome::api {
     OUTCOME_TRY(initial_trie_reader,
                 storage_->getEphemeralBatchAt(header.state_root));
     OUTCOME_TRY(child_root, initial_trie_reader->get(child_storage_key));
-    OUTCOME_TRY(child_root_hash,
-                common::Hash256::fromSpan(gsl::make_span(child_root.get())));
+    OUTCOME_TRY(child_root_hash, common::Hash256::fromSpan(child_root));
     OUTCOME_TRY(child_storage_trie_reader,
                 storage_->getEphemeralBatchAt(child_root_hash));
     auto cursor = child_storage_trie_reader->trieCursor();
@@ -90,8 +89,7 @@ namespace kagome::api {
     OUTCOME_TRY(initial_trie_reader,
                 storage_->getEphemeralBatchAt(header.state_root));
     OUTCOME_TRY(child_root, initial_trie_reader->get(child_storage_key));
-    OUTCOME_TRY(child_root_hash,
-                common::Hash256::fromSpan(gsl::make_span(child_root.get())));
+    OUTCOME_TRY(child_root_hash, common::Hash256::fromSpan(child_root));
     OUTCOME_TRY(child_storage_trie_reader,
                 storage_->getEphemeralBatchAt(child_root_hash));
     auto cursor = child_storage_trie_reader->trieCursor();
@@ -132,13 +130,12 @@ namespace kagome::api {
     OUTCOME_TRY(header, header_repo_->getBlockHeader(at));
     OUTCOME_TRY(trie_reader, storage_->getEphemeralBatchAt(header.state_root));
     OUTCOME_TRY(child_root, trie_reader->get(child_storage_key));
-    OUTCOME_TRY(child_root_hash,
-                common::Hash256::fromSpan(gsl::make_span(child_root.get())));
+    OUTCOME_TRY(child_root_hash, common::Hash256::fromSpan(child_root));
     OUTCOME_TRY(child_storage_trie_reader,
                 storage_->getEphemeralBatchAt(child_root_hash));
     auto res = child_storage_trie_reader->tryGet(key);
-    return common::map_result_optional(res,
-                                       [](const auto &r) { return r.get(); });
+    return common::map_result_optional(
+        std::move(res), [](common::BufferOrView &&r) { return r.into(); });
   }
 
   outcome::result<std::optional<primitives::BlockHash>>
@@ -164,11 +161,10 @@ namespace kagome::api {
     OUTCOME_TRY(header, header_repo_->getBlockHeader(at));
     OUTCOME_TRY(trie_reader, storage_->getEphemeralBatchAt(header.state_root));
     OUTCOME_TRY(child_root, trie_reader->get(child_storage_key));
-    OUTCOME_TRY(child_root_hash,
-                common::Hash256::fromSpan(gsl::make_span(child_root.get())));
+    OUTCOME_TRY(child_root_hash, common::Hash256::fromSpan(child_root));
     OUTCOME_TRY(child_storage_trie_reader,
                 storage_->getEphemeralBatchAt(child_root_hash));
     OUTCOME_TRY(value, child_storage_trie_reader->get(key));
-    return value.get().size();
+    return value.size();
   }
 }  // namespace kagome::api

--- a/core/api/service/state/impl/state_api_impl.cpp
+++ b/core/api/service/state/impl/state_api_impl.cpp
@@ -124,8 +124,8 @@ namespace kagome::api {
     OUTCOME_TRY(header, header_repo_->getBlockHeader(at));
     OUTCOME_TRY(trie_reader, storage_->getEphemeralBatchAt(header.state_root));
     auto res = trie_reader->tryGet(key);
-    return common::map_result_optional(res,
-                                       [](const auto &r) { return r.get(); });
+    return common::map_result_optional(
+        std::move(res), [](common::BufferOrView &&r) { return r.into(); });
   }
 
   outcome::result<std::vector<StateApiImpl::StorageChangeSet>>
@@ -164,14 +164,13 @@ namespace kagome::api {
       OUTCOME_TRY(batch, storage_->getEphemeralBatchAt(header.state_root));
       StorageChangeSet change{block, {}};
       for (auto &key : keys) {
-        OUTCOME_TRY(opt_value, batch->tryGet(key));
+        OUTCOME_TRY(opt_get, batch->tryGet(key));
+        auto opt_value = common::map_optional(
+            std::move(opt_get),
+            [](common::BufferOrView &&r) { return r.into(); });
         auto it = last_values.find(key);
         if (it == last_values.end() || it->second != opt_value) {
-          std::optional<common::Buffer> opt_buffer =
-              opt_value ? std::make_optional(opt_value.value().get())
-                        : std::nullopt;
-          change.changes.push_back(
-              StorageChangeSet::Change{common::Buffer{key}, opt_buffer});
+          change.changes.push_back(StorageChangeSet::Change{key, opt_value});
         }
         last_values[key] = std::move(opt_value);
       }

--- a/core/blockchain/impl/block_storage_impl.cpp
+++ b/core/blockchain/impl/block_storage_impl.cpp
@@ -12,8 +12,6 @@
 namespace kagome::blockchain {
   using primitives::Block;
   using primitives::BlockId;
-  using storage::face::MapCursor;
-  using storage::face::WriteBatch;
   using Buffer = common::Buffer;
   using Prefix = prefix::Prefix;
 

--- a/core/blockchain/impl/block_storage_impl.cpp
+++ b/core/blockchain/impl/block_storage_impl.cpp
@@ -254,7 +254,7 @@ namespace kagome::blockchain {
 
     auto num_to_idx_key =
         prependPrefix(numberToIndexKey(block.number), Prefix::ID_TO_LOOKUP_KEY);
-    OUTCOME_TRY(num_to_idx_val_opt, storage_->tryLoad(num_to_idx_key.view()));
+    OUTCOME_TRY(num_to_idx_val_opt, storage_->tryGet(num_to_idx_key.view()));
     if (num_to_idx_val_opt == block_lookup_key) {
       if (auto res = storage_->remove(num_to_idx_key); res.has_error()) {
         SL_ERROR(logger_,
@@ -299,7 +299,7 @@ namespace kagome::blockchain {
     }
 
     OUTCOME_TRY(leaves_opt,
-                storage_->tryLoad(storage::kBlockTreeLeavesLookupKey));
+                storage_->tryGet(storage::kBlockTreeLeavesLookupKey));
     if (not leaves_opt.has_value()) {
       return BlockStorageError::BLOCK_TREE_LEAVES_NOT_FOUND;
     }

--- a/core/blockchain/impl/common.cpp
+++ b/core/blockchain/impl/common.cpp
@@ -12,7 +12,7 @@
 
 namespace kagome::blockchain {
 
-  outcome::result<std::optional<common::Buffer>> idToLookupKey(
+  outcome::result<std::optional<common::BufferOrView>> idToLookupKey(
       const ReadableBufferStorage &map, const primitives::BlockId &id) {
     auto key = visit_in_place(
         id,

--- a/core/blockchain/impl/common.cpp
+++ b/core/blockchain/impl/common.cpp
@@ -24,7 +24,7 @@ namespace kagome::blockchain {
           return prependPrefix(hash, prefix::Prefix::ID_TO_LOOKUP_KEY);
         });
 
-    OUTCOME_TRY(key_opt, map.tryLoad(key));
+    OUTCOME_TRY(key_opt, map.tryGet(key));
 
     return std::move(key_opt);
   }

--- a/core/blockchain/impl/common.cpp
+++ b/core/blockchain/impl/common.cpp
@@ -35,7 +35,7 @@ namespace kagome::blockchain {
     auto codec = storage::trie::PolkadotCodec();
 
     for (const auto &[key, val] : key_vals) {
-      [[maybe_unused]] auto res = trie.put(key, val);
+      [[maybe_unused]] auto res = trie.put(key, common::BufferView{val});
       BOOST_ASSERT_MSG(res.has_value(), "Insertion into trie failed");
     }
     auto root = trie.getRoot();

--- a/core/blockchain/impl/common.hpp
+++ b/core/blockchain/impl/common.hpp
@@ -21,7 +21,7 @@ namespace kagome::blockchain {
    * Convert a block ID into a key, which is a first part of a key, by which the
    * columns are stored in the database
    */
-  outcome::result<std::optional<common::Buffer>> idToLookupKey(
+  outcome::result<std::optional<common::BufferOrView>> idToLookupKey(
       const ReadableBufferStorage &map, const primitives::BlockId &id);
 
   /**

--- a/core/blockchain/impl/common.hpp
+++ b/core/blockchain/impl/common.hpp
@@ -15,7 +15,7 @@
 namespace kagome::blockchain {
 
   using ReadableBufferStorage =
-      storage::face::Readable<common::BufferView, common::Buffer>;
+      storage::face::Readable<common::Buffer, common::Buffer>;
 
   /**
    * Convert a block ID into a key, which is a first part of a key, by which the

--- a/core/blockchain/impl/common.hpp
+++ b/core/blockchain/impl/common.hpp
@@ -15,7 +15,7 @@
 namespace kagome::blockchain {
 
   using ReadableBufferStorage =
-      storage::face::ReadableStorage<common::BufferView, common::Buffer>;
+      storage::face::Readable<common::BufferView, common::Buffer>;
 
   /**
    * Convert a block ID into a key, which is a first part of a key, by which the

--- a/core/blockchain/impl/storage_util.cpp
+++ b/core/blockchain/impl/storage_util.cpp
@@ -61,7 +61,7 @@ namespace kagome::blockchain {
       const primitives::BlockId &block_id) {
     OUTCOME_TRY(key, idToLookupKey(map, block_id));
     if (!key.has_value()) return std::nullopt;
-    return map.tryLoad(prependPrefix(key.value(), prefix));
+    return map.tryGet(prependPrefix(key.value(), prefix));
   }
 
   common::Buffer numberToIndexKey(primitives::BlockNumber n) {

--- a/core/blockchain/impl/storage_util.cpp
+++ b/core/blockchain/impl/storage_util.cpp
@@ -30,22 +30,21 @@ namespace kagome::blockchain {
     auto num_to_idx_key =
         prependPrefix(numberToIndexKey(block.number), Prefix::ID_TO_LOOKUP_KEY);
     auto block_lookup_key = numberAndHashToLookupKey(block.number, block.hash);
-    return map.put(num_to_idx_key, block_lookup_key);
+    return map.put(num_to_idx_key, std::move(block_lookup_key));
   }
 
   outcome::result<void> putWithPrefix(storage::BufferStorage &map,
                                       prefix::Prefix prefix,
                                       BlockNumber num,
                                       Hash256 block_hash,
-                                      const common::Buffer &value) {
+                                      common::BufferOrView &&value) {
     auto block_lookup_key = numberAndHashToLookupKey(num, block_hash);
 
     auto hash_to_idx_key = prependPrefix(block_hash, Prefix::ID_TO_LOOKUP_KEY);
-    OUTCOME_TRY(map.put(hash_to_idx_key, block_lookup_key));
-
     auto value_lookup_key = prependPrefix(block_lookup_key, prefix);
+    OUTCOME_TRY(map.put(hash_to_idx_key, std::move(block_lookup_key)));
 
-    return map.put(value_lookup_key, value);
+    return map.put(value_lookup_key, std::move(value));
   }
 
   outcome::result<bool> hasWithPrefix(const storage::BufferStorage &map,

--- a/core/blockchain/impl/storage_util.cpp
+++ b/core/blockchain/impl/storage_util.cpp
@@ -55,7 +55,7 @@ namespace kagome::blockchain {
     return map.contains(prependPrefix(key.value(), prefix));
   }
 
-  outcome::result<std::optional<common::Buffer>> getWithPrefix(
+  outcome::result<std::optional<common::BufferOrView>> getWithPrefix(
       const storage::BufferStorage &map,
       prefix::Prefix prefix,
       const primitives::BlockId &block_id) {

--- a/core/blockchain/impl/storage_util.hpp
+++ b/core/blockchain/impl/storage_util.hpp
@@ -86,7 +86,7 @@ namespace kagome::blockchain {
    * @param block_id - id of the block to get entry for
    * @return error, or an encoded entry, if any, or std::nullopt, if none
    */
-  outcome::result<std::optional<common::Buffer>> getWithPrefix(
+  outcome::result<std::optional<common::BufferOrView>> getWithPrefix(
       const storage::BufferStorage &storage,
       prefix::Prefix prefix,
       const primitives::BlockId &block_id);

--- a/core/blockchain/impl/storage_util.hpp
+++ b/core/blockchain/impl/storage_util.hpp
@@ -66,7 +66,7 @@ namespace kagome::blockchain {
                                       prefix::Prefix prefix,
                                       primitives::BlockNumber num,
                                       common::Hash256 block_hash,
-                                      const common::Buffer &value);
+                                      common::BufferOrView &&value);
 
   /**
    * Chech if an entry from the database

--- a/core/common/buffer.hpp
+++ b/core/common/buffer.hpp
@@ -245,9 +245,6 @@ namespace kagome::common {
 
   static inline const Buffer kEmptyBuffer{};
 
-  using BufferMutRef = std::reference_wrapper<Buffer>;
-  using BufferConstRef = std::reference_wrapper<const Buffer>;
-
   namespace literals {
     /// creates a buffer filled with characters from the original string
     /// mind that it does not perform unhexing, there is ""_unhex for it

--- a/core/common/buffer_or_view.hpp
+++ b/core/common/buffer_or_view.hpp
@@ -1,0 +1,74 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_COMMON_BUFFER_OR_VIEW_HPP
+#define KAGOME_COMMON_BUFFER_OR_VIEW_HPP
+
+#include <variant>
+
+#include "common/buffer.hpp"
+
+namespace kagome::common {
+  class BufferOrView {
+   public:
+    BufferOrView() = default;
+
+    BufferOrView(const BufferView &view) : variant{view} {}
+
+    BufferOrView(const std::vector<uint8_t> &vector) = delete;
+    BufferOrView(std::vector<uint8_t> &&vector)
+        : variant{Buffer{std::move(vector)}} {}
+
+    BufferOrView(const BufferOrView &) = delete;
+    BufferOrView(BufferOrView &&) = default;
+
+    BufferOrView &operator=(const BufferOrView &) = delete;
+    BufferOrView &operator=(BufferOrView &&) = default;
+
+    bool owned() const {
+      return variant.index() == 1;
+    }
+
+    BufferView view() const {
+      if (!owned()) {
+        return std::get<BufferView>(variant);
+      }
+      return BufferView{std::get<Buffer>(variant)};
+    }
+
+    operator BufferView() const {
+      return view();
+    }
+
+    size_t size() const {
+      return view().size();
+    }
+
+    // get mutable buffer reference, copy once if view
+    Buffer &mut() {
+      if (!owned()) {
+        auto view = std::get<BufferView>(variant);
+        variant.emplace<Buffer>(view);
+      }
+      return std::get<Buffer>(variant);
+    }
+
+    // move buffer away, copy once if view
+    Buffer into() {
+      auto buffer = std::move(mut());
+      variant.emplace<BufferView>();
+      return buffer;
+    }
+
+   private:
+    std::variant<BufferView, Buffer> variant;
+  };
+}  // namespace kagome::common
+
+template <>
+struct fmt::formatter<kagome::common::BufferOrView>
+    : fmt::formatter<kagome::common::BufferView> {};
+
+#endif  // KAGOME_COMMON_BUFFER_OR_VIEW_HPP

--- a/core/common/buffer_or_view.hpp
+++ b/core/common/buffer_or_view.hpp
@@ -12,6 +12,8 @@
 
 namespace kagome::common {
   class BufferOrView {
+    using Span = gsl::span<const uint8_t>;
+
    public:
     BufferOrView() = default;
 
@@ -64,6 +66,19 @@ namespace kagome::common {
 
    private:
     std::variant<BufferView, Buffer> variant;
+
+    friend bool operator==(const BufferOrView &l, const Span &r) {
+      return l.view() == r;
+    }
+    friend bool operator!=(const BufferOrView &l, const Span &r) {
+      return l.view() != r;
+    }
+    friend bool operator==(const Span &l, const BufferOrView &r) {
+      return l == r.view();
+    }
+    friend bool operator!=(const Span &l, const BufferOrView &r) {
+      return l != r.view();
+    }
   };
 }  // namespace kagome::common
 

--- a/core/common/buffer_or_view.hpp
+++ b/core/common/buffer_or_view.hpp
@@ -79,6 +79,18 @@ namespace kagome::common {
     friend bool operator!=(const Span &l, const BufferOrView &r) {
       return l != r.view();
     }
+    friend bool operator==(const BufferOrView &l, const Buffer &r) {
+      return l.view() == BufferView{r};
+    }
+    friend bool operator!=(const BufferOrView &l, const Buffer &r) {
+      return l.view() != BufferView{r};
+    }
+    friend bool operator==(const Buffer &l, const BufferOrView &r) {
+      return BufferView{l} == r.view();
+    }
+    friend bool operator!=(const Buffer &l, const BufferOrView &r) {
+      return BufferView{l} != r.view();
+    }
   };
 }  // namespace kagome::common
 

--- a/core/common/monadic_utils.hpp
+++ b/core/common/monadic_utils.hpp
@@ -98,8 +98,9 @@ namespace kagome::common {
   template <typename T, typename F, typename R = std::invoke_result_t<F, T &&>>
   outcome::result<std::optional<R>> map_result_optional(
       outcome::result<std::optional<T>> &&res_opt, F const &f) {
-    return map_result(res_opt, [&f](auto &opt) {
-      return map_optional(opt, [&f](auto &v) { return f(std::move(v)); });
+    return map_result(std::move(res_opt), [&f](std::optional<T> &&opt) {
+      return map_optional(std::move(opt),
+                          [&f](T &&v) { return f(std::move(v)); });
     });
   }
 

--- a/core/consensus/babe/impl/babe_config_repository_impl.cpp
+++ b/core/consensus/babe/impl/babe_config_repository_impl.cpp
@@ -103,7 +103,7 @@ namespace kagome::consensus::babe {
 
     // 1. Load last state
     OUTCOME_TRY(encoded_last_state_opt,
-                persistent_storage_->tryLoad(
+                persistent_storage_->tryGet(
                     storage::kBabeConfigRepoStateLookupKey("last")));
 
     if (encoded_last_state_opt.has_value()) {
@@ -138,7 +138,7 @@ namespace kagome::consensus::babe {
            block_number > 0;
            block_number -= kSavepointBlockInterval) {
         OUTCOME_TRY(encoded_saved_state_opt,
-                    persistent_storage_->tryLoad(
+                    persistent_storage_->tryGet(
                         storage::kBabeConfigRepoStateLookupKey(block_number)));
 
         if (not encoded_saved_state_opt.has_value()) {

--- a/core/consensus/babe/impl/consistency_keeper_impl.cpp
+++ b/core/consensus/babe/impl/consistency_keeper_impl.cpp
@@ -32,7 +32,7 @@ namespace kagome::consensus::babe {
 
   bool ConsistencyKeeperImpl::prepare() {
     // try to get record
-    auto buf_opt_res = storage_->tryLoad(storage::kApplyingBlockInfoLookupKey);
+    auto buf_opt_res = storage_->tryGet(storage::kApplyingBlockInfoLookupKey);
     if (buf_opt_res.has_error()) {
       SL_WARN(logger_,
               "Can't check existence of partial applied block",

--- a/core/consensus/babe/impl/consistency_keeper_impl.cpp
+++ b/core/consensus/babe/impl/consistency_keeper_impl.cpp
@@ -41,7 +41,7 @@ namespace kagome::consensus::babe {
     }
 
     // check if record exists
-    auto buf_opt = buf_opt_res.value();
+    auto &buf_opt = buf_opt_res.value();
     if (not buf_opt.has_value()) {
       return true;
     }

--- a/core/consensus/grandpa/impl/authority_manager_impl.cpp
+++ b/core/consensus/grandpa/impl/authority_manager_impl.cpp
@@ -105,7 +105,7 @@ namespace kagome::consensus::grandpa {
 
     // 1. Load last state
     OUTCOME_TRY(encoded_last_state_opt,
-                persistent_storage_->tryLoad(
+                persistent_storage_->tryGet(
                     storage::kAuthorityManagerStateLookupKey("last")));
 
     if (encoded_last_state_opt.has_value()) {
@@ -142,7 +142,7 @@ namespace kagome::consensus::grandpa {
            block_number -= kSavepointBlockInterval) {
         OUTCOME_TRY(
             encoded_saved_state_opt,
-            persistent_storage_->tryLoad(
+            persistent_storage_->tryGet(
                 storage::kAuthorityManagerStateLookupKey(block_number)));
 
         if (not encoded_saved_state_opt.has_value()) {

--- a/core/host_api/impl/child_storage_extension.cpp
+++ b/core/host_api/impl/child_storage_extension.cpp
@@ -18,7 +18,6 @@
 #include <utility>
 
 using kagome::common::Buffer;
-using kagome::common::BufferConstRef;
 using kagome::storage::trie::TrieError;
 
 namespace kagome::host_api {

--- a/core/host_api/impl/storage_extension.cpp
+++ b/core/host_api/impl/storage_extension.cpp
@@ -129,7 +129,7 @@ namespace kagome::host_api {
     SL_TRACE_VOID_FUNC_CALL(logger_, key, value);
 
     auto batch = storage_provider_->getCurrentBatch();
-    auto put_result = batch->put(key, value);
+    auto put_result = batch->put(key, std::move(value));
     if (not put_result) {
       logger_->error(
           "ext_set_storage failed, due to fail in trie db with reason: {}",
@@ -374,7 +374,7 @@ namespace kagome::host_api {
     storage::trie::PolkadotTrieImpl trie;
     for (auto &&p : pv) {
       auto &&key = p.first;
-      auto &&value = p.second;
+      common::BufferView value = p.second;
       // already scale-encoded
       auto put_res = trie.put(key, value);
       if (not put_res) {

--- a/core/host_api/impl/storage_extension.hpp
+++ b/core/host_api/impl/storage_extension.hpp
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 
+#include "common/buffer_or_view.hpp"
 #include "log/logger.hpp"
 #include "runtime/types.hpp"
 #include "storage/trie/serialization/polkadot_codec.hpp"
@@ -143,7 +144,7 @@ namespace kagome::host_api {
      * @param key Buffer representation of the key
      * @return result containing Buffer with the value
      */
-    outcome::result<std::optional<common::BufferConstRef>> get(
+    outcome::result<std::optional<common::BufferOrView>> get(
         const common::BufferView &key) const;
 
     /**

--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -340,7 +340,7 @@ namespace {
 
       for (const auto &[key_, val_] : raw_configs) {
         auto &key = key_;
-        auto &val = val_;
+        common::BufferView val = val_;
         SL_TRACE(
             log, "Key: {}, Val: {}", key.toHex(), val.toHex().substr(0, 200));
         if (auto res = batch->put(key, val); not res) {
@@ -367,7 +367,7 @@ namespace {
 
       common::Buffer child_key;
       child_key.put(storage::kChildStorageDefaultPrefix).put(root_hash);
-      auto res = batch->put(child_key, root_hash);
+      auto res = batch->put(child_key, common::BufferView{root_hash});
       if (res.has_error()) {
         common::raise(res.error());
       }

--- a/core/log/logger.hpp
+++ b/core/log/logger.hpp
@@ -65,11 +65,7 @@ namespace kagome::log {
     return arg;
   }
 
-  template <typename T,
-            typename = std::enable_if_t<std::is_same_v<
-                std::decay_t<decltype(*std::declval<T>().begin())>,
-                uint8_t>>>
-  std::string format_arg(T const &buffer) {
+  inline std::string format_arg(gsl::span<const uint8_t> buffer) {
     if (buffer.size() == 0) return "";
     std::string res;
     if (std::all_of(buffer.begin(), buffer.end(), isalnum)) {

--- a/core/network/impl/peer_manager_impl.cpp
+++ b/core/network/impl/peer_manager_impl.cpp
@@ -745,7 +745,7 @@ namespace kagome::network {
 
   std::vector<scale::PeerInfoSerializable>
   PeerManagerImpl::loadLastActivePeers() {
-    auto get_res = storage_->load(storage::kActivePeersKey);
+    auto get_res = storage_->get(storage::kActivePeersKey);
     if (not get_res) {
       SL_ERROR(log_,
                "List of last active peers cannot be obtained from storage. "

--- a/core/network/impl/synchronizer_impl.cpp
+++ b/core/network/impl/synchronizer_impl.cpp
@@ -117,7 +117,7 @@ namespace kagome::network {
   /** @see AppStateManager::takeControl */
   bool SynchronizerImpl::prepare() {
     auto opt_res =
-        buffer_storage_->tryLoad(storage::kBlockOfIncompleteSyncStateLookupKey);
+        buffer_storage_->tryGet(storage::kBlockOfIncompleteSyncStateLookupKey);
     if (opt_res.has_error()) {
       SL_ERROR(
           log_, "Can't check of incomplete state sync: {}", opt_res.error());

--- a/core/network/impl/synchronizer_impl.cpp
+++ b/core/network/impl/synchronizer_impl.cpp
@@ -991,7 +991,8 @@ namespace kagome::network {
                        state_entry.entries[0].key.toHex(),
                        state_entry.entries.size());
               for (const auto &entry : state_entry.entries) {
-                std::ignore = batch->put(entry.key, entry.value);
+                std::ignore =
+                    batch->put(entry.key, common::BufferView{entry.value});
               }
 
               // store batch to continue at next state_entry

--- a/core/offchain/impl/offchain_local_storage.cpp
+++ b/core/offchain/impl/offchain_local_storage.cpp
@@ -87,6 +87,7 @@ namespace kagome::offchain {
     throw std::invalid_argument("Off-chain local storage is unavailable yet");
 
     auto iKey = internalKey(key);
-    return storage_->load(iKey);
+    OUTCOME_TRY(value, storage_->load(iKey));
+    return value.into();
   }
 }  // namespace kagome::offchain

--- a/core/offchain/impl/offchain_local_storage.cpp
+++ b/core/offchain/impl/offchain_local_storage.cpp
@@ -64,7 +64,7 @@ namespace kagome::offchain {
 
     auto iKey = internalKey(key);
     std::lock_guard lg(mutex_);
-    OUTCOME_TRY(get_opt, storage_->tryLoad(iKey));
+    OUTCOME_TRY(get_opt, storage_->tryGet(iKey));
 
     std::optional<common::BufferView> existing;
     if (get_opt.has_value()) {
@@ -87,7 +87,7 @@ namespace kagome::offchain {
     throw std::invalid_argument("Off-chain local storage is unavailable yet");
 
     auto iKey = internalKey(key);
-    OUTCOME_TRY(value, storage_->load(iKey));
+    OUTCOME_TRY(value, storage_->get(iKey));
     return value.into();
   }
 }  // namespace kagome::offchain

--- a/core/offchain/impl/offchain_persistent_storage.cpp
+++ b/core/offchain/impl/offchain_persistent_storage.cpp
@@ -66,7 +66,8 @@ namespace kagome::offchain {
   outcome::result<common::Buffer> OffchainPersistentStorageImpl::get(
       const common::BufferView &key) {
     auto iKey = internalKey(key);
-    return storage_->load(iKey);
+    OUTCOME_TRY(value, storage_->load(iKey));
+    return value.into();
   }
 
 }  // namespace kagome::offchain

--- a/core/offchain/impl/offchain_persistent_storage.cpp
+++ b/core/offchain/impl/offchain_persistent_storage.cpp
@@ -47,7 +47,7 @@ namespace kagome::offchain {
       common::Buffer value) {
     auto iKey = internalKey(key);
     std::lock_guard lg(mutex_);
-    OUTCOME_TRY(get_opt, storage_->tryLoad(iKey));
+    OUTCOME_TRY(get_opt, storage_->tryGet(iKey));
 
     std::optional<common::BufferView> existing;
     if (get_opt.has_value()) {
@@ -66,7 +66,7 @@ namespace kagome::offchain {
   outcome::result<common::Buffer> OffchainPersistentStorageImpl::get(
       const common::BufferView &key) {
     auto iKey = internalKey(key);
-    OUTCOME_TRY(value, storage_->load(iKey));
+    OUTCOME_TRY(value, storage_->get(iKey));
     return value.into();
   }
 

--- a/core/runtime/common/runtime_environment_factory.cpp
+++ b/core/runtime/common/runtime_environment_factory.cpp
@@ -124,7 +124,7 @@ namespace kagome::runtime {
     auto heappages_res =
         env.storage_provider->getCurrentBatch()->get(heappages_key);
     if (heappages_res.has_value()) {
-      const auto &heappages = heappages_res.value().get();
+      const auto &heappages = heappages_res.value();
       if (sizeof(uint64_t) != heappages.size()) {
         parent_factory->logger_->error(
             "Unable to read :heappages value. Type size mismatch. "
@@ -132,7 +132,7 @@ namespace kagome::runtime {
             sizeof(uint64_t),
             heappages.size());
       } else {
-        uint64_t pages = common::le_bytes_to_uint64(heappages.asVector());
+        uint64_t pages = common::le_bytes_to_uint64(heappages.view());
         env.memory_provider->getCurrentMemory()->get().resize(
             pages * kMemoryPageSize);
         parent_factory->logger_->trace(

--- a/core/runtime/common/runtime_upgrade_tracker_impl.cpp
+++ b/core/runtime/common/runtime_upgrade_tracker_impl.cpp
@@ -25,8 +25,7 @@ namespace kagome::runtime {
     BOOST_ASSERT(code_substitutes);
     BOOST_ASSERT(block_storage);
 
-    OUTCOME_TRY(encoded_opt,
-                storage->tryLoad(storage::kRuntimeHashesLookupKey));
+    OUTCOME_TRY(encoded_opt, storage->tryGet(storage::kRuntimeHashesLookupKey));
 
     std::vector<RuntimeUpgradeData> saved_data{};
     if (encoded_opt.has_value()) {

--- a/core/runtime/common/storage_code_provider.cpp
+++ b/core/runtime/common/storage_code_provider.cpp
@@ -55,7 +55,7 @@ namespace kagome::runtime {
   outcome::result<void> StorageCodeProvider::setCodeFromBatch(
       const storage::trie::EphemeralTrieBatch &batch) const {
     OUTCOME_TRY(code, batch.get(storage::kRuntimeCodeKey));
-    OUTCOME_TRY(uncompressCodeIfNeeded(code.get(), cached_code_));
+    OUTCOME_TRY(uncompressCodeIfNeeded(code, cached_code_));
     return outcome::success();
   }
 }  // namespace kagome::runtime

--- a/core/runtime/common/trie_storage_provider_impl.cpp
+++ b/core/runtime/common/trie_storage_provider_impl.cpp
@@ -81,10 +81,9 @@ namespace kagome::runtime {
                root_path.toHex());
       OUTCOME_TRY(child_root_value, getCurrentBatch()->tryGet(root_path));
       auto child_root_hash =
-          child_root_value ? common::Hash256::fromSpan(
-                                 gsl::make_span(child_root_value.value().get()))
-                                 .value()
-                           : trie_serializer_->getEmptyRootHash();
+          child_root_value
+              ? common::Hash256::fromSpan(*child_root_value).value()
+              : trie_serializer_->getEmptyRootHash();
       OUTCOME_TRY(child_batch,
                   trie_storage_->getPersistentBatchAt(child_root_hash));
       child_batches_.emplace(root_path, std::move(child_batch));

--- a/core/runtime/runtime_api/impl/session_keys_api.cpp
+++ b/core/runtime/runtime_api/impl/session_keys_api.cpp
@@ -24,7 +24,7 @@ namespace kagome::runtime {
   outcome::result<std::vector<std::pair<crypto::KeyTypeId, common::Buffer>>>
   SessionKeysApiImpl::decode_session_keys(
       const primitives::BlockHash &block_hash,
-      common::BufferConstRef encoded) const {
+      common::BufferView encoded) const {
     return executor_
         ->callAt<std::vector<std::pair<crypto::KeyTypeId, common::Buffer>>>(
             block_hash, "SessionKeys_decode_session_keys", encoded);

--- a/core/runtime/runtime_api/impl/session_keys_api.hpp
+++ b/core/runtime/runtime_api/impl/session_keys_api.hpp
@@ -22,7 +22,7 @@ namespace kagome::runtime {
 
     outcome::result<std::vector<std::pair<crypto::KeyTypeId, common::Buffer>>>
     decode_session_keys(const primitives::BlockHash &block_hash,
-                        common::BufferConstRef encoded) const override;
+                        common::BufferView encoded) const override;
 
    private:
     std::shared_ptr<Executor> executor_;

--- a/core/runtime/runtime_api/session_keys_api.hpp
+++ b/core/runtime/runtime_api/session_keys_api.hpp
@@ -38,7 +38,7 @@ namespace kagome::runtime {
     virtual outcome::result<
         std::vector<std::pair<crypto::KeyTypeId, common::Buffer>>>
     decode_session_keys(const primitives::BlockHash &block_hash,
-                        common::BufferConstRef encoded) const = 0;
+                        common::BufferView encoded) const = 0;
   };
 
 }  // namespace kagome::runtime

--- a/core/storage/buffer_map_types.hpp
+++ b/core/storage/buffer_map_types.hpp
@@ -28,7 +28,6 @@ namespace kagome::storage {
 
   using Buffer = common::SLBuffer<std::numeric_limits<size_t>::max()>;
   using BufferView = common::BufferView;
-  using BufferConstRef = common::BufferConstRef;
   using common::BufferOrView;
 
   using BufferBatch = face::WriteBatch<BufferView, Buffer>;

--- a/core/storage/buffer_map_types.hpp
+++ b/core/storage/buffer_map_types.hpp
@@ -22,26 +22,23 @@ namespace kagome::storage::face {
   struct OwnedOrViewTrait<common::Buffer> {
     using type = common::BufferOrView;
   };
+
+  template <>
+  struct ViewTrait<common::Buffer> {
+    using type = common::BufferView;
+  };
 }  // namespace kagome::storage::face
 
 namespace kagome::storage {
-
-  using Buffer = common::SLBuffer<std::numeric_limits<size_t>::max()>;
-  using BufferView = common::BufferView;
+  using common::Buffer;
   using common::BufferOrView;
+  using common::BufferView;
 
-  using BufferBatch = face::WriteBatch<BufferView, Buffer>;
+  using BufferBatch = face::WriteBatch<Buffer, Buffer>;
 
-  using ReadOnlyBufferMap = face::ReadOnlyMap<BufferView, Buffer>;
+  using BufferStorage = face::GenericStorage<Buffer, Buffer>;
 
-  using BufferStorage = face::GenericStorage<Buffer, Buffer, BufferView>;
-
-  using BufferMap = face::GenericMap<BufferView, Buffer>;
-
-  using BufferMapCursor = face::MapCursor<BufferView, Buffer, BufferView>;
-
-  using BufferStorageCursor = face::MapCursor<Buffer, Buffer, BufferView>;
-
+  using BufferStorageCursor = face::MapCursor<Buffer, Buffer>;
 }  // namespace kagome::storage
 
 #endif  // KAGOME_BUFFER_MAP_TYPES_HPP

--- a/core/storage/buffer_map_types.hpp
+++ b/core/storage/buffer_map_types.hpp
@@ -12,15 +12,24 @@
  */
 
 #include "common/buffer.hpp"
+#include "common/buffer_or_view.hpp"
 #include "storage/face/batch_writeable.hpp"
 #include "storage/face/generic_maps.hpp"
 #include "storage/face/write_batch.hpp"
+
+namespace kagome::storage::face {
+  template <>
+  struct OwnedOrView<common::Buffer> {
+    using type = common::BufferOrView;
+  };
+}  // namespace kagome::storage::face
 
 namespace kagome::storage {
 
   using Buffer = common::SLBuffer<std::numeric_limits<size_t>::max()>;
   using BufferView = common::BufferView;
   using BufferConstRef = common::BufferConstRef;
+  using common::BufferOrView;
 
   using BufferBatch = face::WriteBatch<BufferView, Buffer>;
 

--- a/core/storage/buffer_map_types.hpp
+++ b/core/storage/buffer_map_types.hpp
@@ -19,7 +19,7 @@
 
 namespace kagome::storage::face {
   template <>
-  struct OwnedOrView<common::Buffer> {
+  struct OwnedOrViewTrait<common::Buffer> {
     using type = common::BufferOrView;
   };
 }  // namespace kagome::storage::face

--- a/core/storage/buffer_map_types.hpp
+++ b/core/storage/buffer_map_types.hpp
@@ -39,8 +39,7 @@ namespace kagome::storage {
 
   using BufferMap = face::GenericMap<BufferView, Buffer>;
 
-  using BufferMapCursor =
-      face::MapCursor<BufferView, BufferConstRef, BufferView>;
+  using BufferMapCursor = face::MapCursor<BufferView, Buffer, BufferView>;
 
   using BufferStorageCursor = face::MapCursor<Buffer, Buffer, BufferView>;
 

--- a/core/storage/face/batch_writeable.hpp
+++ b/core/storage/face/batch_writeable.hpp
@@ -27,7 +27,9 @@ namespace kagome::storage::face {
      * @brief Creates new Write Batch - an object, which can be used to
      * efficiently write bulk data.
      */
-    virtual std::unique_ptr<WriteBatch<K, V>> batch() = 0;
+    virtual std::unique_ptr<WriteBatch<K, V>> batch() {
+      abort();
+    }
   };
 
 }  // namespace kagome::storage::face

--- a/core/storage/face/generic_maps.hpp
+++ b/core/storage/face/generic_maps.hpp
@@ -20,11 +20,11 @@ namespace kagome::storage::face {
    */
   template <typename K, typename V, typename KView = K>
   struct ReadOnlyMap : public Iterable<K, V, KView>,
-                       public ReadableMap<KView, V> {};
+                       public Readable<KView, V> {};
 
   template <typename K, typename V, typename KView = K>
   struct ReadOnlyStorage : public Iterable<K, V, KView>,
-                           public ReadableStorage<KView, V> {};
+                           public Readable<KView, V> {};
 
   /**
    * @brief An abstraction over a readable, writeable, iterable key-value map.

--- a/core/storage/face/generic_maps.hpp
+++ b/core/storage/face/generic_maps.hpp
@@ -18,28 +18,26 @@ namespace kagome::storage::face {
    * @tparam K key type
    * @tparam V value type
    */
-  template <typename K, typename V, typename KView = K>
-  struct ReadOnlyMap : public Iterable<K, V, KView>,
-                       public Readable<KView, V> {};
+  template <typename K, typename V>
+  struct ReadOnlyMap : Iterable<K, V>, Readable<K, V> {};
 
-  template <typename K, typename V, typename KView = K>
-  struct ReadOnlyStorage : public Iterable<K, V, KView>,
-                           public Readable<KView, V> {};
+  template <typename K, typename V>
+  struct ReadOnlyStorage : Iterable<K, V>, Readable<K, V> {};
 
   /**
    * @brief An abstraction over a readable, writeable, iterable key-value map.
    * @tparam K key type
    * @tparam V value type
    */
-  template <typename K, typename V, typename KView = K>
-  struct GenericMap : public ReadOnlyMap<K, V, KView>,
-                      public Writeable<KView, V>,
-                      public BatchWriteable<KView, V> {};
+  template <typename K, typename V>
+  struct GenericMap : ReadOnlyMap<K, V>,
+                      Writeable<K, V>,
+                      BatchWriteable<K, V> {};
 
-  template <typename K, typename V, typename KView = K>
-  struct GenericStorage : public ReadOnlyStorage<K, V, KView>,
-                          public Writeable<KView, V>,
-                          public BatchWriteable<KView, V> {
+  template <typename K, typename V>
+  struct GenericStorage : ReadOnlyStorage<K, V>,
+                          Writeable<K, V>,
+                          BatchWriteable<K, V> {
     /**
      * Reports RAM state size
      * @return size in bytes

--- a/core/storage/face/generic_maps.hpp
+++ b/core/storage/face/generic_maps.hpp
@@ -19,9 +19,8 @@ namespace kagome::storage::face {
    * @tparam V value type
    */
   template <typename K, typename V, typename KView = K>
-  struct ReadOnlyMap
-      : public Iterable<K, typename ReadableMap<K, V>::ConstValueView, KView>,
-        public ReadableMap<KView, V> {};
+  struct ReadOnlyMap : public Iterable<K, V, KView>,
+                       public ReadableMap<KView, V> {};
 
   template <typename K, typename V, typename KView = K>
   struct ReadOnlyStorage : public Iterable<K, V, KView>,

--- a/core/storage/face/generic_maps.hpp
+++ b/core/storage/face/generic_maps.hpp
@@ -12,37 +12,23 @@
 #include "storage/face/writeable.hpp"
 
 namespace kagome::storage::face {
-
-  /**
-   * @brief An abstraction over a readable and iterable key-value map.
-   * @tparam K key type
-   * @tparam V value type
-   */
-  template <typename K, typename V>
-  struct ReadOnlyMap : Iterable<K, V>, Readable<K, V> {};
-
-  template <typename K, typename V>
-  struct ReadOnlyStorage : Iterable<K, V>, Readable<K, V> {};
-
   /**
    * @brief An abstraction over a readable, writeable, iterable key-value map.
    * @tparam K key type
    * @tparam V value type
    */
   template <typename K, typename V>
-  struct GenericMap : ReadOnlyMap<K, V>,
-                      Writeable<K, V>,
-                      BatchWriteable<K, V> {};
-
-  template <typename K, typename V>
-  struct GenericStorage : ReadOnlyStorage<K, V>,
+  struct GenericStorage : Readable<K, V>,
+                          Iterable<K, V>,
                           Writeable<K, V>,
                           BatchWriteable<K, V> {
     /**
      * Reports RAM state size
      * @return size in bytes
      */
-    virtual size_t size() const = 0;
+    virtual size_t size() const {
+      abort();
+    }
   };
 
 }  // namespace kagome::storage::face

--- a/core/storage/face/iterable.hpp
+++ b/core/storage/face/iterable.hpp
@@ -16,11 +16,10 @@ namespace kagome::storage::face {
    * @brief A mixin for an iterable map.
    * @tparam K map key type
    * @tparam V map value type
-   * @tparam KView map key view type
    */
-  template <typename K, typename V, typename KView = K>
+  template <typename K, typename V>
   struct Iterable {
-    using Cursor = MapCursor<K, V, KView>;
+    using Cursor = MapCursor<K, V>;
 
     virtual ~Iterable() = default;
 

--- a/core/storage/face/map_cursor.hpp
+++ b/core/storage/face/map_cursor.hpp
@@ -10,6 +10,7 @@
 
 #include "outcome/outcome.hpp"
 #include "storage/face/owned_or_view.hpp"
+#include "storage/face/view.hpp"
 
 namespace kagome::storage::face {
 
@@ -17,9 +18,8 @@ namespace kagome::storage::face {
    * @brief An abstraction over generic map cursor.
    * @tparam K key type
    * @tparam V value type
-   * @tparam KView key view type
    */
-  template <typename K, typename V, typename KView = K>
+  template <typename K, typename V>
   struct MapCursor {
     virtual ~MapCursor() = default;
 
@@ -33,7 +33,7 @@ namespace kagome::storage::face {
      * @brief Find given key and seek iterator to this key.
      * @return error if any, true if \arg key found, false otherwise
      */
-    virtual outcome::result<bool> seek(const KView &key) = 0;
+    virtual outcome::result<bool> seek(const View<K> &key) = 0;
 
     /**
      * @brief Same as std::rbegin(...);, e.g. points to the last valid element

--- a/core/storage/face/map_cursor.hpp
+++ b/core/storage/face/map_cursor.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 
 #include "outcome/outcome.hpp"
+#include "storage/face/owned_or_view.hpp"
 
 namespace kagome::storage::face {
 
@@ -62,7 +63,7 @@ namespace kagome::storage::face {
      * @brief Getter for value of the element currently pointed at.
      * @return value if isValid()
      */
-    virtual std::optional<V> value() const = 0;
+    virtual std::optional<OwnedOrViewOf<V>> value() const = 0;
   };
 
 }  // namespace kagome::storage::face

--- a/core/storage/face/map_cursor.hpp
+++ b/core/storage/face/map_cursor.hpp
@@ -63,7 +63,7 @@ namespace kagome::storage::face {
      * @brief Getter for value of the element currently pointed at.
      * @return value if isValid()
      */
-    virtual std::optional<OwnedOrViewOf<V>> value() const = 0;
+    virtual std::optional<OwnedOrView<V>> value() const = 0;
   };
 
 }  // namespace kagome::storage::face

--- a/core/storage/face/owned_or_view.hpp
+++ b/core/storage/face/owned_or_view.hpp
@@ -1,0 +1,17 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_STORAGE_FACE_OWNED_OR_VIEW_HPP
+#define KAGOME_STORAGE_FACE_OWNED_OR_VIEW_HPP
+
+namespace kagome::storage::face {
+  template <typename T>
+  struct OwnedOrView;
+
+  template <typename T>
+  using OwnedOrViewOf = typename OwnedOrView<T>::type;
+}  // namespace kagome::storage::face
+
+#endif  // KAGOME_STORAGE_FACE_OWNED_OR_VIEW_HPP

--- a/core/storage/face/owned_or_view.hpp
+++ b/core/storage/face/owned_or_view.hpp
@@ -8,10 +8,10 @@
 
 namespace kagome::storage::face {
   template <typename T>
-  struct OwnedOrView;
+  struct OwnedOrViewTrait;
 
   template <typename T>
-  using OwnedOrViewOf = typename OwnedOrView<T>::type;
+  using OwnedOrView = typename OwnedOrViewTrait<T>::type;
 }  // namespace kagome::storage::face
 
 #endif  // KAGOME_STORAGE_FACE_OWNED_OR_VIEW_HPP

--- a/core/storage/face/readable.hpp
+++ b/core/storage/face/readable.hpp
@@ -9,6 +9,7 @@
 #include <outcome/outcome.hpp>
 
 #include "storage/face/owned_or_view.hpp"
+#include "storage/face/view.hpp"
 
 namespace kagome::storage::face {
   /**
@@ -25,7 +26,7 @@ namespace kagome::storage::face {
      * @param key K
      * @return true if key has value, false if does not, or error at .
      */
-    virtual outcome::result<bool> contains(const K &key) const = 0;
+    virtual outcome::result<bool> contains(const View<K> &key) const = 0;
 
     /**
      * @brief Returns true if the storage is empty.
@@ -37,7 +38,7 @@ namespace kagome::storage::face {
      * @param key K
      * @return V
      */
-    virtual outcome::result<OwnedOrView<V>> get(const K &key) const = 0;
+    virtual outcome::result<OwnedOrView<V>> get(const View<K> &key) const = 0;
 
     /**
      * @brief Get value by key
@@ -45,7 +46,7 @@ namespace kagome::storage::face {
      * @return V if contains(K) or std::nullopt
      */
     virtual outcome::result<std::optional<OwnedOrView<V>>> tryGet(
-        const K &key) const = 0;
+        const View<K> &key) const = 0;
   };
 }  // namespace kagome::storage::face
 

--- a/core/storage/face/readable.hpp
+++ b/core/storage/face/readable.hpp
@@ -14,8 +14,6 @@ namespace kagome::storage::face {
 
   template <typename K>
   struct ReadableBase {
-    using Key = K;
-
     virtual ~ReadableBase() = default;
 
     /**
@@ -23,7 +21,7 @@ namespace kagome::storage::face {
      * @param key K
      * @return true if key has value, false if does not, or error at .
      */
-    virtual outcome::result<bool> contains(const Key &key) const = 0;
+    virtual outcome::result<bool> contains(const K &key) const = 0;
 
     /**
      * @brief Returns true if the storage is empty.
@@ -38,8 +36,6 @@ namespace kagome::storage::face {
    */
   template <typename K, typename V>
   struct ReadableMap : public ReadableBase<K> {
-    using Key = K;
-
     virtual ~ReadableMap() = default;
 
     /**
@@ -47,7 +43,7 @@ namespace kagome::storage::face {
      * @param key K
      * @return V
      */
-    virtual outcome::result<OwnedOrView<V>> get(const Key &key) const = 0;
+    virtual outcome::result<OwnedOrView<V>> get(const K &key) const = 0;
 
     /**
      * @brief Get value by key
@@ -55,13 +51,11 @@ namespace kagome::storage::face {
      * @return V if contains(K) or std::nullopt
      */
     virtual outcome::result<std::optional<OwnedOrView<V>>> tryGet(
-        const Key &key) const = 0;
+        const K &key) const = 0;
   };
 
   template <typename K, typename V>
   struct ReadableStorage : public ReadableBase<K> {
-    using Key = K;
-
     virtual ~ReadableStorage() = default;
 
     /**
@@ -69,7 +63,7 @@ namespace kagome::storage::face {
      * @param key K
      * @return V
      */
-    virtual outcome::result<OwnedOrView<V>> get(const Key &key) const = 0;
+    virtual outcome::result<OwnedOrView<V>> get(const K &key) const = 0;
 
     /**
      * @brief Load value by key
@@ -77,7 +71,7 @@ namespace kagome::storage::face {
      * @return V if contains(K) or std::nullopt
      */
     virtual outcome::result<std::optional<OwnedOrView<V>>> tryGet(
-        const Key &key) const = 0;
+        const K &key) const = 0;
   };
 
 }  // namespace kagome::storage::face

--- a/core/storage/face/readable.hpp
+++ b/core/storage/face/readable.hpp
@@ -39,9 +39,6 @@ namespace kagome::storage::face {
   template <typename K, typename V>
   struct ReadableMap : public ReadableBase<K> {
     using Key = K;
-    using Value = V;
-    using ValueView = std::reference_wrapper<V>;
-    using ConstValueView = std::reference_wrapper<const V>;
 
     virtual ~ReadableMap() = default;
 
@@ -50,14 +47,14 @@ namespace kagome::storage::face {
      * @param key K
      * @return V
      */
-    virtual outcome::result<ConstValueView> get(const Key &key) const = 0;
+    virtual outcome::result<OwnedOrViewOf<V>> get(const Key &key) const = 0;
 
     /**
      * @brief Get value by key
      * @param key K
      * @return V if contains(K) or std::nullopt
      */
-    virtual outcome::result<std::optional<ConstValueView>> tryGet(
+    virtual outcome::result<std::optional<OwnedOrViewOf<V>>> tryGet(
         const Key &key) const = 0;
   };
 

--- a/core/storage/face/readable.hpp
+++ b/core/storage/face/readable.hpp
@@ -47,14 +47,14 @@ namespace kagome::storage::face {
      * @param key K
      * @return V
      */
-    virtual outcome::result<OwnedOrViewOf<V>> get(const Key &key) const = 0;
+    virtual outcome::result<OwnedOrView<V>> get(const Key &key) const = 0;
 
     /**
      * @brief Get value by key
      * @param key K
      * @return V if contains(K) or std::nullopt
      */
-    virtual outcome::result<std::optional<OwnedOrViewOf<V>>> tryGet(
+    virtual outcome::result<std::optional<OwnedOrView<V>>> tryGet(
         const Key &key) const = 0;
   };
 
@@ -69,14 +69,14 @@ namespace kagome::storage::face {
      * @param key K
      * @return V
      */
-    virtual outcome::result<OwnedOrViewOf<V>> load(const Key &key) const = 0;
+    virtual outcome::result<OwnedOrView<V>> load(const Key &key) const = 0;
 
     /**
      * @brief Load value by key
      * @param key K
      * @return V if contains(K) or std::nullopt
      */
-    virtual outcome::result<std::optional<OwnedOrViewOf<V>>> tryLoad(
+    virtual outcome::result<std::optional<OwnedOrView<V>>> tryLoad(
         const Key &key) const = 0;
   };
 

--- a/core/storage/face/readable.hpp
+++ b/core/storage/face/readable.hpp
@@ -11,10 +11,14 @@
 #include "storage/face/owned_or_view.hpp"
 
 namespace kagome::storage::face {
-
-  template <typename K>
-  struct ReadableBase {
-    virtual ~ReadableBase() = default;
+  /**
+   * @brief A mixin for read-only map.
+   * @tparam K key type
+   * @tparam V value type
+   */
+  template <typename K, typename V>
+  struct Readable {
+    virtual ~Readable() = default;
 
     /**
      * @brief Checks if given key-value binding exists in the storage.
@@ -27,16 +31,6 @@ namespace kagome::storage::face {
      * @brief Returns true if the storage is empty.
      */
     virtual bool empty() const = 0;
-  };
-
-  /**
-   * @brief A mixin for read-only map.
-   * @tparam K key type
-   * @tparam V value type
-   */
-  template <typename K, typename V>
-  struct ReadableMap : public ReadableBase<K> {
-    virtual ~ReadableMap() = default;
 
     /**
      * @brief Get value by key
@@ -53,27 +47,6 @@ namespace kagome::storage::face {
     virtual outcome::result<std::optional<OwnedOrView<V>>> tryGet(
         const K &key) const = 0;
   };
-
-  template <typename K, typename V>
-  struct ReadableStorage : public ReadableBase<K> {
-    virtual ~ReadableStorage() = default;
-
-    /**
-     * @brief Load value by key
-     * @param key K
-     * @return V
-     */
-    virtual outcome::result<OwnedOrView<V>> get(const K &key) const = 0;
-
-    /**
-     * @brief Load value by key
-     * @param key K
-     * @return V if contains(K) or std::nullopt
-     */
-    virtual outcome::result<std::optional<OwnedOrView<V>>> tryGet(
-        const K &key) const = 0;
-  };
-
 }  // namespace kagome::storage::face
 
 #endif  // KAGOME_READABLE_HPP

--- a/core/storage/face/readable.hpp
+++ b/core/storage/face/readable.hpp
@@ -69,14 +69,14 @@ namespace kagome::storage::face {
      * @param key K
      * @return V
      */
-    virtual outcome::result<OwnedOrView<V>> load(const Key &key) const = 0;
+    virtual outcome::result<OwnedOrView<V>> get(const Key &key) const = 0;
 
     /**
      * @brief Load value by key
      * @param key K
      * @return V if contains(K) or std::nullopt
      */
-    virtual outcome::result<std::optional<OwnedOrView<V>>> tryLoad(
+    virtual outcome::result<std::optional<OwnedOrView<V>>> tryGet(
         const Key &key) const = 0;
   };
 

--- a/core/storage/face/readable.hpp
+++ b/core/storage/face/readable.hpp
@@ -8,7 +8,7 @@
 
 #include <outcome/outcome.hpp>
 
-#include "storage/face/map_cursor.hpp"
+#include "storage/face/owned_or_view.hpp"
 
 namespace kagome::storage::face {
 
@@ -64,7 +64,6 @@ namespace kagome::storage::face {
   template <typename K, typename V>
   struct ReadableStorage : public ReadableBase<K> {
     using Key = K;
-    using Value = V;
 
     virtual ~ReadableStorage() = default;
 
@@ -73,14 +72,15 @@ namespace kagome::storage::face {
      * @param key K
      * @return V
      */
-    virtual outcome::result<V> load(const Key &key) const = 0;
+    virtual outcome::result<OwnedOrViewOf<V>> load(const Key &key) const = 0;
 
     /**
      * @brief Load value by key
      * @param key K
      * @return V if contains(K) or std::nullopt
      */
-    virtual outcome::result<std::optional<V>> tryLoad(const Key &key) const = 0;
+    virtual outcome::result<std::optional<OwnedOrViewOf<V>>> tryLoad(
+        const Key &key) const = 0;
   };
 
 }  // namespace kagome::storage::face

--- a/core/storage/face/view.hpp
+++ b/core/storage/face/view.hpp
@@ -1,0 +1,17 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_STORAGE_FACE_VIEW_HPP
+#define KAGOME_STORAGE_FACE_VIEW_HPP
+
+namespace kagome::storage::face {
+  template <typename T>
+  struct ViewTrait;
+
+  template <typename T>
+  using View = typename ViewTrait<T>::type;
+}  // namespace kagome::storage::face
+
+#endif  // KAGOME_STORAGE_FACE_VIEW_HPP

--- a/core/storage/face/writeable.hpp
+++ b/core/storage/face/writeable.hpp
@@ -9,6 +9,7 @@
 #include <outcome/outcome.hpp>
 
 #include "storage/face/owned_or_view.hpp"
+#include "storage/face/view.hpp"
 
 namespace kagome::storage::face {
 
@@ -27,14 +28,15 @@ namespace kagome::storage::face {
      * @param value value
      * @return result containing void if put successful, error otherwise
      */
-    virtual outcome::result<void> put(const K &key, OwnedOrView<V> &&value) = 0;
+    virtual outcome::result<void> put(const View<K> &key,
+                                      OwnedOrView<V> &&value) = 0;
 
     /**
      * @brief Remove value by key
      * @param key K
      * @return error code if error happened
      */
-    virtual outcome::result<void> remove(const K &key) = 0;
+    virtual outcome::result<void> remove(const View<K> &key) = 0;
   };
 
 }  // namespace kagome::storage::face

--- a/core/storage/face/writeable.hpp
+++ b/core/storage/face/writeable.hpp
@@ -8,6 +8,8 @@
 
 #include <outcome/outcome.hpp>
 
+#include "storage/face/owned_or_view.hpp"
+
 namespace kagome::storage::face {
 
   /**
@@ -25,8 +27,8 @@ namespace kagome::storage::face {
      * @param value value
      * @return result containing void if put successful, error otherwise
      */
-    virtual outcome::result<void> put(const K &key, const V &value) = 0;
-    virtual outcome::result<void> put(const K &key, V &&value) = 0;
+    virtual outcome::result<void> put(const K &key,
+                                      OwnedOrViewOf<V> &&value) = 0;
 
     /**
      * @brief Remove value by key

--- a/core/storage/face/writeable.hpp
+++ b/core/storage/face/writeable.hpp
@@ -27,8 +27,7 @@ namespace kagome::storage::face {
      * @param value value
      * @return result containing void if put successful, error otherwise
      */
-    virtual outcome::result<void> put(const K &key,
-                                      OwnedOrViewOf<V> &&value) = 0;
+    virtual outcome::result<void> put(const K &key, OwnedOrView<V> &&value) = 0;
 
     /**
      * @brief Remove value by key

--- a/core/storage/in_memory/in_memory_batch.hpp
+++ b/core/storage/in_memory/in_memory_batch.hpp
@@ -18,13 +18,8 @@ namespace kagome::storage {
     explicit InMemoryBatch(InMemoryStorage &db) : db{db} {}
 
     outcome::result<void> put(const BufferView &key,
-                              const Buffer &value) override {
-      entries[key.toHex()] = value;
-      return outcome::success();
-    }
-
-    outcome::result<void> put(const BufferView &key, Buffer &&value) override {
-      entries[key.toHex()] = std::move(value);
+                              BufferOrView &&value) override {
+      entries[key.toHex()] = value.into();
       return outcome::success();
     }
 
@@ -35,7 +30,8 @@ namespace kagome::storage {
 
     outcome::result<void> commit() override {
       for (auto &entry : entries) {
-        OUTCOME_TRY(db.put(Buffer::fromHex(entry.first).value(), entry.second));
+        OUTCOME_TRY(db.put(Buffer::fromHex(entry.first).value(),
+                           BufferView{entry.second}));
       }
       return outcome::success();
     }

--- a/core/storage/in_memory/in_memory_batch.hpp
+++ b/core/storage/in_memory/in_memory_batch.hpp
@@ -12,8 +12,7 @@
 namespace kagome::storage {
   using kagome::common::Buffer;
 
-  class InMemoryBatch
-      : public kagome::storage::face::WriteBatch<BufferView, Buffer> {
+  class InMemoryBatch : public BufferBatch {
    public:
     explicit InMemoryBatch(InMemoryStorage &db) : db{db} {}
 

--- a/core/storage/in_memory/in_memory_storage.cpp
+++ b/core/storage/in_memory/in_memory_storage.cpp
@@ -12,7 +12,7 @@ using kagome::common::Buffer;
 
 namespace kagome::storage {
 
-  outcome::result<BufferOrView> InMemoryStorage::load(
+  outcome::result<BufferOrView> InMemoryStorage::get(
       const BufferView &key) const {
     if (storage.find(key.toHex()) != storage.end()) {
       return BufferView{storage.at(key.toHex())};
@@ -21,7 +21,7 @@ namespace kagome::storage {
     return DatabaseError::NOT_FOUND;
   }
 
-  outcome::result<std::optional<BufferOrView>> InMemoryStorage::tryLoad(
+  outcome::result<std::optional<BufferOrView>> InMemoryStorage::tryGet(
       const common::BufferView &key) const {
     if (storage.find(key.toHex()) != storage.end()) {
       return BufferView{storage.at(key.toHex())};

--- a/core/storage/in_memory/in_memory_storage.cpp
+++ b/core/storage/in_memory/in_memory_storage.cpp
@@ -31,7 +31,7 @@ namespace kagome::storage {
   }
 
   outcome::result<void> InMemoryStorage::put(const BufferView &key,
-                                             const Buffer &value) {
+                                             BufferOrView &&value) {
     auto it = storage.find(key.toHex());
     if (it != storage.end()) {
       size_t old_value_size = it->second.size();
@@ -39,20 +39,7 @@ namespace kagome::storage {
       size_ -= old_value_size;
     }
     size_ += value.size();
-    storage[key.toHex()] = value;
-    return outcome::success();
-  }
-
-  outcome::result<void> InMemoryStorage::put(const BufferView &key,
-                                             Buffer &&value) {
-    auto it = storage.find(key.toHex());
-    if (it != storage.end()) {
-      size_t old_value_size = it->second.size();
-      BOOST_ASSERT(size_ >= old_value_size);
-      size_ -= old_value_size;
-    }
-    size_ += value.size();
-    storage[key.toHex()] = std::move(value);
+    storage[key.toHex()] = value.into();
     return outcome::success();
   }
 

--- a/core/storage/in_memory/in_memory_storage.cpp
+++ b/core/storage/in_memory/in_memory_storage.cpp
@@ -60,8 +60,7 @@ namespace kagome::storage {
     return outcome::success();
   }
 
-  std::unique_ptr<kagome::storage::face::WriteBatch<BufferView, Buffer>>
-  InMemoryStorage::batch() {
+  std::unique_ptr<BufferBatch> InMemoryStorage::batch() {
     return std::make_unique<InMemoryBatch>(*this);
   }
 

--- a/core/storage/in_memory/in_memory_storage.cpp
+++ b/core/storage/in_memory/in_memory_storage.cpp
@@ -12,19 +12,19 @@ using kagome::common::Buffer;
 
 namespace kagome::storage {
 
-  outcome::result<common::Buffer> InMemoryStorage::load(
+  outcome::result<BufferOrView> InMemoryStorage::load(
       const BufferView &key) const {
     if (storage.find(key.toHex()) != storage.end()) {
-      return storage.at(key.toHex());
+      return BufferView{storage.at(key.toHex())};
     }
 
     return DatabaseError::NOT_FOUND;
   }
 
-  outcome::result<std::optional<Buffer>> InMemoryStorage::tryLoad(
+  outcome::result<std::optional<BufferOrView>> InMemoryStorage::tryLoad(
       const common::BufferView &key) const {
     if (storage.find(key.toHex()) != storage.end()) {
-      return storage.at(key.toHex());
+      return BufferView{storage.at(key.toHex())};
     }
 
     return std::nullopt;

--- a/core/storage/in_memory/in_memory_storage.hpp
+++ b/core/storage/in_memory/in_memory_storage.hpp
@@ -30,10 +30,7 @@ namespace kagome::storage {
         const common::BufferView &key) const override;
 
     outcome::result<void> put(const common::BufferView &key,
-                              const common::Buffer &value) override;
-
-    outcome::result<void> put(const common::BufferView &key,
-                              common::Buffer &&value) override;
+                              BufferOrView &&value) override;
 
     outcome::result<bool> contains(
         const common::BufferView &key) const override;

--- a/core/storage/in_memory/in_memory_storage.hpp
+++ b/core/storage/in_memory/in_memory_storage.hpp
@@ -23,10 +23,10 @@ namespace kagome::storage {
    public:
     ~InMemoryStorage() override = default;
 
-    outcome::result<common::Buffer> load(
+    outcome::result<BufferOrView> load(
         const common::BufferView &key) const override;
 
-    outcome::result<std::optional<common::Buffer>> tryLoad(
+    outcome::result<std::optional<BufferOrView>> tryLoad(
         const common::BufferView &key) const override;
 
     outcome::result<void> put(const common::BufferView &key,

--- a/core/storage/in_memory/in_memory_storage.hpp
+++ b/core/storage/in_memory/in_memory_storage.hpp
@@ -39,9 +39,7 @@ namespace kagome::storage {
 
     outcome::result<void> remove(const common::BufferView &key) override;
 
-    std::unique_ptr<
-        kagome::storage::face::WriteBatch<common::BufferView, common::Buffer>>
-    batch() override;
+    std::unique_ptr<BufferBatch> batch() override;
 
     std::unique_ptr<storage::BufferStorage::Cursor> cursor() override;
 

--- a/core/storage/in_memory/in_memory_storage.hpp
+++ b/core/storage/in_memory/in_memory_storage.hpp
@@ -23,10 +23,10 @@ namespace kagome::storage {
    public:
     ~InMemoryStorage() override = default;
 
-    outcome::result<BufferOrView> load(
+    outcome::result<BufferOrView> get(
         const common::BufferView &key) const override;
 
-    outcome::result<std::optional<BufferOrView>> tryLoad(
+    outcome::result<std::optional<BufferOrView>> tryGet(
         const common::BufferView &key) const override;
 
     outcome::result<void> put(const common::BufferView &key,

--- a/core/storage/in_memory/in_memory_storage.hpp
+++ b/core/storage/in_memory/in_memory_storage.hpp
@@ -41,7 +41,7 @@ namespace kagome::storage {
 
     std::unique_ptr<BufferBatch> batch() override;
 
-    std::unique_ptr<storage::BufferStorage::Cursor> cursor() override;
+    std::unique_ptr<Cursor> cursor() override;
 
     size_t size() const override;
 

--- a/core/storage/rocksdb/rocksdb.cpp
+++ b/core/storage/rocksdb/rocksdb.cpp
@@ -123,7 +123,7 @@ namespace kagome::storage {
     return it->Valid();
   }
 
-  outcome::result<Buffer> RocksDB::load(const BufferView &key) const {
+  outcome::result<BufferOrView> RocksDB::load(const BufferView &key) const {
     std::string value;
     auto status = db_->Get(ro_, make_slice(key), &value);
     if (status.ok()) {
@@ -135,7 +135,7 @@ namespace kagome::storage {
     return status_as_error(status);
   }
 
-  outcome::result<std::optional<Buffer>> RocksDB::tryLoad(
+  outcome::result<std::optional<BufferOrView>> RocksDB::tryLoad(
       const BufferView &key) const {
     std::string value;
     auto status = db_->Get(ro_, make_slice(key), &value);

--- a/core/storage/rocksdb/rocksdb.cpp
+++ b/core/storage/rocksdb/rocksdb.cpp
@@ -153,18 +153,13 @@ namespace kagome::storage {
   }
 
   outcome::result<void> RocksDB::put(const BufferView &key,
-                                     const Buffer &value) {
+                                     BufferOrView &&value) {
     auto status = db_->Put(wo_, make_slice(key), make_slice(value));
     if (status.ok()) {
       return outcome::success();
     }
 
     return status_as_error(status);
-  }
-
-  outcome::result<void> RocksDB::put(const BufferView &key, Buffer &&value) {
-    Buffer copy(std::move(value));
-    return put(key, copy);
   }
 
   outcome::result<void> RocksDB::remove(const BufferView &key) {

--- a/core/storage/rocksdb/rocksdb.cpp
+++ b/core/storage/rocksdb/rocksdb.cpp
@@ -123,7 +123,7 @@ namespace kagome::storage {
     return it->Valid();
   }
 
-  outcome::result<BufferOrView> RocksDB::load(const BufferView &key) const {
+  outcome::result<BufferOrView> RocksDB::get(const BufferView &key) const {
     std::string value;
     auto status = db_->Get(ro_, make_slice(key), &value);
     if (status.ok()) {
@@ -135,7 +135,7 @@ namespace kagome::storage {
     return status_as_error(status);
   }
 
-  outcome::result<std::optional<BufferOrView>> RocksDB::tryLoad(
+  outcome::result<std::optional<BufferOrView>> RocksDB::tryGet(
       const BufferView &key) const {
     std::string value;
     auto status = db_->Get(ro_, make_slice(key), &value);

--- a/core/storage/rocksdb/rocksdb.hpp
+++ b/core/storage/rocksdb/rocksdb.hpp
@@ -38,14 +38,14 @@ namespace kagome::storage {
 
     std::unique_ptr<Cursor> cursor() override;
 
-    outcome::result<bool> contains(const Key &key) const override;
+    outcome::result<bool> contains(const BufferView &key) const override;
 
     bool empty() const override;
 
-    outcome::result<BufferOrView> get(const Key &key) const override;
+    outcome::result<BufferOrView> get(const BufferView &key) const override;
 
     outcome::result<std::optional<BufferOrView>> tryGet(
-        const Key &key) const override;
+        const BufferView &key) const override;
 
     outcome::result<void> put(const BufferView &key,
                               BufferOrView &&value) override;

--- a/core/storage/rocksdb/rocksdb.hpp
+++ b/core/storage/rocksdb/rocksdb.hpp
@@ -49,9 +49,7 @@ namespace kagome::storage {
         const Key &key) const override;
 
     outcome::result<void> put(const BufferView &key,
-                              const Buffer &value) override;
-
-    outcome::result<void> put(const BufferView &key, Buffer &&value) override;
+                              BufferOrView &&value) override;
 
     outcome::result<void> remove(const BufferView &key) override;
 

--- a/core/storage/rocksdb/rocksdb.hpp
+++ b/core/storage/rocksdb/rocksdb.hpp
@@ -42,10 +42,9 @@ namespace kagome::storage {
 
     bool empty() const override;
 
-    outcome::result<kagome::storage::Buffer> load(
-        const Key &key) const override;
+    outcome::result<BufferOrView> load(const Key &key) const override;
 
-    outcome::result<std::optional<Buffer>> tryLoad(
+    outcome::result<std::optional<BufferOrView>> tryLoad(
         const Key &key) const override;
 
     outcome::result<void> put(const BufferView &key,

--- a/core/storage/rocksdb/rocksdb.hpp
+++ b/core/storage/rocksdb/rocksdb.hpp
@@ -42,9 +42,9 @@ namespace kagome::storage {
 
     bool empty() const override;
 
-    outcome::result<BufferOrView> load(const Key &key) const override;
+    outcome::result<BufferOrView> get(const Key &key) const override;
 
-    outcome::result<std::optional<BufferOrView>> tryLoad(
+    outcome::result<std::optional<BufferOrView>> tryGet(
         const Key &key) const override;
 
     outcome::result<void> put(const BufferView &key,

--- a/core/storage/rocksdb/rocksdb_batch.cpp
+++ b/core/storage/rocksdb/rocksdb_batch.cpp
@@ -13,14 +13,9 @@ namespace kagome::storage {
   RocksDB::Batch::Batch(RocksDB &db) : db_(db) {}
 
   outcome::result<void> RocksDB::Batch::put(const BufferView &key,
-                                            const Buffer &value) {
+                                            BufferOrView &&value) {
     batch_.Put(make_slice(key), make_slice(value));
     return outcome::success();
-  }
-
-  outcome::result<void> RocksDB::Batch::put(const BufferView &key,
-                                            Buffer &&value) {
-    return put(key, static_cast<const Buffer &>(value));
   }
 
   outcome::result<void> RocksDB::Batch::remove(const BufferView &key) {

--- a/core/storage/rocksdb/rocksdb_batch.hpp
+++ b/core/storage/rocksdb/rocksdb_batch.hpp
@@ -22,9 +22,7 @@ namespace kagome::storage {
     void clear() override;
 
     outcome::result<void> put(const BufferView &key,
-                              const Buffer &value) override;
-
-    outcome::result<void> put(const BufferView &key, Buffer &&value) override;
+                              BufferOrView &&value) override;
 
     outcome::result<void> remove(const BufferView &key) override;
 

--- a/core/storage/rocksdb/rocksdb_cursor.cpp
+++ b/core/storage/rocksdb/rocksdb_cursor.cpp
@@ -41,7 +41,7 @@ namespace kagome::storage {
                      : std::nullopt;
   }
 
-  std::optional<Buffer> RocksDBCursor::value() const {
+  std::optional<BufferOrView> RocksDBCursor::value() const {
     return isValid() ? std::make_optional(make_buffer(i_->value()))
                      : std::nullopt;
   }

--- a/core/storage/rocksdb/rocksdb_cursor.hpp
+++ b/core/storage/rocksdb/rocksdb_cursor.hpp
@@ -29,7 +29,7 @@ namespace kagome::storage {
 
     std::optional<Buffer> key() const override;
 
-    std::optional<Buffer> value() const override;
+    std::optional<BufferOrView> value() const override;
 
    private:
     std::shared_ptr<rocksdb::Iterator> i_;

--- a/core/storage/trie/impl/ephemeral_trie_batch_impl.cpp
+++ b/core/storage/trie/impl/ephemeral_trie_batch_impl.cpp
@@ -48,12 +48,7 @@ namespace kagome::storage::trie {
   }
 
   outcome::result<void> EphemeralTrieBatchImpl::put(const BufferView &key,
-                                                    const Buffer &value) {
-    return trie_->put(key, value);
-  }
-
-  outcome::result<void> EphemeralTrieBatchImpl::put(const BufferView &key,
-                                                    Buffer &&value) {
+                                                    BufferOrView &&value) {
     return trie_->put(key, std::move(value));
   }
 

--- a/core/storage/trie/impl/ephemeral_trie_batch_impl.cpp
+++ b/core/storage/trie/impl/ephemeral_trie_batch_impl.cpp
@@ -16,12 +16,12 @@ namespace kagome::storage::trie {
     BOOST_ASSERT(trie_ != nullptr);
   }
 
-  outcome::result<BufferConstRef> EphemeralTrieBatchImpl::get(
+  outcome::result<BufferOrView> EphemeralTrieBatchImpl::get(
       const BufferView &key) const {
     return trie_->get(key);
   }
 
-  outcome::result<std::optional<BufferConstRef>> EphemeralTrieBatchImpl::tryGet(
+  outcome::result<std::optional<BufferOrView>> EphemeralTrieBatchImpl::tryGet(
       const BufferView &key) const {
     return trie_->tryGet(key);
   }

--- a/core/storage/trie/impl/ephemeral_trie_batch_impl.hpp
+++ b/core/storage/trie/impl/ephemeral_trie_batch_impl.hpp
@@ -18,8 +18,8 @@ namespace kagome::storage::trie {
                            std::shared_ptr<PolkadotTrie> trie);
     ~EphemeralTrieBatchImpl() override = default;
 
-    outcome::result<BufferConstRef> get(const BufferView &key) const override;
-    outcome::result<std::optional<BufferConstRef>> tryGet(
+    outcome::result<BufferOrView> get(const BufferView &key) const override;
+    outcome::result<std::optional<BufferOrView>> tryGet(
         const BufferView &key) const override;
     std::unique_ptr<PolkadotTrieCursor> trieCursor() override;
     outcome::result<bool> contains(const BufferView &key) const override;

--- a/core/storage/trie/impl/ephemeral_trie_batch_impl.hpp
+++ b/core/storage/trie/impl/ephemeral_trie_batch_impl.hpp
@@ -28,8 +28,7 @@ namespace kagome::storage::trie {
         const BufferView &prefix,
         std::optional<uint64_t> limit = std::nullopt) override;
     outcome::result<void> put(const BufferView &key,
-                              const Buffer &value) override;
-    outcome::result<void> put(const BufferView &key, Buffer &&value) override;
+                              BufferOrView &&value) override;
     outcome::result<void> remove(const BufferView &key) override;
     outcome::result<RootHash> hash() override;
 

--- a/core/storage/trie/impl/persistent_trie_batch_impl.cpp
+++ b/core/storage/trie/impl/persistent_trie_batch_impl.cpp
@@ -99,22 +99,17 @@ namespace kagome::storage::trie {
   }
 
   outcome::result<void> PersistentTrieBatchImpl::put(const BufferView &key,
-                                                     const Buffer &value) {
+                                                     BufferOrView &&value) {
     OUTCOME_TRY(contains, trie_->contains(key));
     bool is_new_entry = not contains;
-    auto res = trie_->put(key, value);
+    auto value_copy = value.mut();
+    auto res = trie_->put(key, std::move(value));
     if (res and changes_.has_value()) {
-      SL_TRACE_VOID_FUNC_CALL(logger_, key, value);
+      SL_TRACE_VOID_FUNC_CALL(logger_, key, value_copy);
 
-      changes_.value()->onPut(key, value, is_new_entry);
+      changes_.value()->onPut(key, value_copy, is_new_entry);
     }
     return res;
-  }
-
-  outcome::result<void> PersistentTrieBatchImpl::put(const BufferView &key,
-                                                     Buffer &&value) {
-    return put(key, value);  // cannot take possession of value, check the
-                             // const-ref version definition
   }
 
   outcome::result<void> PersistentTrieBatchImpl::remove(const BufferView &key) {

--- a/core/storage/trie/impl/persistent_trie_batch_impl.cpp
+++ b/core/storage/trie/impl/persistent_trie_batch_impl.cpp
@@ -62,13 +62,13 @@ namespace kagome::storage::trie {
     return std::make_unique<TopperTrieBatchImpl>(shared_from_this());
   }
 
-  outcome::result<BufferConstRef> PersistentTrieBatchImpl::get(
+  outcome::result<BufferOrView> PersistentTrieBatchImpl::get(
       const BufferView &key) const {
     return trie_->get(key);
   }
 
-  outcome::result<std::optional<BufferConstRef>>
-  PersistentTrieBatchImpl::tryGet(const BufferView &key) const {
+  outcome::result<std::optional<BufferOrView>> PersistentTrieBatchImpl::tryGet(
+      const BufferView &key) const {
     return trie_->tryGet(key);
   }
 

--- a/core/storage/trie/impl/persistent_trie_batch_impl.hpp
+++ b/core/storage/trie/impl/persistent_trie_batch_impl.hpp
@@ -33,8 +33,8 @@ namespace kagome::storage::trie {
     outcome::result<RootHash> commit() override;
     std::unique_ptr<TopperTrieBatch> batchOnTop() override;
 
-    outcome::result<BufferConstRef> get(const BufferView &key) const override;
-    outcome::result<std::optional<BufferConstRef>> tryGet(
+    outcome::result<BufferOrView> get(const BufferView &key) const override;
+    outcome::result<std::optional<BufferOrView>> tryGet(
         const BufferView &key) const override;
     std::unique_ptr<PolkadotTrieCursor> trieCursor() override;
     outcome::result<bool> contains(const BufferView &key) const override;

--- a/core/storage/trie/impl/persistent_trie_batch_impl.hpp
+++ b/core/storage/trie/impl/persistent_trie_batch_impl.hpp
@@ -43,8 +43,7 @@ namespace kagome::storage::trie {
         const BufferView &prefix,
         std::optional<uint64_t> limit = std::nullopt) override;
     outcome::result<void> put(const BufferView &key,
-                              const Buffer &value) override;
-    outcome::result<void> put(const BufferView &key, Buffer &&value) override;
+                              BufferOrView &&value) override;
     outcome::result<void> remove(const BufferView &key) override;
 
    private:

--- a/core/storage/trie/impl/topper_trie_batch_impl.cpp
+++ b/core/storage/trie/impl/topper_trie_batch_impl.cpp
@@ -28,20 +28,20 @@ namespace kagome::storage::trie {
       const std::shared_ptr<TrieBatch> &parent)
       : parent_(parent) {}
 
-  outcome::result<common::BufferConstRef> TopperTrieBatchImpl::get(
+  outcome::result<BufferOrView> TopperTrieBatchImpl::get(
       const BufferView &key) const {
     OUTCOME_TRY(opt_value, tryGet(key));
     if (opt_value) {
-      return opt_value.value();
+      return std::move(*opt_value);
     }
     return TrieError::NO_VALUE;
   }
 
-  outcome::result<std::optional<common::BufferConstRef>>
-  TopperTrieBatchImpl::tryGet(const BufferView &key) const {
+  outcome::result<std::optional<BufferOrView>> TopperTrieBatchImpl::tryGet(
+      const BufferView &key) const {
     if (auto it = cache_.find(key); it != cache_.end()) {
       if (it->second.has_value()) {
-        return it->second.value();
+        return BufferView{it->second.value()};
       }
       return std::nullopt;
     }

--- a/core/storage/trie/impl/topper_trie_batch_impl.cpp
+++ b/core/storage/trie/impl/topper_trie_batch_impl.cpp
@@ -91,13 +91,8 @@ namespace kagome::storage::trie {
   }
 
   outcome::result<void> TopperTrieBatchImpl::put(const BufferView &key,
-                                                 const Buffer &value) {
-    return put(key, Buffer(value));
-  }
-
-  outcome::result<void> TopperTrieBatchImpl::put(const BufferView &key,
-                                                 Buffer &&value) {
-    cache_.insert_or_assign(Buffer{key}, std::move(value));
+                                                 BufferOrView &&value) {
+    cache_.insert_or_assign(Buffer{key}, value.into());
     return outcome::success();
   }
 
@@ -128,7 +123,7 @@ namespace kagome::storage::trie {
       }
       for (auto it = cache_.begin(); it != cache_.end(); it++) {
         if (it->second.has_value()) {
-          OUTCOME_TRY(p->put(it->first, it->second.value()));
+          OUTCOME_TRY(p->put(it->first, BufferView{it->second.value()}));
         } else {
           OUTCOME_TRY(p->remove(it->first));
         }

--- a/core/storage/trie/impl/topper_trie_batch_impl.hpp
+++ b/core/storage/trie/impl/topper_trie_batch_impl.hpp
@@ -37,8 +37,7 @@ namespace kagome::storage::trie {
     bool empty() const override;
 
     outcome::result<void> put(const BufferView &key,
-                              const Buffer &value) override;
-    outcome::result<void> put(const BufferView &key, Buffer &&value) override;
+                              BufferOrView &&value) override;
     outcome::result<void> remove(const BufferView &key) override;
     outcome::result<std::tuple<bool, uint32_t>> clearPrefix(
         const BufferView &prefix, std::optional<uint64_t> limit) override;

--- a/core/storage/trie/impl/topper_trie_batch_impl.hpp
+++ b/core/storage/trie/impl/topper_trie_batch_impl.hpp
@@ -24,9 +24,8 @@ namespace kagome::storage::trie {
 
     explicit TopperTrieBatchImpl(const std::shared_ptr<TrieBatch> &parent);
 
-    outcome::result<common::BufferConstRef> get(
-        const BufferView &key) const override;
-    outcome::result<std::optional<common::BufferConstRef>> tryGet(
+    outcome::result<BufferOrView> get(const BufferView &key) const override;
+    outcome::result<std::optional<BufferOrView>> tryGet(
         const BufferView &key) const override;
 
     /**

--- a/core/storage/trie/impl/trie_storage_backend_batch.cpp
+++ b/core/storage/trie/impl/trie_storage_backend_batch.cpp
@@ -8,9 +8,7 @@
 namespace kagome::storage::trie {
 
   TrieStorageBackendBatch::TrieStorageBackendBatch(
-      std::unique_ptr<face::WriteBatch<common::BufferView, common::Buffer>>
-          storage_batch,
-      common::Buffer node_prefix)
+      std::unique_ptr<BufferBatch> storage_batch, common::Buffer node_prefix)
       : storage_batch_{std::move(storage_batch)},
         node_prefix_{std::move(node_prefix)} {
     BOOST_ASSERT(storage_batch_ != nullptr);

--- a/core/storage/trie/impl/trie_storage_backend_batch.cpp
+++ b/core/storage/trie/impl/trie_storage_backend_batch.cpp
@@ -25,12 +25,7 @@ namespace kagome::storage::trie {
   }
 
   outcome::result<void> TrieStorageBackendBatch::put(
-      const common::BufferView &key, const common::Buffer &value) {
-    return storage_batch_->put(prefixKey(key), value);
-  }
-
-  outcome::result<void> TrieStorageBackendBatch::put(
-      const common::BufferView &key, common::Buffer &&value) {
+      const common::BufferView &key, BufferOrView &&value) {
     return storage_batch_->put(prefixKey(key), std::move(value));
   }
 

--- a/core/storage/trie/impl/trie_storage_backend_batch.hpp
+++ b/core/storage/trie/impl/trie_storage_backend_batch.hpp
@@ -14,13 +14,10 @@ namespace kagome::storage::trie {
    * Batch implementation for TrieStorageBackend
    * @see TrieStorageBackend
    */
-  class TrieStorageBackendBatch
-      : public face::WriteBatch<common::BufferView, common::Buffer> {
+  class TrieStorageBackendBatch : public BufferBatch {
    public:
-    TrieStorageBackendBatch(
-        std::unique_ptr<face::WriteBatch<common::BufferView, common::Buffer>>
-            storage_batch,
-        common::Buffer node_prefix);
+    TrieStorageBackendBatch(std::unique_ptr<BufferBatch> storage_batch,
+                            common::Buffer node_prefix);
     ~TrieStorageBackendBatch() override = default;
 
     outcome::result<void> commit() override;
@@ -34,8 +31,7 @@ namespace kagome::storage::trie {
    private:
     common::Buffer prefixKey(const common::BufferView &key) const;
 
-    std::unique_ptr<face::WriteBatch<common::BufferView, common::Buffer>>
-        storage_batch_;
+    std::unique_ptr<BufferBatch> storage_batch_;
     common::Buffer node_prefix_;
   };
 

--- a/core/storage/trie/impl/trie_storage_backend_batch.hpp
+++ b/core/storage/trie/impl/trie_storage_backend_batch.hpp
@@ -6,8 +6,7 @@
 #ifndef KAGOME_STORAGE_TRIE_IMPL_TRIE_STORAGE_BACKEND_BATCH
 #define KAGOME_STORAGE_TRIE_IMPL_TRIE_STORAGE_BACKEND_BATCH
 
-#include "common/buffer.hpp"
-#include "storage/face/write_batch.hpp"
+#include "storage/buffer_map_types.hpp"
 
 namespace kagome::storage::trie {
 
@@ -27,10 +26,7 @@ namespace kagome::storage::trie {
     outcome::result<void> commit() override;
 
     outcome::result<void> put(const common::BufferView &key,
-                              const common::Buffer &value) override;
-
-    outcome::result<void> put(const common::BufferView &key,
-                              common::Buffer &&value) override;
+                              BufferOrView &&value) override;
 
     outcome::result<void> remove(const common::BufferView &key) override;
     void clear() override;

--- a/core/storage/trie/impl/trie_storage_backend_impl.cpp
+++ b/core/storage/trie/impl/trie_storage_backend_impl.cpp
@@ -49,12 +49,7 @@ namespace kagome::storage::trie {
   }
 
   outcome::result<void> TrieStorageBackendImpl::put(const BufferView &key,
-                                                    const Buffer &value) {
-    return storage_->put(prefixKey(key), value);
-  }
-
-  outcome::result<void> TrieStorageBackendImpl::put(const BufferView &key,
-                                                    Buffer &&value) {
+                                                    BufferOrView &&value) {
     return storage_->put(prefixKey(key), std::move(value));
   }
 

--- a/core/storage/trie/impl/trie_storage_backend_impl.cpp
+++ b/core/storage/trie/impl/trie_storage_backend_impl.cpp
@@ -23,8 +23,7 @@ namespace kagome::storage::trie {
         ->cursor();  // TODO(Harrm): perhaps should iterate over trie nodes only
   }
 
-  std::unique_ptr<face::WriteBatch<BufferView, Buffer>>
-  TrieStorageBackendImpl::batch() {
+  std::unique_ptr<BufferBatch> TrieStorageBackendImpl::batch() {
     return std::make_unique<TrieStorageBackendBatch>(storage_->batch(),
                                                      node_prefix_);
   }

--- a/core/storage/trie/impl/trie_storage_backend_impl.cpp
+++ b/core/storage/trie/impl/trie_storage_backend_impl.cpp
@@ -29,12 +29,12 @@ namespace kagome::storage::trie {
                                                      node_prefix_);
   }
 
-  outcome::result<Buffer> TrieStorageBackendImpl::load(
+  outcome::result<BufferOrView> TrieStorageBackendImpl::load(
       const BufferView &key) const {
     return storage_->load(prefixKey(key));
   }
 
-  outcome::result<std::optional<Buffer>> TrieStorageBackendImpl::tryLoad(
+  outcome::result<std::optional<BufferOrView>> TrieStorageBackendImpl::tryLoad(
       const BufferView &key) const {
     return storage_->tryLoad(prefixKey(key));
   }

--- a/core/storage/trie/impl/trie_storage_backend_impl.cpp
+++ b/core/storage/trie/impl/trie_storage_backend_impl.cpp
@@ -60,9 +60,4 @@ namespace kagome::storage::trie {
       const common::BufferView &key) const {
     return common::Buffer{node_prefix_}.put(key);
   }
-
-  size_t TrieStorageBackendImpl::size() const {
-    return storage_->size();
-  }
-
 }  // namespace kagome::storage::trie

--- a/core/storage/trie/impl/trie_storage_backend_impl.cpp
+++ b/core/storage/trie/impl/trie_storage_backend_impl.cpp
@@ -28,14 +28,14 @@ namespace kagome::storage::trie {
                                                      node_prefix_);
   }
 
-  outcome::result<BufferOrView> TrieStorageBackendImpl::load(
+  outcome::result<BufferOrView> TrieStorageBackendImpl::get(
       const BufferView &key) const {
-    return storage_->load(prefixKey(key));
+    return storage_->get(prefixKey(key));
   }
 
-  outcome::result<std::optional<BufferOrView>> TrieStorageBackendImpl::tryLoad(
+  outcome::result<std::optional<BufferOrView>> TrieStorageBackendImpl::tryGet(
       const BufferView &key) const {
-    return storage_->tryLoad(prefixKey(key));
+    return storage_->tryGet(prefixKey(key));
   }
 
   outcome::result<bool> TrieStorageBackendImpl::contains(

--- a/core/storage/trie/impl/trie_storage_backend_impl.hpp
+++ b/core/storage/trie/impl/trie_storage_backend_impl.hpp
@@ -22,8 +22,8 @@ namespace kagome::storage::trie {
     std::unique_ptr<Cursor> cursor() override;
     std::unique_ptr<face::WriteBatch<BufferView, Buffer>> batch() override;
 
-    outcome::result<Buffer> load(const BufferView &key) const override;
-    outcome::result<std::optional<Buffer>> tryLoad(
+    outcome::result<BufferOrView> load(const BufferView &key) const override;
+    outcome::result<std::optional<BufferOrView>> tryLoad(
         const BufferView &key) const override;
     outcome::result<bool> contains(const BufferView &key) const override;
     bool empty() const override;

--- a/core/storage/trie/impl/trie_storage_backend_impl.hpp
+++ b/core/storage/trie/impl/trie_storage_backend_impl.hpp
@@ -29,8 +29,7 @@ namespace kagome::storage::trie {
     bool empty() const override;
 
     outcome::result<void> put(const BufferView &key,
-                              const Buffer &value) override;
-    outcome::result<void> put(const BufferView &key, Buffer &&value) override;
+                              BufferOrView &&value) override;
     outcome::result<void> remove(const common::BufferView &key) override;
 
     size_t size() const override;

--- a/core/storage/trie/impl/trie_storage_backend_impl.hpp
+++ b/core/storage/trie/impl/trie_storage_backend_impl.hpp
@@ -20,7 +20,7 @@ namespace kagome::storage::trie {
     ~TrieStorageBackendImpl() override = default;
 
     std::unique_ptr<Cursor> cursor() override;
-    std::unique_ptr<face::WriteBatch<BufferView, Buffer>> batch() override;
+    std::unique_ptr<BufferBatch> batch() override;
 
     outcome::result<BufferOrView> load(const BufferView &key) const override;
     outcome::result<std::optional<BufferOrView>> tryLoad(

--- a/core/storage/trie/impl/trie_storage_backend_impl.hpp
+++ b/core/storage/trie/impl/trie_storage_backend_impl.hpp
@@ -32,8 +32,6 @@ namespace kagome::storage::trie {
                               BufferOrView &&value) override;
     outcome::result<void> remove(const common::BufferView &key) override;
 
-    size_t size() const override;
-
    private:
     common::Buffer prefixKey(const common::BufferView &key) const;
 

--- a/core/storage/trie/impl/trie_storage_backend_impl.hpp
+++ b/core/storage/trie/impl/trie_storage_backend_impl.hpp
@@ -22,8 +22,8 @@ namespace kagome::storage::trie {
     std::unique_ptr<Cursor> cursor() override;
     std::unique_ptr<BufferBatch> batch() override;
 
-    outcome::result<BufferOrView> load(const BufferView &key) const override;
-    outcome::result<std::optional<BufferOrView>> tryLoad(
+    outcome::result<BufferOrView> get(const BufferView &key) const override;
+    outcome::result<std::optional<BufferOrView>> tryGet(
         const BufferView &key) const override;
     outcome::result<bool> contains(const BufferView &key) const override;
     bool empty() const override;

--- a/core/storage/trie/polkadot_trie/polkadot_trie.hpp
+++ b/core/storage/trie/polkadot_trie/polkadot_trie.hpp
@@ -17,8 +17,7 @@ namespace kagome::storage::trie {
    * For specification see Polkadot Runtime Environment Protocol Specification
    * '2.1.2 The General Tree Structure' and further
    */
-  class PolkadotTrie : public face::ReadOnlyMap<Buffer, Buffer>,
-                       public face::Writeable<Buffer, Buffer> {
+  class PolkadotTrie : public BufferStorage {
    public:
     using NodePtr = std::shared_ptr<TrieNode>;
     using ConstNodePtr = std::shared_ptr<const TrieNode>;

--- a/core/storage/trie/polkadot_trie/polkadot_trie.hpp
+++ b/core/storage/trie/polkadot_trie/polkadot_trie.hpp
@@ -17,10 +17,8 @@ namespace kagome::storage::trie {
    * For specification see Polkadot Runtime Environment Protocol Specification
    * '2.1.2 The General Tree Structure' and further
    */
-  class PolkadotTrie
-      : public face::
-            ReadOnlyMap<common::Buffer, common::Buffer, common::BufferView>,
-        public face::Writeable<common::BufferView, common::Buffer> {
+  class PolkadotTrie : public face::ReadOnlyMap<Buffer, Buffer>,
+                       public face::Writeable<Buffer, Buffer> {
    public:
     using NodePtr = std::shared_ptr<TrieNode>;
     using ConstNodePtr = std::shared_ptr<const TrieNode>;

--- a/core/storage/trie/polkadot_trie/polkadot_trie_cursor.hpp
+++ b/core/storage/trie/polkadot_trie/polkadot_trie_cursor.hpp
@@ -6,16 +6,14 @@
 #ifndef KAGOME_CORE_STORAGE_TRIE_POLKADOT_TRIE_POLKADOT_TRIE_CURSOR
 #define KAGOME_CORE_STORAGE_TRIE_POLKADOT_TRIE_POLKADOT_TRIE_CURSOR
 
-#include "storage/face/map_cursor.hpp"
+#include "storage/buffer_map_types.hpp"
 
 #include "common/buffer.hpp"
 #include "storage/trie/polkadot_trie/trie_node.hpp"
 
 namespace kagome::storage::trie {
 
-  class PolkadotTrieCursor : public face::MapCursor<common::Buffer,
-                                                    common::BufferConstRef,
-                                                    common::BufferView> {
+  class PolkadotTrieCursor : public BufferStorageCursor {
    public:
     virtual ~PolkadotTrieCursor() override = default;
 

--- a/core/storage/trie/polkadot_trie/polkadot_trie_cursor_impl.cpp
+++ b/core/storage/trie/polkadot_trie/polkadot_trie_cursor_impl.cpp
@@ -373,13 +373,12 @@ namespace kagome::storage::trie {
     return std::nullopt;
   }
 
-  std::optional<common::BufferConstRef> PolkadotTrieCursorImpl::value() const {
+  std::optional<BufferOrView> PolkadotTrieCursorImpl::value() const {
     if (const auto *search_state = std::get_if<SearchState>(&state_);
         search_state != nullptr) {
       const auto &value_opt = search_state->getCurrent().value;
       if (value_opt) {
-        return std::make_optional<common::BufferConstRef>(
-            std::cref(value_opt.value()));
+        return BufferView{*value_opt};
       }
       return std::nullopt;
     }

--- a/core/storage/trie/polkadot_trie/polkadot_trie_cursor_impl.hpp
+++ b/core/storage/trie/polkadot_trie/polkadot_trie_cursor_impl.hpp
@@ -64,7 +64,7 @@ namespace kagome::storage::trie {
 
     [[nodiscard]] std::optional<common::Buffer> key() const override;
 
-    [[nodiscard]] std::optional<common::BufferConstRef> value() const override;
+    [[nodiscard]] std::optional<BufferOrView> value() const override;
 
    private:
     outcome::result<void> seekLowerBoundInternal(

--- a/core/storage/trie/polkadot_trie/polkadot_trie_impl.cpp
+++ b/core/storage/trie/polkadot_trie/polkadot_trie_impl.cpp
@@ -452,24 +452,24 @@ namespace kagome::storage::trie {
     return br;
   }
 
-  outcome::result<common::BufferConstRef> PolkadotTrieImpl::get(
+  outcome::result<BufferOrView> PolkadotTrieImpl::get(
       const common::BufferView &key) const {
     OUTCOME_TRY(opt_value, tryGet(key));
     if (opt_value.has_value()) {
-      return opt_value.value();
+      return std::move(*opt_value);
     }
     return TrieError::NO_VALUE;
   }
 
-  outcome::result<std::optional<common::BufferConstRef>>
-  PolkadotTrieImpl::tryGet(const common::BufferView &key) const {
+  outcome::result<std::optional<BufferOrView>> PolkadotTrieImpl::tryGet(
+      const common::BufferView &key) const {
     if (not nodes_->getRoot()) {
       return std::nullopt;
     }
     auto nibbles = KeyNibbles::fromByteBuffer(key);
     OUTCOME_TRY(node, getNode(nodes_->getRoot(), nibbles));
     if (node && node->value) {
-      return node->value.value();
+      return BufferView{node->value.value()};
     }
     return std::nullopt;
   }

--- a/core/storage/trie/polkadot_trie/polkadot_trie_impl.cpp
+++ b/core/storage/trie/polkadot_trie/polkadot_trie_impl.cpp
@@ -293,12 +293,6 @@ namespace kagome::storage::trie {
 
   PolkadotTrieImpl::~PolkadotTrieImpl() {}
 
-  outcome::result<void> PolkadotTrieImpl::put(const BufferView &key,
-                                              const Buffer &value) {
-    auto value_copy = value;
-    return put(key, std::move(value_copy));
-  }
-
   PolkadotTrie::ConstNodePtr PolkadotTrieImpl::getRoot() const {
     return nodes_->getRoot();
   }
@@ -308,7 +302,7 @@ namespace kagome::storage::trie {
   }
 
   outcome::result<void> PolkadotTrieImpl::put(const BufferView &key,
-                                              Buffer &&value) {
+                                              BufferOrView &&value) {
     auto k_enc = KeyNibbles::fromByteBuffer(key);
 
     NodePtr root = nodes_->getRoot();
@@ -316,8 +310,9 @@ namespace kagome::storage::trie {
     // insert fetches a sequence of nodes (a path) from the storage and
     // these nodes are processed in memory, so any changes applied to them
     // will be written back to the storage only on storeNode call
-    OUTCOME_TRY(n,
-                insert(root, k_enc, std::make_shared<LeafNode>(k_enc, value)));
+    OUTCOME_TRY(
+        n,
+        insert(root, k_enc, std::make_shared<LeafNode>(k_enc, value.into())));
     nodes_->setRoot(n);
 
     return outcome::success();

--- a/core/storage/trie/polkadot_trie/polkadot_trie_impl.hpp
+++ b/core/storage/trie/polkadot_trie/polkadot_trie_impl.hpp
@@ -58,12 +58,8 @@ namespace kagome::storage::trie {
         std::optional<uint64_t> limit,
         const OnDetachCallback &callback) override;
 
-    // value will be copied
     outcome::result<void> put(const common::BufferView &key,
-                              const common::Buffer &value) override;
-
-    outcome::result<void> put(const common::BufferView &key,
-                              common::Buffer &&value) override;
+                              BufferOrView &&value) override;
 
     outcome::result<void> remove(const common::BufferView &key) override;
 

--- a/core/storage/trie/polkadot_trie/polkadot_trie_impl.hpp
+++ b/core/storage/trie/polkadot_trie/polkadot_trie_impl.hpp
@@ -63,10 +63,10 @@ namespace kagome::storage::trie {
 
     outcome::result<void> remove(const common::BufferView &key) override;
 
-    outcome::result<common::BufferConstRef> get(
+    outcome::result<BufferOrView> get(
         const common::BufferView &key) const override;
 
-    outcome::result<std::optional<common::BufferConstRef>> tryGet(
+    outcome::result<std::optional<BufferOrView>> tryGet(
         const common::BufferView &key) const override;
 
     std::unique_ptr<PolkadotTrieCursor> trieCursor() override;

--- a/core/storage/trie/serialization/ordered_trie_hash.hpp
+++ b/core/storage/trie/serialization/ordered_trie_hash.hpp
@@ -38,7 +38,7 @@ namespace kagome::storage::trie {
     scale::CompactInteger key = 0;
     while (it != end) {
       OUTCOME_TRY(enc, scale::encode(key++));
-      OUTCOME_TRY(trie.put(common::Buffer{enc}, *it));
+      OUTCOME_TRY(trie.put(enc, BufferView{*it}));
       it++;
     }
     OUTCOME_TRY(enc, codec.encodeNode(*trie.getRoot()));

--- a/core/storage/trie/serialization/trie_serializer_impl.cpp
+++ b/core/storage/trie/serialization/trie_serializer_impl.cpp
@@ -61,7 +61,7 @@ namespace kagome::storage::trie {
               return batch->put(hash, std::move(encoded));
             }));
     auto key = codec_->hash256(enc);
-    OUTCOME_TRY(batch->put(key, enc));
+    OUTCOME_TRY(batch->put(key, std::move(enc)));
     OUTCOME_TRY(batch->commit());
 
     return key;

--- a/core/storage/trie/serialization/trie_serializer_impl.cpp
+++ b/core/storage/trie/serialization/trie_serializer_impl.cpp
@@ -83,7 +83,7 @@ namespace kagome::storage::trie {
     }
     Buffer enc;
     if (codec_->isMerkleHash(db_key)) {
-      OUTCOME_TRY(db, backend_->load(db_key));
+      OUTCOME_TRY(db, backend_->get(db_key));
       enc = db.into();
     } else {
       // `isMerkleHash(db_key) == false` means `db_key` is value itself

--- a/core/storage/trie/serialization/trie_serializer_impl.cpp
+++ b/core/storage/trie/serialization/trie_serializer_impl.cpp
@@ -84,7 +84,7 @@ namespace kagome::storage::trie {
     Buffer enc;
     if (codec_->isMerkleHash(db_key)) {
       OUTCOME_TRY(db, backend_->load(db_key));
-      enc = std::move(db);
+      enc = db.into();
     } else {
       // `isMerkleHash(db_key) == false` means `db_key` is value itself
       enc = db_key;

--- a/core/storage/trie/trie_batches.hpp
+++ b/core/storage/trie/trie_batches.hpp
@@ -12,10 +12,9 @@
 
 namespace kagome::storage::trie {
 
-  class TrieBatch
-      : public face::ReadableMap<BufferView, Buffer>,
-        public face::Writeable<BufferView, Buffer>,
-        public face::Iterable<Buffer, common::BufferConstRef, BufferView> {
+  class TrieBatch : public face::ReadableMap<BufferView, Buffer>,
+                    public face::Writeable<BufferView, Buffer>,
+                    public face::Iterable<Buffer, Buffer, BufferView> {
    public:
     ~TrieBatch() override = default;
 

--- a/core/storage/trie/trie_batches.hpp
+++ b/core/storage/trie/trie_batches.hpp
@@ -12,9 +12,7 @@
 
 namespace kagome::storage::trie {
 
-  class TrieBatch : public face::Readable<Buffer, Buffer>,
-                    public face::Writeable<Buffer, Buffer>,
-                    public face::Iterable<Buffer, Buffer> {
+  class TrieBatch : public BufferStorage {
    public:
     ~TrieBatch() override = default;
 

--- a/core/storage/trie/trie_batches.hpp
+++ b/core/storage/trie/trie_batches.hpp
@@ -19,8 +19,6 @@ namespace kagome::storage::trie {
    public:
     ~TrieBatch() override = default;
 
-    using Cursor =
-        face::Iterable<Buffer, common::BufferConstRef, BufferView>::Cursor;
     std::unique_ptr<Cursor> cursor() final {
       return trieCursor();
     }

--- a/core/storage/trie/trie_batches.hpp
+++ b/core/storage/trie/trie_batches.hpp
@@ -12,9 +12,9 @@
 
 namespace kagome::storage::trie {
 
-  class TrieBatch : public face::Readable<BufferView, Buffer>,
-                    public face::Writeable<BufferView, Buffer>,
-                    public face::Iterable<Buffer, Buffer, BufferView> {
+  class TrieBatch : public face::Readable<Buffer, Buffer>,
+                    public face::Writeable<Buffer, Buffer>,
+                    public face::Iterable<Buffer, Buffer> {
    public:
     ~TrieBatch() override = default;
 

--- a/core/storage/trie/trie_batches.hpp
+++ b/core/storage/trie/trie_batches.hpp
@@ -12,7 +12,7 @@
 
 namespace kagome::storage::trie {
 
-  class TrieBatch : public face::ReadableMap<BufferView, Buffer>,
+  class TrieBatch : public face::Readable<BufferView, Buffer>,
                     public face::Writeable<BufferView, Buffer>,
                     public face::Iterable<Buffer, Buffer, BufferView> {
    public:

--- a/core/utils/kagome_db_editor.cpp
+++ b/core/utils/kagome_db_editor.cpp
@@ -148,9 +148,8 @@ void child_storage_root_hashes(
       if (auto value_res = batch->tryGet(key.value());
           value_res.has_value() && value_res.value().has_value()) {
         auto &value_opt = value_res.value();
-        log->trace("Found child root hash {}", value_opt.value().get());
-        hashes.insert(
-            common::Hash256::fromSpan(value_opt.value().get()).value());
+        log->trace("Found child root hash {}", *value_opt);
+        hashes.insert(common::Hash256::fromSpan(*value_opt).value());
       }
       res = cursor->next();
       key = cursor->key();
@@ -422,7 +421,7 @@ int db_editor_main(int argc, const char **argv) {
         count = 0;
         while (cursor->key().has_value()) {
           ofs << "  - "
-              << check(batch->get(check(cursor->key()).value())).value().get()
+              << check(batch->get(check(cursor->key()).value())).value().view()
               << "\n";
           if (not(++count % 50000)) {
             log->trace("{} values were dumped.", count);

--- a/core/utils/storage_explorer.cpp
+++ b/core/utils/storage_explorer.cpp
@@ -280,7 +280,7 @@ class QueryStateCommand : public Command {
     }
     auto &value_opt = value_res.value();
     if (value_opt.has_value()) {
-      std::cout << "Value is " << value_opt->get().toHex() << "\n";
+      std::cout << "Value is " << value_opt->view().toHex() << "\n";
     } else {
       std::cout << "No value by given key\n";
     }

--- a/test/core/api/service/child_state/child_state_api_test.cpp
+++ b/test/core/api/service/child_state/child_state_api_test.cpp
@@ -74,7 +74,7 @@ namespace kagome::api {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
           static const auto key = "a"_buf;
           static const common::Buffer value{"1"_hash256};
-          EXPECT_CALL(*batch, get(key.view()))
+          EXPECT_CALL(*batch, getMock(key.view()))
               .WillRepeatedly(testing::Return(value));
           return batch;
         }));
@@ -83,7 +83,7 @@ namespace kagome::api {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
           static const auto key = "b"_buf;
           static const common::Buffer value = "2"_buf;
-          EXPECT_CALL(*batch, tryGet(key.view()))
+          EXPECT_CALL(*batch, tryGetMock(key.view()))
               .WillRepeatedly(
                   testing::Return(std::make_optional(std::cref(value))));
           return batch;
@@ -102,7 +102,7 @@ namespace kagome::api {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
           static const auto key = "c"_buf;
           static const common::Buffer value{"3"_hash256};
-          EXPECT_CALL(*batch, get(key.view()))
+          EXPECT_CALL(*batch, getMock(key.view()))
               .WillRepeatedly(testing::Return(value));
           return batch;
         }));
@@ -111,7 +111,7 @@ namespace kagome::api {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
           static const auto key = "d"_buf;
           static const auto value = "4"_buf;
-          EXPECT_CALL(*batch, tryGet(key.view()))
+          EXPECT_CALL(*batch, tryGetMock(key.view()))
               .WillRepeatedly(
                   testing::Return(std::make_optional(std::cref(value))));
           return batch;
@@ -145,7 +145,7 @@ namespace kagome::api {
     EXPECT_CALL(*storage_, getEphemeralBatchAt("6789"_hash256))
         .WillOnce(testing::Invoke([&](auto &root) {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
-          EXPECT_CALL(*batch, get(child_storage_key.view()))
+          EXPECT_CALL(*batch, getMock(child_storage_key.view()))
               .WillOnce(testing::Return(common::Buffer("2020"_hash256)));
           return batch;
         }));
@@ -201,7 +201,7 @@ namespace kagome::api {
     EXPECT_CALL(*storage_, getEphemeralBatchAt("6789"_hash256))
         .WillOnce(testing::Invoke([&](auto &root) {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
-          EXPECT_CALL(*batch, get(child_storage_key.view()))
+          EXPECT_CALL(*batch, getMock(child_storage_key.view()))
               .WillOnce(testing::Return(common::Buffer("2020"_hash256)));
           return batch;
         }));
@@ -255,14 +255,14 @@ namespace kagome::api {
         .WillOnce(testing::Invoke([&](auto &root) {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
           static auto v = common::Buffer("2020"_hash256);
-          EXPECT_CALL(*batch, get(child_storage_key.view()))
+          EXPECT_CALL(*batch, getMock(child_storage_key.view()))
               .WillOnce(testing::Return(v));
           return batch;
         }));
     EXPECT_CALL(*storage_, getEphemeralBatchAt("2020"_hash256))
         .WillOnce(testing::Invoke([&](auto &root) {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
-          EXPECT_CALL(*batch, get(key.view()))
+          EXPECT_CALL(*batch, getMock(key.view()))
               .WillOnce(testing::Return(expected_result));
           return batch;
         }));

--- a/test/core/api/service/state/state_api_test.cpp
+++ b/test/core/api/service/state/state_api_test.cpp
@@ -85,7 +85,7 @@ namespace kagome::api {
     EXPECT_CALL(*storage_, getEphemeralBatchAt(_))
         .WillRepeatedly(testing::Invoke([&in_buf, &out_buf](auto &root) {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
-          EXPECT_CALL(*batch, tryGet(in_buf.view()))
+          EXPECT_CALL(*batch, tryGetMock(in_buf.view()))
               .WillRepeatedly(testing::Return(std::cref(out_buf)));
           return batch;
         }));
@@ -384,7 +384,7 @@ namespace kagome::api {
             auto batch =
                 std::make_unique<storage::trie::EphemeralTrieBatchMock>();
             for (auto &key : keys) {
-              EXPECT_CALL(*batch, tryGet(key.view()))
+              EXPECT_CALL(*batch, tryGetMock(key.view()))
                   .WillOnce(testing::Return(common::Buffer(root)));
             }
             return batch;
@@ -456,7 +456,7 @@ namespace kagome::api {
           auto batch =
               std::make_unique<storage::trie::EphemeralTrieBatchMock>();
           for (auto &key : keys) {
-            EXPECT_CALL(*batch, tryGet(key.view()))
+            EXPECT_CALL(*batch, tryGetMock(key.view()))
                 .WillOnce(testing::Return(common::Buffer(root)));
           }
           return batch;

--- a/test/core/blockchain/block_storage_test.cpp
+++ b/test/core/blockchain/block_storage_test.cpp
@@ -56,7 +56,7 @@ class BlockStorageTest : public testing::Test {
         .WillRepeatedly(Return(genesis_block_hash));
 
     // check if storage contained genesis block
-    EXPECT_CALL(*storage, tryLoad(_)).WillRepeatedly(Return(std::nullopt));
+    EXPECT_CALL(*storage, tryLoadMock(_)).WillRepeatedly(Return(std::nullopt));
 
     // put genesis block into storage
     EXPECT_CALL(*storage, put(_, _)).WillRepeatedly(Return(outcome::success()));
@@ -92,7 +92,8 @@ TEST_F(BlockStorageTest, CreateWithEmptyStorage) {
       .WillRepeatedly(Return(genesis_block_hash));
 
   // check if storage contained genesis block
-  EXPECT_CALL(*empty_storage, tryLoad(_)).WillRepeatedly(Return(std::nullopt));
+  EXPECT_CALL(*empty_storage, tryLoadMock(_))
+      .WillRepeatedly(Return(std::nullopt));
 
   // put genesis block into storage
   EXPECT_CALL(*empty_storage, put(_, _))
@@ -112,7 +113,7 @@ TEST_F(BlockStorageTest, CreateWithEmptyStorage) {
 TEST_F(BlockStorageTest, CreateWithExistingGenesis) {
   // trying to get header of block number 0 (genesis block)
   EXPECT_CALL(*storage, contains(_)).WillOnce(Return(outcome::success(true)));
-  EXPECT_CALL(*storage, tryLoad(_))
+  EXPECT_CALL(*storage, tryLoadMock(_))
       // trying to get header of block number 0 (genesis block)
       .WillOnce(Return(Buffer{genesis_block_hash}));
 
@@ -131,7 +132,7 @@ TEST_F(BlockStorageTest, CreateWithStorageError) {
       std::make_shared<GenericStorageMock<Buffer, Buffer, BufferView>>();
 
   // check if storage contained genesis block
-  EXPECT_CALL(*empty_storage, tryLoad(_))
+  EXPECT_CALL(*empty_storage, tryLoadMock(_))
       .WillOnce(Return(kagome::storage::DatabaseError::IO_ERROR));
 
   EXPECT_OUTCOME_ERROR(
@@ -150,7 +151,7 @@ TEST_F(BlockStorageTest, PutBlock) {
 
   EXPECT_CALL(*hasher, blake2b_256(_)).WillOnce(Return(regular_block_hash));
 
-  EXPECT_CALL(*storage, tryLoad(_)).WillOnce(Return(std::nullopt));
+  EXPECT_CALL(*storage, tryLoadMock(_)).WillOnce(Return(std::nullopt));
 
   Block block;
   block.header.number = 1;
@@ -167,7 +168,7 @@ TEST_F(BlockStorageTest, PutBlock) {
 TEST_F(BlockStorageTest, PutWithStorageError) {
   auto block_storage = createWithGenesis();
 
-  EXPECT_CALL(*storage, tryLoad(_))
+  EXPECT_CALL(*storage, tryLoadMock(_))
       .WillOnce(Return(Buffer{1, 1, 1, 1}))
       .WillOnce(Return(kagome::storage::DatabaseError::IO_ERROR));
 

--- a/test/core/blockchain/block_storage_test.cpp
+++ b/test/core/blockchain/block_storage_test.cpp
@@ -27,7 +27,7 @@ using kagome::primitives::BlockData;
 using kagome::primitives::BlockHash;
 using kagome::primitives::BlockHeader;
 using kagome::primitives::BlockNumber;
-using kagome::storage::face::GenericStorageMock;
+using kagome::storage::BufferStorageMock;
 using kagome::storage::trie::RootHash;
 using scale::encode;
 using testing::_;
@@ -43,8 +43,8 @@ class BlockStorageTest : public testing::Test {
     root_hash.fill(1);
   }
   std::shared_ptr<HasherMock> hasher = std::make_shared<HasherMock>();
-  std::shared_ptr<GenericStorageMock<Buffer, Buffer, BufferView>> storage =
-      std::make_shared<GenericStorageMock<Buffer, Buffer, BufferView>>();
+  std::shared_ptr<BufferStorageMock> storage =
+      std::make_shared<BufferStorageMock>();
 
   BlockHash genesis_block_hash{{'g', 'e', 'n', 'e', 's', 'i', 's'}};
   BlockHash regular_block_hash{{'r', 'e', 'g', 'u', 'l', 'a', 'r'}};
@@ -84,8 +84,7 @@ TEST_F(BlockStorageTest, CreateWithGenesis) {
  * @then storage will be initialized by genesis block
  */
 TEST_F(BlockStorageTest, CreateWithEmptyStorage) {
-  auto empty_storage =
-      std::make_shared<GenericStorageMock<Buffer, Buffer, BufferView>>();
+  auto empty_storage = std::make_shared<BufferStorageMock>();
 
   // calculate hash of genesis block at put block header
   EXPECT_CALL(*hasher, blake2b_256(_))
@@ -128,8 +127,7 @@ TEST_F(BlockStorageTest, CreateWithExistingGenesis) {
  * @then initialisation will fail
  */
 TEST_F(BlockStorageTest, CreateWithStorageError) {
-  auto empty_storage =
-      std::make_shared<GenericStorageMock<Buffer, Buffer, BufferView>>();
+  auto empty_storage = std::make_shared<BufferStorageMock>();
 
   // check if storage contained genesis block
   EXPECT_CALL(*empty_storage, tryGetMock(_))

--- a/test/core/blockchain/block_storage_test.cpp
+++ b/test/core/blockchain/block_storage_test.cpp
@@ -56,7 +56,7 @@ class BlockStorageTest : public testing::Test {
         .WillRepeatedly(Return(genesis_block_hash));
 
     // check if storage contained genesis block
-    EXPECT_CALL(*storage, tryLoadMock(_)).WillRepeatedly(Return(std::nullopt));
+    EXPECT_CALL(*storage, tryGetMock(_)).WillRepeatedly(Return(std::nullopt));
 
     // put genesis block into storage
     EXPECT_CALL(*storage, put(_, _)).WillRepeatedly(Return(outcome::success()));
@@ -92,7 +92,7 @@ TEST_F(BlockStorageTest, CreateWithEmptyStorage) {
       .WillRepeatedly(Return(genesis_block_hash));
 
   // check if storage contained genesis block
-  EXPECT_CALL(*empty_storage, tryLoadMock(_))
+  EXPECT_CALL(*empty_storage, tryGetMock(_))
       .WillRepeatedly(Return(std::nullopt));
 
   // put genesis block into storage
@@ -113,7 +113,7 @@ TEST_F(BlockStorageTest, CreateWithEmptyStorage) {
 TEST_F(BlockStorageTest, CreateWithExistingGenesis) {
   // trying to get header of block number 0 (genesis block)
   EXPECT_CALL(*storage, contains(_)).WillOnce(Return(outcome::success(true)));
-  EXPECT_CALL(*storage, tryLoadMock(_))
+  EXPECT_CALL(*storage, tryGetMock(_))
       // trying to get header of block number 0 (genesis block)
       .WillOnce(Return(Buffer{genesis_block_hash}));
 
@@ -132,7 +132,7 @@ TEST_F(BlockStorageTest, CreateWithStorageError) {
       std::make_shared<GenericStorageMock<Buffer, Buffer, BufferView>>();
 
   // check if storage contained genesis block
-  EXPECT_CALL(*empty_storage, tryLoadMock(_))
+  EXPECT_CALL(*empty_storage, tryGetMock(_))
       .WillOnce(Return(kagome::storage::DatabaseError::IO_ERROR));
 
   EXPECT_OUTCOME_ERROR(
@@ -151,7 +151,7 @@ TEST_F(BlockStorageTest, PutBlock) {
 
   EXPECT_CALL(*hasher, blake2b_256(_)).WillOnce(Return(regular_block_hash));
 
-  EXPECT_CALL(*storage, tryLoadMock(_)).WillOnce(Return(std::nullopt));
+  EXPECT_CALL(*storage, tryGetMock(_)).WillOnce(Return(std::nullopt));
 
   Block block;
   block.header.number = 1;
@@ -168,7 +168,7 @@ TEST_F(BlockStorageTest, PutBlock) {
 TEST_F(BlockStorageTest, PutWithStorageError) {
   auto block_storage = createWithGenesis();
 
-  EXPECT_CALL(*storage, tryLoadMock(_))
+  EXPECT_CALL(*storage, tryGetMock(_))
       .WillOnce(Return(Buffer{1, 1, 1, 1}))
       .WillOnce(Return(kagome::storage::DatabaseError::IO_ERROR));
 

--- a/test/core/consensus/authority/authority_manager_test.cpp
+++ b/test/core/consensus/authority/authority_manager_test.cpp
@@ -69,7 +69,7 @@ class AuthorityManagerTest : public testing::Test {
     EXPECT_CALL(*trie_storage, getEphemeralBatchAt(_))
         .WillRepeatedly(testing::Invoke([] {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
-          EXPECT_CALL(*batch, tryGet(_))
+          EXPECT_CALL(*batch, tryGetMock(_))
               .WillRepeatedly(
                   Return(storage::Buffer::fromHex("0000000000000000").value()));
           return batch;

--- a/test/core/consensus/babe/babe_config_repository_test.cpp
+++ b/test/core/consensus/babe/babe_config_repository_test.cpp
@@ -34,7 +34,7 @@ using primitives::BlockId;
 using primitives::BlockInfo;
 using primitives::events::ChainSubscriptionEngine;
 using runtime::BabeApiMock;
-using storage::face::GenericStorageMock;
+using storage::BufferStorageMock;
 
 using std::chrono_literals::operator""ms;
 
@@ -56,8 +56,7 @@ class BabeConfigRepositoryTest : public testing::Test {
     app_state_manager = std::make_shared<application::AppStateManagerMock>();
     EXPECT_CALL(*app_state_manager, atPrepare(_)).WillOnce(Return());
 
-    persistent_storage =
-        std::make_shared<GenericStorageMock<Buffer, Buffer, BufferView>>();
+    persistent_storage = std::make_shared<BufferStorageMock>();
     EXPECT_CALL(*persistent_storage, tryGetMock(_))
         .WillRepeatedly(Return(std::nullopt));
 
@@ -91,8 +90,7 @@ class BabeConfigRepositoryTest : public testing::Test {
   primitives::BabeConfiguration babe_config;
 
   std::shared_ptr<application::AppStateManagerMock> app_state_manager;
-  std::shared_ptr<GenericStorageMock<Buffer, Buffer, BufferView>>
-      persistent_storage;
+  std::shared_ptr<BufferStorageMock> persistent_storage;
   std::shared_ptr<blockchain::BlockTreeMock> block_tree;
   std::shared_ptr<blockchain::BlockHeaderRepository> header_repo;
   std::shared_ptr<runtime::BabeApiMock> babe_api;

--- a/test/core/consensus/babe/babe_config_repository_test.cpp
+++ b/test/core/consensus/babe/babe_config_repository_test.cpp
@@ -58,7 +58,7 @@ class BabeConfigRepositoryTest : public testing::Test {
 
     persistent_storage =
         std::make_shared<GenericStorageMock<Buffer, Buffer, BufferView>>();
-    EXPECT_CALL(*persistent_storage, tryLoad(_))
+    EXPECT_CALL(*persistent_storage, tryLoadMock(_))
         .WillRepeatedly(Return(std::nullopt));
 
     block_tree = std::make_shared<BlockTreeMock>();

--- a/test/core/consensus/babe/babe_config_repository_test.cpp
+++ b/test/core/consensus/babe/babe_config_repository_test.cpp
@@ -58,7 +58,7 @@ class BabeConfigRepositoryTest : public testing::Test {
 
     persistent_storage =
         std::make_shared<GenericStorageMock<Buffer, Buffer, BufferView>>();
-    EXPECT_CALL(*persistent_storage, tryLoadMock(_))
+    EXPECT_CALL(*persistent_storage, tryGetMock(_))
         .WillRepeatedly(Return(std::nullopt));
 
     block_tree = std::make_shared<BlockTreeMock>();

--- a/test/core/host_api/child_storage_extension_test.cpp
+++ b/test/core/host_api/child_storage_extension_test.cpp
@@ -152,11 +152,9 @@ TEST_P(ReadOutcomeParameterizedTest, GetTest) {
 
   // 'func' (lambda)
   auto &param = GetParam();
-  auto param_ref = kagome::common::map_result_optional(
-      param, [](auto &v) { return std::cref(v); });
 
-  EXPECT_CALL(*trie_child_storage_batch_, tryGet(key.view()))
-      .WillOnce(Return(param_ref));
+  EXPECT_CALL(*trie_child_storage_batch_, tryGetMock(key.view()))
+      .WillOnce(Return(param));
 
   // results
   if (GetParam().has_error()) {
@@ -244,13 +242,8 @@ TEST_P(ReadOutcomeParameterizedTest, ReadTest) {
 
   // 'func' (lambda)
   auto &param = GetParam();
-  EXPECT_CALL(*trie_child_storage_batch_, tryGet(key.view()))
-      .WillOnce(Return([&]() -> outcome::result<std::optional<BufferConstRef>> {
-        if (param.has_error()) return param.as_failure();
-        auto &opt = param.value();
-        if (opt) return std::cref(opt.value());
-        return std::nullopt;
-      }()));
+  EXPECT_CALL(*trie_child_storage_batch_, tryGetMock(key.view()))
+      .WillOnce(Return(param));
 
   // results
 

--- a/test/core/host_api/child_storage_extension_test.cpp
+++ b/test/core/host_api/child_storage_extension_test.cpp
@@ -27,7 +27,6 @@
 #include "testutil/prepare_loggers.hpp"
 
 using kagome::common::Buffer;
-using kagome::common::BufferConstRef;
 using kagome::host_api::ChildStorageExtension;
 using kagome::runtime::Memory;
 using kagome::runtime::MemoryMock;

--- a/test/core/host_api/storage_extension_test.cpp
+++ b/test/core/host_api/storage_extension_test.cpp
@@ -317,7 +317,7 @@ TEST_P(OutcomeParameterizedTest, StorageReadTest) {
   EXPECT_CALL(*memory_, loadN(key.ptr, key.size)).WillOnce(Return(key_data));
   EXPECT_CALL(*storage_provider_, getCurrentBatch())
       .WillOnce(Return(trie_batch_));
-  EXPECT_CALL(*trie_batch_, tryGet(key_data.view()))
+  EXPECT_CALL(*trie_batch_, tryGetMock(key_data.view()))
       .WillOnce(Return(value_data));
   EXPECT_CALL(
       *memory_,
@@ -367,7 +367,7 @@ TEST_F(StorageExtensionTest, ExtStorageAppendTest) {
   Buffer vals_encoded;
   {
     // @when there is no value by given key in trie
-    EXPECT_CALL(*trie_batch_, tryGet(key_data.view()))
+    EXPECT_CALL(*trie_batch_, tryGetMock(key_data.view()))
         .WillOnce(Return(std::nullopt));
 
     // @then storage is inserted by scale encoded vector containing
@@ -383,7 +383,7 @@ TEST_F(StorageExtensionTest, ExtStorageAppendTest) {
 
   {
     // @when there is a value by given key (inserted above)
-    EXPECT_CALL(*trie_batch_, tryGet(key_data.view()))
+    EXPECT_CALL(*trie_batch_, tryGetMock(key_data.view()))
         .WillOnce(Return(vals_encoded));
 
     // @then storage is inserted by scale encoded vector containing two
@@ -426,7 +426,7 @@ TEST_F(StorageExtensionTest, ExtStorageAppendTestCompactLenChanged) {
 
   {
     // @when encoded vals is stored by given key
-    EXPECT_CALL(*trie_batch_, tryGet(key_data.view()))
+    EXPECT_CALL(*trie_batch_, tryGetMock(key_data.view()))
         .WillOnce(Return(vals_encoded));
 
     // @when storage is inserted by one more value by the same key
@@ -535,7 +535,7 @@ TEST_F(StorageExtensionTest, StorageGetV1Test) {
       .WillOnce(Return(value_span));
 
   // expect key-value pair was put to db
-  EXPECT_CALL(*trie_batch_, tryGet(key.view())).WillOnce(Return(value));
+  EXPECT_CALL(*trie_batch_, tryGetMock(key.view())).WillOnce(Return(value));
 
   ASSERT_EQ(value_span,
             storage_extension_->ext_storage_get_version_1(key_span));
@@ -651,7 +651,7 @@ TEST_F(StorageExtensionTest, RootTest) {
         return cursor;
       }));
 
-  EXPECT_CALL(*trie_batch_, tryGet(current_key.view()))
+  EXPECT_CALL(*trie_batch_, tryGetMock(current_key.view()))
       .WillOnce(
           Return(outcome::success(std::make_optional(std::cref(empty_hash)))));
   EXPECT_CALL(*trie_batch_, remove(current_key.view()))

--- a/test/core/network/synchronizer_test.cpp
+++ b/test/core/network/synchronizer_test.cpp
@@ -39,6 +39,7 @@ using primitives::BlockHash;
 using primitives::BlockHeader;
 using primitives::BlockInfo;
 using primitives::BlockNumber;
+using storage::BufferStorageMock;
 
 using ::testing::_;
 using ::testing::AnyNumber;
@@ -112,13 +113,8 @@ class SynchronizerTest
       std::make_shared<libp2p::basic::SchedulerMock>();
   std::shared_ptr<crypto::HasherMock> hasher =
       std::make_shared<crypto::HasherMock>();
-  std::shared_ptr<storage::face::GenericStorageMock<common::Buffer,
-                                                    common::Buffer,
-                                                    common::BufferView>>
-      buffer_storage = std::make_shared<
-          storage::face::GenericStorageMock<common::Buffer,
-                                            common::Buffer,
-                                            common::BufferView>>();
+  std::shared_ptr<BufferStorageMock> buffer_storage =
+      std::make_shared<BufferStorageMock>();
 
   std::shared_ptr<network::SynchronizerImpl> synchronizer;
 

--- a/test/core/runtime/runtime_test_base.hpp
+++ b/test/core/runtime/runtime_test_base.hpp
@@ -67,11 +67,9 @@ class RuntimeTestBase : public ::testing::Test {
   using Digest = primitives::Digest;
   using PersistentTrieBatchMock = storage::trie::PersistentTrieBatchMock;
   using EphemeralTrieBatchMock = storage::trie::EphemeralTrieBatchMock;
-  using TopperTrieBatchMock = storage::trie::TopperTrieBatchMock;
 
   void initStorage() {
     using storage::trie::PersistentTrieBatch;
-    using storage::trie::TopperTrieBatchMock;
 
     auto random_generator = std::make_shared<crypto::BoostRandomGenerator>();
     auto sr25519_provider =
@@ -192,7 +190,7 @@ class RuntimeTestBase : public ::testing::Test {
 
   template <typename BatchMock>
   void prepareStorageBatchExpectations(BatchMock &batch) {
-    ON_CALL(batch, get(_)).WillByDefault(testing::Invoke([](auto &key) {
+    ON_CALL(batch, getMock(_)).WillByDefault(testing::Invoke([](auto &key) {
       static common::Buffer buf;
       return std::cref(buf);
     }));
@@ -209,7 +207,7 @@ class RuntimeTestBase : public ::testing::Test {
       return cursor;
     }));
     static auto heappages_key = ":heappages"_buf;
-    EXPECT_CALL(batch, get(heappages_key.view()));
+    EXPECT_CALL(batch, getMock(heappages_key.view()));
   }
 
   primitives::BlockHeader createBlockHeader(primitives::BlockHash const &hash,

--- a/test/core/runtime/storage_code_provider_test.cpp
+++ b/test/core/runtime/storage_code_provider_test.cpp
@@ -53,7 +53,8 @@ TEST_F(StorageCodeProviderTest, GetCodeWhenNoStorageUpdates) {
   EXPECT_CALL(*trie_db, getEphemeralBatchAt(first_state_root))
       .WillOnce(Invoke([this]() {
         auto batch = std::make_unique<storage::trie::EphemeralTrieBatchMock>();
-        EXPECT_CALL(*batch, get(common::BufferView{storage::kRuntimeCodeKey}))
+        EXPECT_CALL(*batch,
+                    getMock(common::BufferView{storage::kRuntimeCodeKey}))
             .WillOnce(Return(state_code_));
         return batch;
       }));
@@ -94,7 +95,8 @@ TEST_F(StorageCodeProviderTest, DISABLED_GetCodeWhenStorageUpdates) {
   EXPECT_CALL(*trie_db, getEphemeralBatchAt(first_state_root))
       .WillOnce(Invoke([this]() {
         auto batch = std::make_unique<storage::trie::EphemeralTrieBatchMock>();
-        EXPECT_CALL(*batch, get(common::BufferView{storage::kRuntimeCodeKey}))
+        EXPECT_CALL(*batch,
+                    getMock(common::BufferView{storage::kRuntimeCodeKey}))
             .WillOnce(Return(state_code_));
         return batch;
       }));
@@ -108,7 +110,8 @@ TEST_F(StorageCodeProviderTest, DISABLED_GetCodeWhenStorageUpdates) {
   EXPECT_CALL(*trie_db, getEphemeralBatchAt(second_state_root))
       .WillOnce(Invoke([&new_state_code](auto &) {
         auto batch = std::make_unique<storage::trie::EphemeralTrieBatchMock>();
-        EXPECT_CALL(*batch, get(common::BufferView{storage::kRuntimeCodeKey}))
+        EXPECT_CALL(*batch,
+                    getMock(common::BufferView{storage::kRuntimeCodeKey}))
             .WillOnce(Return(new_state_code));
         return batch;
       }));

--- a/test/core/runtime/trie_storage_provider_test.cpp
+++ b/test/core/runtime/trie_storage_provider_test.cpp
@@ -84,7 +84,7 @@ TEST_F(TrieStorageProviderTest, NestedTransactions) {
           ASSERT_OUTCOME_SUCCESS(
               val,
               batch->get(Buffer(std::vector<uint8_t>(key.begin(), key.end()))));
-          actual_view += val.get().asString();
+          actual_view += val.mut().asString();
         }
         EXPECT_EQ(actual_view, expected_view);
       };

--- a/test/core/storage/rocksdb/rocksdb_integration_test.cpp
+++ b/test/core/storage/rocksdb/rocksdb_integration_test.cpp
@@ -117,7 +117,7 @@ TEST_F(RocksDb_Integration_Test, Iterator) {
     auto v = it->value().value();
     EXPECT_EQ(k, v);
 
-    logger->info("key: {}, value: {}", k.toHex(), v.toHex());
+    logger->info("key: {}, value: {}", k.toHex(), v.view().toHex());
 
     EXPECT_GE(k[0], 0);
     EXPECT_LT(k[0], size);

--- a/test/core/storage/rocksdb/rocksdb_integration_test.cpp
+++ b/test/core/storage/rocksdb/rocksdb_integration_test.cpp
@@ -37,7 +37,7 @@ struct RocksDb_Integration_Test : public test::BaseRocksDB_Test {
  * @then {value} is correct
  */
 TEST_F(RocksDb_Integration_Test, Put_Get) {
-  ASSERT_OUTCOME_SUCCESS_TRY(db_->put(key_, value_));
+  ASSERT_OUTCOME_SUCCESS_TRY(db_->put(key_, BufferView{value_}));
   ASSERT_OUTCOME_SUCCESS(contains, db_->contains(key_));
   EXPECT_TRUE(contains);
   EXPECT_OUTCOME_TRUE_2(val, db_->load(key_));
@@ -72,7 +72,7 @@ TEST_F(RocksDb_Integration_Test, WriteBatch) {
   ASSERT_TRUE(batch);
 
   for (const auto &item : keys) {
-    ASSERT_OUTCOME_SUCCESS_TRY(batch->put(item, item));
+    ASSERT_OUTCOME_SUCCESS_TRY(batch->put(item, BufferView{item}));
     ASSERT_OUTCOME_SUCCESS(contains, db_->contains(item));
     EXPECT_FALSE(contains);
   }
@@ -104,7 +104,7 @@ TEST_F(RocksDb_Integration_Test, Iterator) {
   }
 
   for (const auto &item : keys) {
-    ASSERT_OUTCOME_SUCCESS_TRY(db_->put(item, item));
+    ASSERT_OUTCOME_SUCCESS_TRY(db_->put(item, BufferView{item}));
   }
 
   std::array<size_t, size> counter{};

--- a/test/core/storage/rocksdb/rocksdb_integration_test.cpp
+++ b/test/core/storage/rocksdb/rocksdb_integration_test.cpp
@@ -40,7 +40,7 @@ TEST_F(RocksDb_Integration_Test, Put_Get) {
   ASSERT_OUTCOME_SUCCESS_TRY(db_->put(key_, BufferView{value_}));
   ASSERT_OUTCOME_SUCCESS(contains, db_->contains(key_));
   EXPECT_TRUE(contains);
-  EXPECT_OUTCOME_TRUE_2(val, db_->load(key_));
+  EXPECT_OUTCOME_TRUE_2(val, db_->get(key_));
   EXPECT_EQ(val, value_);
 }
 
@@ -53,7 +53,7 @@ TEST_F(RocksDb_Integration_Test, Get_NonExistent) {
   ASSERT_OUTCOME_SUCCESS(contains, db_->contains(key_));
   EXPECT_FALSE(contains);
   ASSERT_OUTCOME_SUCCESS_TRY(db_->remove(key_));
-  auto r = db_->load(key_);
+  auto r = db_->get(key_);
   EXPECT_FALSE(r);
   EXPECT_EQ(r.error().value(), (int)DatabaseError::NOT_FOUND);
 }
@@ -82,7 +82,7 @@ TEST_F(RocksDb_Integration_Test, WriteBatch) {
   for (const auto &item : expected) {
     ASSERT_OUTCOME_SUCCESS(contains, db_->contains(item));
     EXPECT_TRUE(contains);
-    ASSERT_OUTCOME_SUCCESS(val, db_->load(item));
+    ASSERT_OUTCOME_SUCCESS(val, db_->get(item));
     EXPECT_EQ(val, item);
   }
 

--- a/test/core/storage/trie/polkadot_trie/polkadot_trie_cursor_test.cpp
+++ b/test/core/storage/trie/polkadot_trie/polkadot_trie_cursor_test.cpp
@@ -109,7 +109,7 @@ TEST_F(PolkadotTrieCursorTest, NextOnSmallTrie) {
     ASSERT_TRUE(cursor.key());
     ASSERT_TRUE(cursor.value());
     ASSERT_EQ(cursor.key().value(), p.first);
-    ASSERT_EQ(cursor.value().value().get(), p.second);
+    ASSERT_EQ(cursor.value().value(), p.second);
   }
   EXPECT_OUTCOME_SUCCESS(r1, cursor.next())
   ASSERT_FALSE(cursor.isValid());
@@ -190,9 +190,9 @@ TEST_F(PolkadotTrieCursorTest, LowerBoundKeyNotPresent) {
   auto trie = makeTrie(lex_sorted_vals);
   auto cursor = trie->trieCursor();
   cursor->seekLowerBound("06066666"_hex2buf).value();
-  ASSERT_EQ(cursor->value().value().get(), "0607"_hex2buf);
+  ASSERT_EQ(cursor->value().value(), "0607"_hex2buf);
   EXPECT_OUTCOME_TRUE_1(cursor->next())
-  ASSERT_EQ(cursor->value().value().get(), "060708"_hex2buf);
+  ASSERT_EQ(cursor->value().value(), "060708"_hex2buf);
 }
 
 /**
@@ -218,9 +218,9 @@ TEST_F(PolkadotTrieCursorTest, LowerBoundMiddleFromRoot) {
   auto trie = makeTrie(lex_sorted_vals);
   auto cursor = trie->trieCursor();
   cursor->seekLowerBound("03"_hex2buf).value();
-  ASSERT_EQ(cursor->value().value().get(), "05"_hex2buf);
+  ASSERT_EQ(cursor->value().value(), "05"_hex2buf);
   EXPECT_OUTCOME_TRUE_1(cursor->next())
-  ASSERT_EQ(cursor->value().value().get(), "06"_hex2buf);
+  ASSERT_EQ(cursor->value().value(), "06"_hex2buf);
 }
 
 /**
@@ -234,9 +234,9 @@ TEST_F(PolkadotTrieCursorTest, LowerBoundFirstKey) {
   auto cursor = trie->trieCursor();
 
   cursor->seekLowerBound("00"_hex2buf).value();
-  ASSERT_EQ(cursor->value().value().get(), "0102"_hex2buf);
+  ASSERT_EQ(cursor->value().value(), "0102"_hex2buf);
   EXPECT_OUTCOME_TRUE_1(cursor->next())
-  ASSERT_EQ(cursor->value().value().get(), "0103"_hex2buf);
+  ASSERT_EQ(cursor->value().value(), "0103"_hex2buf);
 }
 
 /**

--- a/test/core/storage/trie/polkadot_trie/polkadot_trie_cursor_test.cpp
+++ b/test/core/storage/trie/polkadot_trie/polkadot_trie_cursor_test.cpp
@@ -18,6 +18,7 @@
 #include "testutil/storage/polkadot_trie_printer.hpp"
 
 using kagome::common::Buffer;
+using kagome::common::BufferView;
 using kagome::storage::trie::PolkadotTrie;
 using kagome::storage::trie::PolkadotTrieCursorImpl;
 using kagome::storage::trie::PolkadotTrieImpl;
@@ -55,7 +56,7 @@ std::tuple<std::shared_ptr<PolkadotTrie>, std::set<Buffer>> generateRandomTrie(
   for (size_t i = 0; i < keys_num; i++) {
     kagome::common::Buffer key(key_length_gen(), 0);
     std::generate(key.begin(), key.end(), std::ref(key_gen));
-    EXPECT_OUTCOME_TRUE_1(trie->put(key, key))
+    EXPECT_OUTCOME_TRUE_1(trie->put(key, BufferView{key}))
     keys.emplace(std::move(key));
   }
   std::get<0>(res) = std::move(trie);
@@ -66,7 +67,7 @@ std::shared_ptr<PolkadotTrie> makeTrie(
     const std::vector<std::pair<Buffer, Buffer>> &vals) {
   auto trie = std::make_shared<PolkadotTrieImpl>();
   for (auto &p : vals) {
-    EXPECT_OUTCOME_TRUE_1(trie->put(p.first, p.second))
+    EXPECT_OUTCOME_TRUE_1(trie->put(p.first, BufferView{p.second}));
   }
   return trie;
 }

--- a/test/core/storage/trie/polkadot_trie/polkadot_trie_test.cpp
+++ b/test/core/storage/trie/polkadot_trie/polkadot_trie_test.cpp
@@ -88,7 +88,7 @@ TEST_P(TrieTest, RunCommand) {
       case Command::GET: {
         if (command.value) {
           ASSERT_OUTCOME_SUCCESS(val, trie->get(command.key));
-          ASSERT_EQ(val.get(), command.value.value());
+          ASSERT_EQ(val, command.value.value());
         } else {
           EXPECT_OUTCOME_FALSE(err, trie->get(command.key));
           ASSERT_EQ(
@@ -268,18 +268,18 @@ TEST_F(TrieTest, Put) {
 
   for (auto &entry : data) {
     ASSERT_OUTCOME_SUCCESS(res, trie->get(entry.first));
-    ASSERT_EQ(res.get(), entry.second);
+    ASSERT_EQ(res, entry.second);
   }
   ASSERT_OUTCOME_SUCCESS_TRY(trie->put("102030"_hex2buf, "0a0b0c"_hex2buf));
   ASSERT_OUTCOME_SUCCESS_TRY(trie->put("104050"_hex2buf, "0a0b0c"_hex2buf));
   ASSERT_OUTCOME_SUCCESS_TRY(trie->put("102030"_hex2buf, "010203"_hex2buf));
   ASSERT_OUTCOME_SUCCESS(v1, trie->get("102030"_hex2buf));
-  ASSERT_EQ(v1.get(), "010203"_hex2buf);
+  ASSERT_EQ(v1, "010203"_hex2buf);
   ASSERT_OUTCOME_SUCCESS(v2, trie->get("104050"_hex2buf));
-  ASSERT_EQ(v2.get(), "0a0b0c"_hex2buf);
+  ASSERT_EQ(v2, "0a0b0c"_hex2buf);
   ASSERT_OUTCOME_SUCCESS_TRY(trie->put("1332"_hex2buf, ""_buf));
   ASSERT_OUTCOME_SUCCESS(v3, trie->get("1332"_hex2buf));
-  ASSERT_EQ(v3.get(), ""_buf);
+  ASSERT_EQ(v3, ""_buf);
 }
 
 /**
@@ -312,7 +312,7 @@ TEST_F(TrieTest, Replace) {
   ASSERT_OUTCOME_SUCCESS_TRY(
       trie->put(data[1].first, BufferView{data[3].second}));
   ASSERT_OUTCOME_SUCCESS(res, trie->get(data[1].first));
-  ASSERT_EQ(res.get(), data[3].second);
+  ASSERT_EQ(res, data[3].second);
 }
 
 /**

--- a/test/core/storage/trie/polkadot_trie/polkadot_trie_test.cpp
+++ b/test/core/storage/trie/polkadot_trie/polkadot_trie_test.cpp
@@ -14,6 +14,7 @@
 #include "testutil/storage/polkadot_trie_printer.hpp"
 
 using kagome::common::Buffer;
+using kagome::common::BufferView;
 using kagome::common::Hash256;
 using kagome::storage::trie::BranchNode;
 using kagome::storage::trie::KeyNibbles;
@@ -59,7 +60,7 @@ const std::vector<std::pair<Buffer, Buffer>> TrieTest::data = {
 
 void FillSmallTree(PolkadotTrie &trie) {
   for (auto &entry : TrieTest::data) {
-    ASSERT_OUTCOME_SUCCESS_TRY(trie.put(entry.first, entry.second));
+    ASSERT_OUTCOME_SUCCESS_TRY(trie.put(entry.first, BufferView{entry.second}));
   }
 }
 
@@ -98,7 +99,7 @@ TEST_P(TrieTest, RunCommand) {
       }
       case Command::PUT: {
         ASSERT_OUTCOME_SUCCESS_TRY(
-            trie->put(command.key, command.value.value()));
+            trie->put(command.key, BufferView{command.value.value()}));
         break;
       }
       case Command::REMOVE: {
@@ -308,7 +309,8 @@ TEST_F(TrieTest, Remove) {
 TEST_F(TrieTest, Replace) {
   FillSmallTree(*trie);
 
-  ASSERT_OUTCOME_SUCCESS_TRY(trie->put(data[1].first, data[3].second));
+  ASSERT_OUTCOME_SUCCESS_TRY(
+      trie->put(data[1].first, BufferView{data[3].second}));
   ASSERT_OUTCOME_SUCCESS(res, trie->get(data[1].first));
   ASSERT_EQ(res.get(), data[3].second);
 }
@@ -324,7 +326,8 @@ TEST_F(TrieTest, ClearPrefix) {
                                                  {"bat"_buf, "789"_buf},
                                                  {"batch"_buf, "0-="_buf}};
   for (auto &entry : data) {
-    ASSERT_OUTCOME_SUCCESS_TRY(trie->put(entry.first, entry.second));
+    ASSERT_OUTCOME_SUCCESS_TRY(
+        trie->put(entry.first, BufferView{entry.second}));
   }
   ASSERT_OUTCOME_SUCCESS_TRY(
       trie->clearPrefix("bar"_buf, std::nullopt, [](const auto &, auto &&) {
@@ -535,7 +538,8 @@ TEST_F(TrieTest, GetPath) {
       {"0a0b0c"_hex2buf, "deadbeef"_hex2buf}};
 
   for (const auto &entry : TrieTest::data) {
-    ASSERT_OUTCOME_SUCCESS_TRY(trie->put(entry.first, entry.second));
+    ASSERT_OUTCOME_SUCCESS_TRY(
+        trie->put(entry.first, BufferView{entry.second}));
   }
 
   std::vector<std::pair<const BranchNode *, uint8_t>> path;
@@ -568,7 +572,8 @@ TEST_F(TrieTest, GetPathToInvalid) {
       {"0a0b0c"_hex2buf, "deadbeef"_hex2buf}};
 
   for (const auto &entry : TrieTest::data) {
-    ASSERT_OUTCOME_SUCCESS_TRY(trie->put(entry.first, entry.second));
+    ASSERT_OUTCOME_SUCCESS_TRY(
+        trie->put(entry.first, BufferView{entry.second}));
   }
   EXPECT_OUTCOME_SOME_ERROR(
       _,
@@ -592,7 +597,8 @@ TEST_F(TrieTest, GetNodeReturnsNullptrWhenNotFound) {
       {"0a0b0c"_hex2buf, "deadbeef"_hex2buf}};
 
   for (auto &entry : TrieTest::data) {
-    ASSERT_OUTCOME_SUCCESS_TRY(trie->put(entry.first, entry.second));
+    ASSERT_OUTCOME_SUCCESS_TRY(
+        trie->put(entry.first, BufferView{entry.second}));
   }
   ASSERT_OUTCOME_SUCCESS(
       res,

--- a/test/core/storage/trie/polkadot_trie_cursor_dummy.hpp
+++ b/test/core/storage/trie/polkadot_trie_cursor_dummy.hpp
@@ -61,8 +61,8 @@ namespace kagome::storage::trie {
       return current_->first;
     }
 
-    std::optional<common::BufferConstRef> value() const override {
-      return current_->second;
+    std::optional<BufferOrView> value() const override {
+      return BufferView{current_->second};
     }
   };
 }  // namespace kagome::storage::trie

--- a/test/core/storage/trie/trie_storage/trie_batch_test.cpp
+++ b/test/core/storage/trie/trie_storage/trie_batch_test.cpp
@@ -25,7 +25,6 @@ using kagome::common::BufferOrView;
 using kagome::common::BufferView;
 using kagome::common::Hash256;
 using kagome::primitives::BlockHash;
-using kagome::storage::face::WriteBatch;
 using kagome::subscription::SubscriptionEngine;
 using testing::_;
 using testing::Invoke;

--- a/test/core/storage/trie/trie_storage/trie_batch_test.cpp
+++ b/test/core/storage/trie/trie_storage/trie_batch_test.cpp
@@ -122,7 +122,7 @@ TEST_F(TrieBatchTest, Put) {
   new_batch = trie->getEphemeralBatchAt(root_hash).value();
   for (auto &entry : data) {
     ASSERT_OUTCOME_SUCCESS(res, new_batch->get(entry.first));
-    ASSERT_EQ(res.get(), entry.second);
+    ASSERT_EQ(res, entry.second);
   }
 
   ASSERT_OUTCOME_SUCCESS_TRY(
@@ -130,9 +130,9 @@ TEST_F(TrieBatchTest, Put) {
   ASSERT_OUTCOME_SUCCESS_TRY(
       new_batch->put("104050"_hex2buf, "0a0b0c"_hex2buf));
   ASSERT_OUTCOME_SUCCESS(v1, new_batch->get("102030"_hex2buf));
-  ASSERT_EQ(v1.get(), "010203"_hex2buf);
+  ASSERT_EQ(v1, "010203"_hex2buf);
   ASSERT_OUTCOME_SUCCESS(v2, new_batch->get("104050"_hex2buf));
-  ASSERT_EQ(v2.get(), "0a0b0c"_hex2buf);
+  ASSERT_EQ(v2, "0a0b0c"_hex2buf);
 }
 
 /**
@@ -171,7 +171,7 @@ TEST_F(TrieBatchTest, Replace) {
   ASSERT_OUTCOME_SUCCESS(root_hash, batch->commit());
   auto read_batch = trie->getEphemeralBatchAt(root_hash).value();
   ASSERT_OUTCOME_SUCCESS(res, read_batch->get(data[1].first));
-  ASSERT_EQ(res.get(), data[3].second);
+  ASSERT_EQ(res, data[3].second);
 }
 
 /**

--- a/test/core/storage/trie/trie_storage/trie_storage_backend_test.cpp
+++ b/test/core/storage/trie/trie_storage/trie_storage_backend_test.cpp
@@ -15,7 +15,7 @@
 
 using kagome::common::Buffer;
 using kagome::common::BufferView;
-using kagome::storage::face::GenericStorageMock;
+using kagome::storage::BufferStorageMock;
 using kagome::storage::face::WriteBatchMock;
 using kagome::storage::trie::TrieStorageBackendImpl;
 using testing::Invoke;
@@ -25,8 +25,8 @@ static const Buffer kNodePrefix{1};
 
 class TrieDbBackendTest : public testing::Test {
  public:
-  std::shared_ptr<GenericStorageMock<Buffer, Buffer, BufferView>> storage =
-      std::make_shared<GenericStorageMock<Buffer, Buffer, BufferView>>();
+  std::shared_ptr<BufferStorageMock> storage =
+      std::make_shared<BufferStorageMock>();
   TrieStorageBackendImpl backend{storage, kNodePrefix};
 };
 
@@ -65,7 +65,7 @@ TEST_F(TrieDbBackendTest, Get) {
  * @then it delegates them to the underlying storage batch with added prefixes
  */
 TEST_F(TrieDbBackendTest, Batch) {
-  auto batch_mock = std::make_unique<WriteBatchMock<BufferView, Buffer>>();
+  auto batch_mock = std::make_unique<WriteBatchMock<Buffer, Buffer>>();
   auto buf_abc = Buffer{kNodePrefix}.put("abc"_buf);
   EXPECT_CALL(*batch_mock, put(buf_abc.view(), "123"_buf))
       .WillOnce(Return(outcome::success()));

--- a/test/core/storage/trie/trie_storage/trie_storage_backend_test.cpp
+++ b/test/core/storage/trie/trie_storage/trie_storage_backend_test.cpp
@@ -54,7 +54,8 @@ TEST_F(TrieDbBackendTest, Put) {
 TEST_F(TrieDbBackendTest, Get) {
   Buffer prefixed{kNodePrefix};
   prefixed.put("abc"_buf);
-  EXPECT_CALL(*storage, load(BufferView{prefixed})).WillOnce(Return("123"_buf));
+  EXPECT_CALL(*storage, loadMock(BufferView{prefixed}))
+      .WillOnce(Return("123"_buf));
   EXPECT_OUTCOME_TRUE_1(backend.load("abc"_buf));
 }
 

--- a/test/core/storage/trie/trie_storage/trie_storage_backend_test.cpp
+++ b/test/core/storage/trie/trie_storage/trie_storage_backend_test.cpp
@@ -54,9 +54,9 @@ TEST_F(TrieDbBackendTest, Put) {
 TEST_F(TrieDbBackendTest, Get) {
   Buffer prefixed{kNodePrefix};
   prefixed.put("abc"_buf);
-  EXPECT_CALL(*storage, loadMock(BufferView{prefixed}))
+  EXPECT_CALL(*storage, getMock(BufferView{prefixed}))
       .WillOnce(Return("123"_buf));
-  EXPECT_OUTCOME_TRUE_1(backend.load("abc"_buf));
+  EXPECT_OUTCOME_TRUE_1(backend.get("abc"_buf));
 }
 
 /**

--- a/test/core/storage/trie/trie_storage/trie_storage_test.cpp
+++ b/test/core/storage/trie/trie_storage/trie_storage_test.cpp
@@ -80,11 +80,11 @@ TEST(TriePersistencyTest, CreateDestroyCreate) {
           .value();
   auto batch = storage->getPersistentBatchAt(root).value();
   EXPECT_OUTCOME_TRUE(v1, batch->get("123"_buf));
-  ASSERT_EQ(v1.get(), "abc"_buf);
+  ASSERT_EQ(v1, "abc"_buf);
   EXPECT_OUTCOME_TRUE(v2, batch->get("345"_buf));
-  ASSERT_EQ(v2.get(), "def"_buf);
+  ASSERT_EQ(v2, "def"_buf);
   EXPECT_OUTCOME_TRUE(v3, batch->get("678"_buf));
-  ASSERT_EQ(v3.get(), "xyz"_buf);
+  ASSERT_EQ(v3, "xyz"_buf);
 
   boost::filesystem::remove_all("/tmp/kagome_rocksdb_persistency_test");
 }

--- a/test/mock/core/runtime/session_keys_api_mock.hpp
+++ b/test/mock/core/runtime/session_keys_api_mock.hpp
@@ -22,7 +22,7 @@ namespace kagome::runtime {
 
     MOCK_METHOD(outcome::result<std::vector<TypedKey>>,
                 decode_session_keys,
-                (const primitives::BlockHash &, common::BufferConstRef),
+                (const primitives::BlockHash &, common::BufferView),
                 (const, override));
   };
 

--- a/test/mock/core/storage/persistent_map_mock.hpp
+++ b/test/mock/core/storage/persistent_map_mock.hpp
@@ -29,12 +29,9 @@ namespace kagome::storage::face {
 
     MOCK_CONST_METHOD0_T(empty, bool());
 
-    MOCK_METHOD(outcome::result<void>,
-                put,
-                (const KView &, const V &),
-                (override));
-    outcome::result<void> put(const KView &k, V &&v) override {
-      return put(k, v);
+    MOCK_METHOD(outcome::result<void>, put, (const KView &, const V &));
+    outcome::result<void> put(const KView &k, OwnedOrViewOf<V> &&v) override {
+      return put(k, v.mut());
     }
 
     MOCK_METHOD1_T(remove, outcome::result<void>(const KView &));

--- a/test/mock/core/storage/persistent_map_mock.hpp
+++ b/test/mock/core/storage/persistent_map_mock.hpp
@@ -20,10 +20,26 @@ namespace kagome::storage::face {
         cursor,
         std::unique_ptr<typename face::GenericStorage<K, V, KView>::Cursor>());
 
-    MOCK_CONST_METHOD1_T(load, outcome::result<V>(const KView &));
+    MOCK_METHOD(outcome::result<V>, loadMock, (const KView &), (const));
 
-    MOCK_CONST_METHOD1_T(tryLoad,
-                         outcome::result<std::optional<V>>(const KView &));
+    MOCK_METHOD(outcome::result<std::optional<V>>,
+                tryLoadMock,
+                (const KView &),
+                (const));
+
+    outcome::result<OwnedOrViewOf<V>> load(const KView &key) const override {
+      OUTCOME_TRY(value, loadMock(key));
+      return std::move(value);
+    }
+
+    outcome::result<std::optional<OwnedOrViewOf<V>>> tryLoad(
+        const KView &key) const override {
+      OUTCOME_TRY(value, tryLoadMock(key));
+      if (value) {
+        return std::move(*value);
+      }
+      return std::nullopt;
+    }
 
     MOCK_CONST_METHOD1_T(contains, outcome::result<bool>(const KView &));
 

--- a/test/mock/core/storage/persistent_map_mock.hpp
+++ b/test/mock/core/storage/persistent_map_mock.hpp
@@ -27,12 +27,12 @@ namespace kagome::storage::face {
                 (const KView &),
                 (const));
 
-    outcome::result<OwnedOrViewOf<V>> load(const KView &key) const override {
+    outcome::result<OwnedOrView<V>> load(const KView &key) const override {
       OUTCOME_TRY(value, loadMock(key));
       return std::move(value);
     }
 
-    outcome::result<std::optional<OwnedOrViewOf<V>>> tryLoad(
+    outcome::result<std::optional<OwnedOrView<V>>> tryLoad(
         const KView &key) const override {
       OUTCOME_TRY(value, tryLoadMock(key));
       if (value) {
@@ -46,7 +46,7 @@ namespace kagome::storage::face {
     MOCK_CONST_METHOD0_T(empty, bool());
 
     MOCK_METHOD(outcome::result<void>, put, (const KView &, const V &));
-    outcome::result<void> put(const KView &k, OwnedOrViewOf<V> &&v) override {
+    outcome::result<void> put(const KView &k, OwnedOrView<V> &&v) override {
       return put(k, v.mut());
     }
 

--- a/test/mock/core/storage/persistent_map_mock.hpp
+++ b/test/mock/core/storage/persistent_map_mock.hpp
@@ -20,21 +20,21 @@ namespace kagome::storage::face {
         cursor,
         std::unique_ptr<typename face::GenericStorage<K, V, KView>::Cursor>());
 
-    MOCK_METHOD(outcome::result<V>, loadMock, (const KView &), (const));
+    MOCK_METHOD(outcome::result<V>, getMock, (const KView &), (const));
 
     MOCK_METHOD(outcome::result<std::optional<V>>,
-                tryLoadMock,
+                tryGetMock,
                 (const KView &),
                 (const));
 
-    outcome::result<OwnedOrView<V>> load(const KView &key) const override {
-      OUTCOME_TRY(value, loadMock(key));
+    outcome::result<OwnedOrView<V>> get(const KView &key) const override {
+      OUTCOME_TRY(value, getMock(key));
       return std::move(value);
     }
 
-    outcome::result<std::optional<OwnedOrView<V>>> tryLoad(
+    outcome::result<std::optional<OwnedOrView<V>>> tryGet(
         const KView &key) const override {
-      OUTCOME_TRY(value, tryLoadMock(key));
+      OUTCOME_TRY(value, tryGetMock(key));
       if (value) {
         return std::move(*value);
       }

--- a/test/mock/core/storage/trie/polkadot_trie_cursor_mock.h
+++ b/test/mock/core/storage/trie/polkadot_trie_cursor_mock.h
@@ -34,10 +34,7 @@ namespace kagome::storage::trie {
 
     MOCK_METHOD(std::optional<common::Buffer>, key, (), (const, override));
 
-    MOCK_METHOD(std::optional<common::BufferConstRef>,
-                value,
-                (),
-                (const, override));
+    MOCK_METHOD(std::optional<BufferOrView>, value, (), (const, override));
   };
 }  // namespace kagome::storage::trie
 

--- a/test/mock/core/storage/trie/trie_batches_mock.hpp
+++ b/test/mock/core/storage/trie/trie_batches_mock.hpp
@@ -36,11 +36,10 @@ namespace kagome::storage::trie {
 
     MOCK_METHOD(outcome::result<void>,
                 put,
-                (const common::BufferView &, const common::Buffer &),
-                (override));
+                (const common::BufferView &, const Buffer &));
     outcome::result<void> put(const common::BufferView &k,
-                              common::Buffer &&v) override {
-      return put(k, v);
+                              BufferOrView &&v) override {
+      return put(k, v.mut());
     }
 
     MOCK_METHOD(outcome::result<void>,
@@ -87,11 +86,10 @@ namespace kagome::storage::trie {
 
     MOCK_METHOD(outcome::result<void>,
                 put,
-                (const common::BufferView &, const common::Buffer &),
-                (override));
+                (const common::BufferView &, const Buffer &));
     outcome::result<void> put(const common::BufferView &k,
-                              common::Buffer &&v) override {
-      return put(k, v);
+                              BufferOrView &&v) override {
+      return put(k, v.mut());
     }
 
     MOCK_METHOD(outcome::result<void>,
@@ -127,11 +125,10 @@ namespace kagome::storage::trie {
 
     MOCK_METHOD(outcome::result<void>,
                 put,
-                (const common::BufferView &, const common::Buffer &),
-                (override));
+                (const common::BufferView &, const Buffer &));
     outcome::result<void> put(const common::BufferView &k,
-                              common::Buffer &&v) override {
-      return put(k, v);
+                              BufferOrView &&v) override {
+      return put(k, v.mut());
     }
 
     MOCK_METHOD(outcome::result<void>,

--- a/test/mock/core/storage/trie/trie_batches_mock.hpp
+++ b/test/mock/core/storage/trie/trie_batches_mock.hpp
@@ -14,15 +14,29 @@ namespace kagome::storage::trie {
 
   class PersistentTrieBatchMock : public PersistentTrieBatch {
    public:
-    MOCK_METHOD(outcome::result<common::BufferConstRef>,
-                get,
+    MOCK_METHOD(outcome::result<Buffer>,
+                getMock,
                 (const common::BufferView &),
-                (const, override));
+                (const));
 
-    MOCK_METHOD(outcome::result<std::optional<common::BufferConstRef>>,
-                tryGet,
+    MOCK_METHOD(outcome::result<std::optional<Buffer>>,
+                tryGetMock,
                 (const common::BufferView &),
-                (const, override));
+                (const));
+
+    outcome::result<BufferOrView> get(const BufferView &key) const override {
+      OUTCOME_TRY(value, getMock(key));
+      return std::move(value);
+    }
+
+    outcome::result<std::optional<BufferOrView>> tryGet(
+        const BufferView &key) const override {
+      OUTCOME_TRY(value, tryGetMock(key));
+      if (value) {
+        return std::move(*value);
+      }
+      return std::nullopt;
+    }
 
     MOCK_METHOD(std::unique_ptr<PolkadotTrieCursor>,
                 trieCursor,
@@ -64,15 +78,29 @@ namespace kagome::storage::trie {
 
   class EphemeralTrieBatchMock : public EphemeralTrieBatch {
    public:
-    MOCK_METHOD(outcome::result<common::BufferConstRef>,
-                get,
+    MOCK_METHOD(outcome::result<Buffer>,
+                getMock,
                 (const common::BufferView &),
-                (const, override));
+                (const));
 
-    MOCK_METHOD(outcome::result<std::optional<common::BufferConstRef>>,
-                tryGet,
+    MOCK_METHOD(outcome::result<std::optional<Buffer>>,
+                tryGetMock,
                 (const common::BufferView &),
-                (const, override));
+                (const));
+
+    outcome::result<BufferOrView> get(const BufferView &key) const override {
+      OUTCOME_TRY(value, getMock(key));
+      return std::move(value);
+    }
+
+    outcome::result<std::optional<BufferOrView>> tryGet(
+        const BufferView &key) const override {
+      OUTCOME_TRY(value, tryGetMock(key));
+      if (value) {
+        return std::move(*value);
+      }
+      return std::nullopt;
+    }
 
     MOCK_METHOD(std::unique_ptr<PolkadotTrieCursor>,
                 trieCursor,
@@ -106,47 +134,6 @@ namespace kagome::storage::trie {
 
     MOCK_METHOD(outcome::result<RootHash>, hash, (), (override));
   };
-
-  class TopperTrieBatchMock : public TopperTrieBatch {
-   public:
-    MOCK_METHOD(outcome::result<void>, writeBack, (), (override));
-
-    MOCK_METHOD(outcome::result<common::BufferConstRef>,
-                get,
-                (const common::BufferView &),
-                (const, override));
-
-    MOCK_METHOD(outcome::result<bool>,
-                contains,
-                (const common::BufferView &),
-                (const, override));
-
-    MOCK_METHOD(bool, empty, (), (const, override));
-
-    MOCK_METHOD(outcome::result<void>,
-                put,
-                (const common::BufferView &, const Buffer &));
-    outcome::result<void> put(const common::BufferView &k,
-                              BufferOrView &&v) override {
-      return put(k, v.mut());
-    }
-
-    MOCK_METHOD(outcome::result<void>,
-                remove,
-                (const common::BufferView &),
-                (override));
-
-    MOCK_METHOD(std::unique_ptr<PolkadotTrieCursor>,
-                trieCursor,
-                (),
-                (override));
-
-    MOCK_METHOD((outcome::result<std::tuple<bool, uint32_t>>),
-                clearPrefix,
-                (const common::BufferView &buf, std::optional<uint64_t> limit),
-                (override));
-  };
-
 }  // namespace kagome::storage::trie
 
 #endif  // KAGOME_TEST_MOCK_CORE_STORAGE_TRIE_TRIE_BATCHES_MOCK

--- a/test/mock/core/storage/trie/trie_storage_backend_mock.hpp
+++ b/test/mock/core/storage/trie/trie_storage_backend_mock.hpp
@@ -14,10 +14,7 @@ namespace kagome::storage::trie {
 
   class TrieStorageBackendMock : public TrieStorageBackend {
    public:
-    MOCK_METHOD(std::unique_ptr<face::WriteBatch<Buffer, Buffer>>,
-                batch,
-                (),
-                (override));
+    MOCK_METHOD(std::unique_ptr<BufferBatch>, batch, (), (override));
 
     MOCK_METHOD(std::unique_ptr<face::MapCursor<Buffer, Buffer>>,
                 cursor,

--- a/test/mock/core/storage/write_batch_mock.hpp
+++ b/test/mock/core/storage/write_batch_mock.hpp
@@ -20,7 +20,7 @@ namespace kagome::storage::face {
     MOCK_METHOD(void, clear, (), (override));
 
     MOCK_METHOD2_T(put, outcome::result<void>(const K &key, const V &value));
-    outcome::result<void> put(const K &key, OwnedOrViewOf<V> &&value) override {
+    outcome::result<void> put(const K &key, OwnedOrView<V> &&value) override {
       return put(key, value.mut());
     }
 

--- a/test/mock/core/storage/write_batch_mock.hpp
+++ b/test/mock/core/storage/write_batch_mock.hpp
@@ -19,12 +19,14 @@ namespace kagome::storage::face {
 
     MOCK_METHOD(void, clear, (), (override));
 
-    MOCK_METHOD2_T(put, outcome::result<void>(const K &key, const V &value));
-    outcome::result<void> put(const K &key, OwnedOrView<V> &&value) override {
+    MOCK_METHOD2_T(put,
+                   outcome::result<void>(const View<K> &key, const V &value));
+    outcome::result<void> put(const View<K> &key,
+                              OwnedOrView<V> &&value) override {
       return put(key, value.mut());
     }
 
-    MOCK_METHOD1_T(remove, outcome::result<void>(const K &key));
+    MOCK_METHOD1_T(remove, outcome::result<void>(const View<K> &key));
   };
 
 }  // namespace kagome::storage::face

--- a/test/mock/core/storage/write_batch_mock.hpp
+++ b/test/mock/core/storage/write_batch_mock.hpp
@@ -20,8 +20,8 @@ namespace kagome::storage::face {
     MOCK_METHOD(void, clear, (), (override));
 
     MOCK_METHOD2_T(put, outcome::result<void>(const K &key, const V &value));
-    outcome::result<void> put(const K &key, V &&value) override {
-      return put(key, value);
+    outcome::result<void> put(const K &key, OwnedOrViewOf<V> &&value) override {
+      return put(key, value.mut());
     }
 
     MOCK_METHOD1_T(remove, outcome::result<void>(const K &key));


### PR DESCRIPTION
### Referenced issues
- #1432

### Description of the Change
- Add `BufferOrView`, like [rust Cow](https://doc.rust-lang.org/std/borrow/enum.Cow.html)
  - Move only.
  - Construct from buffer view, or from moved buffer.
  - `mut` and `into` like rust.
- Deduplicate storage interface read returning either buffer or view.
- Deduplicate storage interface write accepting buffer or view.
- Merge storage interfaces and inherit implementations from single one.

### Benefits
- Deduplicate code
- Simplify ambiguous interface

### Possible Drawbacks