### PR TITLE
fix submit and watch (python)

### DIFF
--- a/core/api/service/impl/api_service_impl.cpp
+++ b/core/api/service/impl/api_service_impl.cpp
@@ -100,7 +100,9 @@ namespace {
                 name,
                 std::move(value),
                 [session{std::move(session)}](const auto &response) {
-                  session->respond(response);
+                  session->post([session, response{std::string{response}}] {
+                    session->respond(response);
+                  });
                 });
   }
 }  // namespace

--- a/core/api/service/impl/api_service_impl.cpp
+++ b/core/api/service/impl/api_service_impl.cpp
@@ -100,6 +100,8 @@ namespace {
                 name,
                 std::move(value),
                 [session{std::move(session)}](const auto &response) {
+                  // Defer sending JSON-RPC event until subscription id is sent.
+                  // TODO(turuslan): #1474, refactor jrpc notifications
                   session->post([session, response{std::string{response}}] {
                     session->respond(response);
                   });

--- a/core/api/transport/impl/http/http_session.cpp
+++ b/core/api/transport/impl/http/http_session.cpp
@@ -129,4 +129,8 @@ namespace kagome::api {
                                 std::string_view message) {
     logger_->error("error occurred: {}, message: {}", ec, message);
   }
+
+  void HttpSession::post(std::function<void()> cb) {
+    boost::asio::post(strand_, std::move(cb));
+  }
 }  // namespace kagome::api

--- a/core/api/transport/impl/http/http_session.hpp
+++ b/core/api/transport/impl/http/http_session.hpp
@@ -85,6 +85,8 @@ namespace kagome::api {
       return SessionType::kHttp;
     }
 
+    void post(std::function<void()> cb) override;
+
    private:
     /**
      * @brief stops session

--- a/core/api/transport/impl/ws/ws_session.hpp
+++ b/core/api/transport/impl/ws/ws_session.hpp
@@ -74,6 +74,8 @@ namespace kagome::api {
      */
     void respond(std::string_view response) override;
 
+    void post(std::function<void()> cb) override;
+
     /**
      * @brief Closes the incoming connection with "try again later" response
      */
@@ -151,9 +153,7 @@ namespace kagome::api {
     Configuration config_;  ///< session configuration
     boost::beast::websocket::stream<boost::asio::ip::tcp::socket &> stream_;
     boost::beast::flat_buffer rbuffer_;  ///< read buffer
-    boost::beast::flat_buffer wbuffer_;  ///< write buffer
 
-    std::mutex cs_;
     std::queue<std::string> pending_responses_;
 
     std::atomic_bool writing_in_progress_ = false;

--- a/core/api/transport/impl/ws/ws_session.hpp
+++ b/core/api/transport/impl/ws/ws_session.hpp
@@ -156,7 +156,7 @@ namespace kagome::api {
 
     std::queue<std::string> pending_responses_;
 
-    std::atomic_bool writing_in_progress_ = false;
+    bool writing_in_progress_ = false;
     std::atomic_bool stopped_ = false;
 
     SessionId const id_;

--- a/core/api/transport/session.hpp
+++ b/core/api/transport/session.hpp
@@ -106,10 +106,12 @@ namespace kagome::api {
      */
     virtual SessionType type() const = 0;
 
+    // TODO(turuslan): #1474, refactor jrpc notifications
     /**
      * `boost::asio::post(io_context, cb)` to `io_context` of this session.
      *
-     * Defers sending JSON-RPC event until it's subscription id is sent.
+     * Callback is pushed to write queue and will be called after all currently
+     * queued writes will complete.
      */
     virtual void post(std::function<void()> cb) = 0;
 

--- a/core/api/transport/session.hpp
+++ b/core/api/transport/session.hpp
@@ -106,6 +106,11 @@ namespace kagome::api {
      */
     virtual SessionType type() const = 0;
 
+    /**
+     * `boost::asio::post(io_context, cb)` to `io_context` of this session.
+     *
+     * Defers sending JSON-RPC event until it's subscription id is sent.
+     */
     virtual void post(std::function<void()> cb) = 0;
 
    private:

--- a/core/api/transport/session.hpp
+++ b/core/api/transport/session.hpp
@@ -106,6 +106,8 @@ namespace kagome::api {
      */
     virtual SessionType type() const = 0;
 
+    virtual void post(std::function<void()> cb) = 0;
+
    private:
     std::function<OnRequestSignature> on_request_;  ///< `on request` callback
     OnCloseHandler on_close_;


### PR DESCRIPTION
### Referenced issues
- #1324

### Description of the Change
- send subscription id before events (https://github.com/polkascan/py-substrate-interface/pull/311)
- mutex for map
- simplify websocket write

### Benefits
- python `submit_extrinsic(wait_for_finalization)` works

### Possible Drawbacks