### PR TITLE
trie light proof cb

### DIFF
--- a/core/api/service/child_state/impl/child_state_api_impl.cpp
+++ b/core/api/service/child_state/impl/child_state_api_impl.cpp
@@ -49,11 +49,11 @@ namespace kagome::api {
 
     OUTCOME_TRY(header, header_repo_->getBlockHeader(block_hash));
     OUTCOME_TRY(initial_trie_reader,
-                storage_->getEphemeralBatchAt(header.state_root));
+                storage_->getEphemeralBatchAt(header.state_root, {}));
     OUTCOME_TRY(child_root, initial_trie_reader->get(child_storage_key));
     OUTCOME_TRY(child_root_hash, common::Hash256::fromSpan(child_root));
     OUTCOME_TRY(child_storage_trie_reader,
-                storage_->getEphemeralBatchAt(child_root_hash));
+                storage_->getEphemeralBatchAt(child_root_hash, {}));
     auto cursor = child_storage_trie_reader->trieCursor();
 
     OUTCOME_TRY(cursor->seekLowerBound(prefix));
@@ -87,11 +87,11 @@ namespace kagome::api {
 
     OUTCOME_TRY(header, header_repo_->getBlockHeader(block_hash));
     OUTCOME_TRY(initial_trie_reader,
-                storage_->getEphemeralBatchAt(header.state_root));
+                storage_->getEphemeralBatchAt(header.state_root, {}));
     OUTCOME_TRY(child_root, initial_trie_reader->get(child_storage_key));
     OUTCOME_TRY(child_root_hash, common::Hash256::fromSpan(child_root));
     OUTCOME_TRY(child_storage_trie_reader,
-                storage_->getEphemeralBatchAt(child_root_hash));
+                storage_->getEphemeralBatchAt(child_root_hash, {}));
     auto cursor = child_storage_trie_reader->trieCursor();
 
     // if prev_key is bigger than prefix, then set cursor to the next key after
@@ -128,11 +128,12 @@ namespace kagome::api {
     auto at = block_hash_opt ? block_hash_opt.value()
                              : block_tree_->getLastFinalized().hash;
     OUTCOME_TRY(header, header_repo_->getBlockHeader(at));
-    OUTCOME_TRY(trie_reader, storage_->getEphemeralBatchAt(header.state_root));
+    OUTCOME_TRY(trie_reader,
+                storage_->getEphemeralBatchAt(header.state_root, {}));
     OUTCOME_TRY(child_root, trie_reader->get(child_storage_key));
     OUTCOME_TRY(child_root_hash, common::Hash256::fromSpan(child_root));
     OUTCOME_TRY(child_storage_trie_reader,
-                storage_->getEphemeralBatchAt(child_root_hash));
+                storage_->getEphemeralBatchAt(child_root_hash, {}));
     auto res = child_storage_trie_reader->tryGet(key);
     return common::map_result_optional(
         std::move(res), [](common::BufferOrView &&r) { return r.into(); });
@@ -159,11 +160,12 @@ namespace kagome::api {
     auto at = block_hash_opt ? block_hash_opt.value()
                              : block_tree_->getLastFinalized().hash;
     OUTCOME_TRY(header, header_repo_->getBlockHeader(at));
-    OUTCOME_TRY(trie_reader, storage_->getEphemeralBatchAt(header.state_root));
+    OUTCOME_TRY(trie_reader,
+                storage_->getEphemeralBatchAt(header.state_root, {}));
     OUTCOME_TRY(child_root, trie_reader->get(child_storage_key));
     OUTCOME_TRY(child_root_hash, common::Hash256::fromSpan(child_root));
     OUTCOME_TRY(child_storage_trie_reader,
-                storage_->getEphemeralBatchAt(child_root_hash));
+                storage_->getEphemeralBatchAt(child_root_hash, {}));
     OUTCOME_TRY(value, child_storage_trie_reader->get(key));
     return value.size();
   }

--- a/core/api/service/state/impl/state_api_impl.cpp
+++ b/core/api/service/state/impl/state_api_impl.cpp
@@ -68,7 +68,7 @@ namespace kagome::api {
       const std::optional<primitives::BlockHash> &opt_at) const {
     auto at =
         opt_at.has_value() ? opt_at.value() : block_tree_->bestLeaf().hash;
-    return executor_->callAtRaw(at, method, data);
+    return executor_->callAtRaw(at, method, data, {});
   }
 
   outcome::result<std::vector<common::Buffer>> StateApiImpl::getKeysPaged(
@@ -83,7 +83,7 @@ namespace kagome::api {
 
     OUTCOME_TRY(header, header_repo_->getBlockHeader(block_hash));
     OUTCOME_TRY(initial_trie_reader,
-                storage_->getEphemeralBatchAt(header.state_root));
+                storage_->getEphemeralBatchAt(header.state_root, {}));
     auto cursor = initial_trie_reader->trieCursor();
 
     // if prev_key is bigger than prefix, then set cursor to the next key after
@@ -122,7 +122,8 @@ namespace kagome::api {
   outcome::result<std::optional<common::Buffer>> StateApiImpl::getStorageAt(
       const common::BufferView &key, const primitives::BlockHash &at) const {
     OUTCOME_TRY(header, header_repo_->getBlockHeader(at));
-    OUTCOME_TRY(trie_reader, storage_->getEphemeralBatchAt(header.state_root));
+    OUTCOME_TRY(trie_reader,
+                storage_->getEphemeralBatchAt(header.state_root, {}));
     auto res = trie_reader->tryGet(key);
     return common::map_result_optional(
         std::move(res), [](common::BufferOrView &&r) { return r.into(); });
@@ -161,7 +162,7 @@ namespace kagome::api {
     OUTCOME_TRY(range, block_tree_->getChainByBlocks(from, to));
     for (auto &block : range) {
       OUTCOME_TRY(header, header_repo_->getBlockHeader(block));
-      OUTCOME_TRY(batch, storage_->getEphemeralBatchAt(header.state_root));
+      OUTCOME_TRY(batch, storage_->getEphemeralBatchAt(header.state_root, {}));
       StorageChangeSet change{block, {}};
       for (auto &key : keys) {
         OUTCOME_TRY(opt_get, batch->tryGet(key));

--- a/core/blockchain/impl/block_tree_impl.cpp
+++ b/core/blockchain/impl/block_tree_impl.cpp
@@ -271,7 +271,7 @@ namespace kagome::blockchain {
     const auto &state_root = target_block_header.state_root;
 
     // Check if target block has state
-    if (auto res = trie_storage->getEphemeralBatchAt(state_root);
+    if (auto res = trie_storage->getEphemeralBatchAt(state_root, {});
         res.has_error()) {
       SL_WARN(log, "Can't get state of target block: {}", res.error());
       SL_CRITICAL(

--- a/core/consensus/babe/impl/babe_impl.cpp
+++ b/core/consensus/babe/impl/babe_impl.cpp
@@ -143,7 +143,7 @@ namespace kagome::consensus::babe {
       const auto &state_root = best_block_header.state_root;
 
       // Check if target block has state
-      if (auto res = trie_storage_->getEphemeralBatchAt(state_root);
+      if (auto res = trie_storage_->getEphemeralBatchAt(state_root, {});
           res.has_error()) {
         SL_WARN(log_, "Can't get state of best block: {}", res.error());
         SL_CRITICAL(log_,

--- a/core/network/impl/state_protocol_observer_impl.cpp
+++ b/core/network/impl/state_protocol_observer_impl.cpp
@@ -46,7 +46,7 @@ namespace kagome::network {
   StateProtocolObserverImpl::getEntry(const storage::trie::RootHash &hash,
                                       const common::Buffer &key,
                                       size_t limit) const {
-    OUTCOME_TRY(batch, storage_->getEphemeralBatchAt(hash));
+    OUTCOME_TRY(batch, storage_->getEphemeralBatchAt(hash, {}));
 
     auto cursor = batch->trieCursor();
 
@@ -80,7 +80,7 @@ namespace kagome::network {
   outcome::result<network::StateResponse>
   StateProtocolObserverImpl::onStateRequest(const StateRequest &request) const {
     OUTCOME_TRY(header, blocks_headers_->getBlockHeader(request.hash));
-    OUTCOME_TRY(batch, storage_->getEphemeralBatchAt(header.state_root));
+    OUTCOME_TRY(batch, storage_->getEphemeralBatchAt(header.state_root, {}));
 
     auto cursor = batch->trieCursor();
     // if key is not empty continue iteration from place where left

--- a/core/runtime/common/executor.hpp
+++ b/core/runtime/common/executor.hpp
@@ -61,7 +61,7 @@ namespace kagome::runtime {
     outcome::result<std::unique_ptr<RuntimeEnvironment>> persistentAt(
         primitives::BlockHash const &block_hash) {
       OUTCOME_TRY(env_template, env_factory_->start(block_hash));
-      OUTCOME_TRY(env, env_template->persistent().make());
+      OUTCOME_TRY(env, env_template->persistent().make({}));
       return std::move(env);
     }
 
@@ -76,7 +76,8 @@ namespace kagome::runtime {
                                    storage::trie::RootHash const &storage_state,
                                    std::string_view name,
                                    Args &&...args) {
-      OUTCOME_TRY(env, env_factory_->start(block_info, storage_state)->make());
+      OUTCOME_TRY(env,
+                  env_factory_->start(block_info, storage_state)->make({}));
       return callMediateInternal<Result>(
           *env, name, std::forward<Args>(args)...);
     }
@@ -91,7 +92,7 @@ namespace kagome::runtime {
                                    std::string_view name,
                                    Args &&...args) {
       OUTCOME_TRY(env_template, env_factory_->start(block_hash));
-      OUTCOME_TRY(env, env_template->make());
+      OUTCOME_TRY(env, env_template->make({}));
       return callMediateInternal<Result>(
           *env, name, std::forward<Args>(args)...);
     }
@@ -105,7 +106,7 @@ namespace kagome::runtime {
     outcome::result<Result> callAtGenesis(std::string_view name,
                                           Args &&...args) {
       OUTCOME_TRY(env_template, env_factory_->start());
-      OUTCOME_TRY(env, env_template->make());
+      OUTCOME_TRY(env, env_template->make({}));
       return callMediateInternal<Result>(
           *env, name, std::forward<Args>(args)...);
     }
@@ -113,9 +114,10 @@ namespace kagome::runtime {
     outcome::result<common::Buffer> callAtRaw(
         const primitives::BlockHash &block_hash,
         std::string_view name,
-        const common::Buffer &encoded_args) override {
+        const common::Buffer &encoded_args,
+        OnDbRead on_db_read) override {
       OUTCOME_TRY(env_template, env_factory_->start(block_hash));
-      OUTCOME_TRY(env, env_template->make());
+      OUTCOME_TRY(env, env_template->make(std::move(on_db_read)));
 
       auto &memory = env->memory_provider->getCurrentMemory()->get();
 

--- a/core/runtime/common/runtime_environment_factory.cpp
+++ b/core/runtime/common/runtime_environment_factory.cpp
@@ -62,7 +62,7 @@ namespace kagome::runtime {
         instance->getEnvironment().storage_provider,
         {},
     };
-    env.storage_provider->setToEphemeralAt(storage::trie::kEmptyRootHash)
+    env.storage_provider->setToEphemeralAt(storage::trie::kEmptyRootHash, {})
         .value();
     OUTCOME_TRY(resetMemory(*instance));
     return env;
@@ -142,7 +142,8 @@ namespace kagome::runtime {
   }
 
   outcome::result<std::unique_ptr<RuntimeEnvironment>>
-  RuntimeEnvironmentFactory::RuntimeEnvironmentTemplate::make() {
+  RuntimeEnvironmentFactory::RuntimeEnvironmentTemplate::make(
+      OnDbRead on_db_read) {
     KAGOME_PROFILE_START(runtime_env_making);
     auto parent_factory = parent_factory_.lock();
     if (parent_factory == nullptr) {
@@ -178,7 +179,8 @@ namespace kagome::runtime {
         return Error::FAILED_TO_SET_STORAGE_STATE;
       }
     } else {
-      if (auto res = env.storage_provider->setToEphemeralAt(storage_state_);
+      if (auto res = env.storage_provider->setToEphemeralAt(
+              storage_state_, std::move(on_db_read));
           !res) {
         SL_DEBUG(
             parent_factory->logger_,

--- a/core/runtime/common/storage_code_provider.cpp
+++ b/core/runtime/common/storage_code_provider.cpp
@@ -45,7 +45,7 @@ namespace kagome::runtime {
           return cached_code_;
         }
       }
-      OUTCOME_TRY(batch, storage_->getEphemeralBatchAt(state));
+      OUTCOME_TRY(batch, storage_->getEphemeralBatchAt(state, {}));
       OUTCOME_TRY(code, setCodeFromBatch(*batch.get()));
       cached_code_ = std::move(code);
       last_state_root_ = state;

--- a/core/runtime/common/trie_storage_provider_impl.cpp
+++ b/core/runtime/common/trie_storage_provider_impl.cpp
@@ -36,11 +36,13 @@ namespace kagome::runtime {
   }
 
   outcome::result<void> TrieStorageProviderImpl::setToEphemeralAt(
-      const common::Hash256 &state_root) {
+      const common::Hash256 &state_root, OnDbRead on_db_read) {
     SL_DEBUG(logger_,
              "Setting storage provider to ephemeral batch with root {}",
              state_root);
-    OUTCOME_TRY(batch, trie_storage_->getEphemeralBatchAt(state_root));
+    OUTCOME_TRY(
+        batch,
+        trie_storage_->getEphemeralBatchAt(state_root, std::move(on_db_read)));
     child_batches_.clear();
     persistent_batch_.reset();
     current_batch_ = std::move(batch);

--- a/core/runtime/common/trie_storage_provider_impl.hpp
+++ b/core/runtime/common/trie_storage_provider_impl.hpp
@@ -31,8 +31,8 @@ namespace kagome::runtime {
 
     ~TrieStorageProviderImpl() override = default;
 
-    outcome::result<void> setToEphemeralAt(
-        const common::Hash256 &state_root) override;
+    outcome::result<void> setToEphemeralAt(const common::Hash256 &state_root,
+                                           OnDbRead on_db_read) override;
 
     outcome::result<void> setToPersistentAt(
         const common::Hash256 &state_root) override;

--- a/core/runtime/raw_executor.hpp
+++ b/core/runtime/raw_executor.hpp
@@ -16,6 +16,8 @@ namespace kagome::runtime {
    public:
     using Buffer = common::Buffer;
     using BlockHash = primitives::BlockHash;
+    using OnDbRead = std::function<void(common::BufferView)>;
+
     virtual ~RawExecutor() = default;
 
     /**
@@ -28,7 +30,8 @@ namespace kagome::runtime {
      */
     virtual outcome::result<Buffer> callAtRaw(const BlockHash &block_hash,
                                               std::string_view name,
-                                              const Buffer &encoded_args) = 0;
+                                              const Buffer &encoded_args,
+                                              OnDbRead on_db_read) = 0;
   };
 
 }  // namespace kagome::runtime

--- a/core/runtime/runtime_environment_factory.hpp
+++ b/core/runtime/runtime_environment_factory.hpp
@@ -105,6 +105,8 @@ namespace kagome::runtime {
 
   struct RuntimeEnvironmentFactory::RuntimeEnvironmentTemplate {
    public:
+    using OnDbRead = std::function<void(common::BufferView)>;
+
     RuntimeEnvironmentTemplate(
         std::weak_ptr<const RuntimeEnvironmentFactory> parent_factory_,
         const primitives::BlockInfo &blockchain_state,
@@ -115,7 +117,7 @@ namespace kagome::runtime {
     [[nodiscard]] virtual RuntimeEnvironmentTemplate &persistent();
 
     [[nodiscard]] virtual outcome::result<std::unique_ptr<RuntimeEnvironment>>
-    make();
+    make(OnDbRead on_db_read);
 
    private:
     primitives::BlockInfo blockchain_state_;

--- a/core/runtime/trie_storage_provider.hpp
+++ b/core/runtime/trie_storage_provider.hpp
@@ -28,6 +28,7 @@ namespace kagome::runtime {
     using Batch = storage::trie::TrieBatch;
     using PersistentBatch = storage::trie::PersistentTrieBatch;
     using StateVersion = storage::trie::StateVersion;
+    using OnDbRead = std::function<void(common::BufferView)>;
 
     virtual ~TrieStorageProvider() = default;
 
@@ -35,7 +36,7 @@ namespace kagome::runtime {
      * Sets the current batch to a new ephemeral batch
      */
     virtual outcome::result<void> setToEphemeralAt(
-        const common::Hash256 &state_root) = 0;
+        const common::Hash256 &state_root, OnDbRead on_db_read) = 0;
 
     /**
      * Sets the current batch to a new persistent batch at specified storage

--- a/core/storage/trie/impl/trie_storage_impl.cpp
+++ b/core/storage/trie/impl/trie_storage_impl.cpp
@@ -56,15 +56,17 @@ namespace kagome::storage::trie {
     SL_DEBUG(logger_,
              "Initialize persistent trie batch with root: {}",
              root.toHex());
-    OUTCOME_TRY(trie, serializer_->retrieveTrie(Buffer{root}));
+    OUTCOME_TRY(trie, serializer_->retrieveTrie(Buffer{root}, {}));
     return PersistentTrieBatchImpl::create(
         codec_, serializer_, changes_, std::move(trie));
   }
 
   outcome::result<std::unique_ptr<EphemeralTrieBatch>>
-  TrieStorageImpl::getEphemeralBatchAt(const RootHash &root) const {
+  TrieStorageImpl::getEphemeralBatchAt(const RootHash &root,
+                                       OnDbRead on_db_read) const {
     SL_DEBUG(logger_, "Initialize ephemeral trie batch with root: {}", root);
-    OUTCOME_TRY(trie, serializer_->retrieveTrie(Buffer{root}));
+    OUTCOME_TRY(trie,
+                serializer_->retrieveTrie(Buffer{root}, std::move(on_db_read)));
     return std::make_unique<EphemeralTrieBatchImpl>(codec_, std::move(trie));
   }
 }  // namespace kagome::storage::trie

--- a/core/storage/trie/impl/trie_storage_impl.hpp
+++ b/core/storage/trie/impl/trie_storage_impl.hpp
@@ -40,7 +40,7 @@ namespace kagome::storage::trie {
     outcome::result<std::unique_ptr<PersistentTrieBatch>> getPersistentBatchAt(
         const RootHash &root) override;
     outcome::result<std::unique_ptr<EphemeralTrieBatch>> getEphemeralBatchAt(
-        const RootHash &root) const override;
+        const RootHash &root, OnDbRead on_db_read) const override;
 
    protected:
     TrieStorageImpl(

--- a/core/storage/trie/serialization/trie_serializer.hpp
+++ b/core/storage/trie/serialization/trie_serializer.hpp
@@ -17,6 +17,8 @@ namespace kagome::storage::trie {
    */
   class TrieSerializer {
    public:
+    using OnDbRead = std::function<void(common::BufferView)>;
+
     virtual ~TrieSerializer() = default;
 
     /**
@@ -36,7 +38,7 @@ namespace kagome::storage::trie {
      * is no entry for provided key.
      */
     virtual outcome::result<std::shared_ptr<PolkadotTrie>> retrieveTrie(
-        const common::Buffer &db_key) const = 0;
+        const common::Buffer &db_key, OnDbRead on_db_read) const = 0;
   };
 
 }  // namespace kagome::storage::trie

--- a/core/storage/trie/serialization/trie_serializer_impl.hpp
+++ b/core/storage/trie/serialization/trie_serializer_impl.hpp
@@ -33,7 +33,7 @@ namespace kagome::storage::trie {
                                         StateVersion version) override;
 
     outcome::result<std::shared_ptr<PolkadotTrie>> retrieveTrie(
-        const common::Buffer &db_key) const override;
+        const common::Buffer &db_key, OnDbRead on_db_read) const override;
 
    private:
     /**
@@ -49,13 +49,14 @@ namespace kagome::storage::trie {
      * nodes as its children
      */
     outcome::result<PolkadotTrie::NodePtr> retrieveNode(
-        const common::Buffer &db_key) const;
+        const common::Buffer &db_key, const OnDbRead &on_db_read) const;
     /**
      * Retrieves a node, replacing a dummy node to an actual node if
      * needed
      */
     outcome::result<PolkadotTrie::NodePtr> retrieveNode(
-        const std::shared_ptr<OpaqueTrieNode> &node) const;
+        const std::shared_ptr<OpaqueTrieNode> &node,
+        const OnDbRead &on_db_read) const;
 
     std::shared_ptr<PolkadotTrieFactory> trie_factory_;
     std::shared_ptr<Codec> codec_;

--- a/core/storage/trie/trie_storage.hpp
+++ b/core/storage/trie/trie_storage.hpp
@@ -21,6 +21,8 @@ namespace kagome::storage::trie {
    */
   class TrieStorage {
    public:
+    using OnDbRead = std::function<void(common::BufferView)>;
+
     virtual ~TrieStorage() = default;
 
     /**
@@ -31,7 +33,7 @@ namespace kagome::storage::trie {
     virtual outcome::result<std::unique_ptr<PersistentTrieBatch>>
     getPersistentBatchAt(const RootHash &root) = 0;
     virtual outcome::result<std::unique_ptr<EphemeralTrieBatch>>
-    getEphemeralBatchAt(const RootHash &root) const = 0;
+    getEphemeralBatchAt(const RootHash &root, OnDbRead on_db_read) const = 0;
   };
 
 }  // namespace kagome::storage::trie

--- a/core/utils/kagome_db_editor.cpp
+++ b/core/utils/kagome_db_editor.cpp
@@ -439,7 +439,8 @@ int db_editor_main(int argc, const char **argv) {
       need_additional_compaction = true;
     } else if (DUMP == cmd) {
       auto batch =
-          check(trie->getEphemeralBatchAt(last_finalized_block.hash)).value();
+          check(trie->getEphemeralBatchAt(last_finalized_block.hash, {}))
+              .value();
       auto cursor = batch->trieCursor();
       auto res = check(cursor->next());
       {

--- a/core/utils/storage_explorer.cpp
+++ b/core/utils/storage_explorer.cpp
@@ -264,7 +264,7 @@ class QueryStateCommand : public Command {
     } else {
       throwError("Invalid block hash!");
     }
-    auto batch = trie_storage->getEphemeralBatchAt(state_root);
+    auto batch = trie_storage->getEphemeralBatchAt(state_root, {});
     if (!batch) {
       throwError("Failed getting trie batch: {}", batch.error());
     }

--- a/test/core/api/service/child_state/child_state_api_test.cpp
+++ b/test/core/api/service/child_state/child_state_api_test.cpp
@@ -69,8 +69,8 @@ namespace kagome::api {
     primitives::BlockId did = "D"_hash256;
     EXPECT_CALL(*block_header_repo_, getBlockHeader(did))
         .WillOnce(testing::Return(BlockHeader{.state_root = "CDE"_hash256}));
-    EXPECT_CALL(*storage_, getEphemeralBatchAt("CDE"_hash256))
-        .WillOnce(testing::Invoke([](auto &root) {
+    EXPECT_CALL(*storage_, getEphemeralBatchAt("CDE"_hash256, _))
+        .WillOnce(testing::Invoke([](auto &&, auto &&) {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
           static const auto key = "a"_buf;
           static const common::Buffer value{"1"_hash256};
@@ -78,8 +78,8 @@ namespace kagome::api {
               .WillRepeatedly(testing::Return(value));
           return batch;
         }));
-    EXPECT_CALL(*storage_, getEphemeralBatchAt("1"_hash256))
-        .WillOnce(testing::Invoke([](auto &root) {
+    EXPECT_CALL(*storage_, getEphemeralBatchAt("1"_hash256, _))
+        .WillOnce(testing::Invoke([](auto &&, auto &&) {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
           static const auto key = "b"_buf;
           static const common::Buffer value = "2"_buf;
@@ -97,8 +97,8 @@ namespace kagome::api {
     primitives::BlockId bid = "B"_hash256;
     EXPECT_CALL(*block_header_repo_, getBlockHeader(bid))
         .WillOnce(testing::Return(BlockHeader{.state_root = "ABC"_hash256}));
-    EXPECT_CALL(*storage_, getEphemeralBatchAt("ABC"_hash256))
-        .WillOnce(testing::Invoke([](auto &root) {
+    EXPECT_CALL(*storage_, getEphemeralBatchAt("ABC"_hash256, _))
+        .WillOnce(testing::Invoke([](auto &&, auto &&) {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
           static const auto key = "c"_buf;
           static const common::Buffer value{"3"_hash256};
@@ -106,8 +106,8 @@ namespace kagome::api {
               .WillRepeatedly(testing::Return(value));
           return batch;
         }));
-    EXPECT_CALL(*storage_, getEphemeralBatchAt("3"_hash256))
-        .WillOnce(testing::Invoke([](auto &root) {
+    EXPECT_CALL(*storage_, getEphemeralBatchAt("3"_hash256, _))
+        .WillOnce(testing::Invoke([](auto &&, auto &&) {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
           static const auto key = "d"_buf;
           static const auto value = "4"_buf;
@@ -142,15 +142,15 @@ namespace kagome::api {
     EXPECT_CALL(*block_header_repo_,
                 getBlockHeader(primitives::BlockId(block_hash)))
         .WillOnce(Return(BlockHeader{.state_root = "6789"_hash256}));
-    EXPECT_CALL(*storage_, getEphemeralBatchAt("6789"_hash256))
-        .WillOnce(testing::Invoke([&](auto &root) {
+    EXPECT_CALL(*storage_, getEphemeralBatchAt("6789"_hash256, _))
+        .WillOnce(testing::Invoke([&](auto &&, auto &&) {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
           EXPECT_CALL(*batch, getMock(child_storage_key.view()))
               .WillOnce(testing::Return(common::Buffer("2020"_hash256)));
           return batch;
         }));
-    EXPECT_CALL(*storage_, getEphemeralBatchAt("2020"_hash256))
-        .WillOnce(testing::Invoke([&](auto &root) {
+    EXPECT_CALL(*storage_, getEphemeralBatchAt("2020"_hash256, _))
+        .WillOnce(testing::Invoke([&](auto &&, auto &&) {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
           EXPECT_CALL(*batch, trieCursor())
               .WillOnce(testing::Invoke([&prefix]() {
@@ -198,15 +198,15 @@ namespace kagome::api {
     EXPECT_CALL(*block_header_repo_,
                 getBlockHeader(primitives::BlockId(block_hash)))
         .WillOnce(Return(BlockHeader{.state_root = "6789"_hash256}));
-    EXPECT_CALL(*storage_, getEphemeralBatchAt("6789"_hash256))
-        .WillOnce(testing::Invoke([&](auto &root) {
+    EXPECT_CALL(*storage_, getEphemeralBatchAt("6789"_hash256, _))
+        .WillOnce(testing::Invoke([&](auto &&, auto &&) {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
           EXPECT_CALL(*batch, getMock(child_storage_key.view()))
               .WillOnce(testing::Return(common::Buffer("2020"_hash256)));
           return batch;
         }));
-    EXPECT_CALL(*storage_, getEphemeralBatchAt("2020"_hash256))
-        .WillOnce(testing::Invoke([&](auto &root) {
+    EXPECT_CALL(*storage_, getEphemeralBatchAt("2020"_hash256, _))
+        .WillOnce(testing::Invoke([&](auto &&, auto &&) {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
           EXPECT_CALL(*batch, trieCursor())
               .WillOnce(testing::Invoke([&prev_key]() {
@@ -251,16 +251,16 @@ namespace kagome::api {
                 getBlockHeader(primitives::BlockId{block_hash}))
         .WillOnce(Return(BlockHeader{.state_root = "6789"_hash256}));
     auto batch = std::make_unique<EphemeralTrieBatchMock>();
-    EXPECT_CALL(*storage_, getEphemeralBatchAt("6789"_hash256))
-        .WillOnce(testing::Invoke([&](auto &root) {
+    EXPECT_CALL(*storage_, getEphemeralBatchAt("6789"_hash256, _))
+        .WillOnce(testing::Invoke([&](auto &&, auto &&) {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
           static auto v = common::Buffer("2020"_hash256);
           EXPECT_CALL(*batch, getMock(child_storage_key.view()))
               .WillOnce(testing::Return(v));
           return batch;
         }));
-    EXPECT_CALL(*storage_, getEphemeralBatchAt("2020"_hash256))
-        .WillOnce(testing::Invoke([&](auto &root) {
+    EXPECT_CALL(*storage_, getEphemeralBatchAt("2020"_hash256, _))
+        .WillOnce(testing::Invoke([&](auto &&, auto &&) {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
           EXPECT_CALL(*batch, getMock(key.view()))
               .WillOnce(testing::Return(expected_result));

--- a/test/core/api/service/state/state_api_test.cpp
+++ b/test/core/api/service/state/state_api_test.cpp
@@ -82,8 +82,8 @@ namespace kagome::api {
         .WillOnce(testing::Return(BlockHeader{.state_root = "CDE"_hash256}));
     auto in_buf = "a"_buf;
     auto out_buf = "1"_buf;
-    EXPECT_CALL(*storage_, getEphemeralBatchAt(_))
-        .WillRepeatedly(testing::Invoke([&in_buf, &out_buf](auto &root) {
+    EXPECT_CALL(*storage_, getEphemeralBatchAt(_, _))
+        .WillRepeatedly(testing::Invoke([&in_buf, &out_buf](auto &&, auto &&) {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
           EXPECT_CALL(*batch, tryGetMock(in_buf.view()))
               .WillRepeatedly(testing::Return(std::cref(out_buf)));
@@ -126,8 +126,8 @@ namespace kagome::api {
       EXPECT_CALL(*block_header_repo_, getBlockHeader(did))
           .WillOnce(testing::Return(BlockHeader{.state_root = "CDE"_hash256}));
 
-      EXPECT_CALL(*storage, getEphemeralBatchAt(_))
-          .WillRepeatedly(testing::Invoke([this](auto &root) {
+      EXPECT_CALL(*storage, getEphemeralBatchAt(_, _))
+          .WillRepeatedly(testing::Invoke([this](auto &&, auto &&) {
             auto batch = std::make_unique<EphemeralTrieBatchMock>();
             EXPECT_CALL(*batch, trieCursor())
                 .WillRepeatedly(testing::Invoke([this]() {
@@ -379,8 +379,8 @@ namespace kagome::api {
                   getBlockHeader(primitives::BlockId{block_hash}))
           .WillOnce(testing::Return(
               primitives::BlockHeader{.state_root = state_root}));
-      EXPECT_CALL(*storage_, getEphemeralBatchAt(state_root))
-          .WillOnce(testing::Invoke([&keys](auto &root) {
+      EXPECT_CALL(*storage_, getEphemeralBatchAt(state_root, _))
+          .WillOnce(testing::Invoke([&keys](auto &root, auto &&) {
             auto batch =
                 std::make_unique<storage::trie::EphemeralTrieBatchMock>();
             for (auto &key : keys) {
@@ -451,8 +451,8 @@ namespace kagome::api {
     EXPECT_CALL(*block_header_repo_, getBlockHeader(primitives::BlockId{at}))
         .WillOnce(
             testing::Return(primitives::BlockHeader{.state_root = state_root}));
-    EXPECT_CALL(*storage_, getEphemeralBatchAt(state_root))
-        .WillOnce(testing::Invoke([&keys](auto &root) {
+    EXPECT_CALL(*storage_, getEphemeralBatchAt(state_root, _))
+        .WillOnce(testing::Invoke([&keys](auto &root, auto &&) {
           auto batch =
               std::make_unique<storage::trie::EphemeralTrieBatchMock>();
           for (auto &key : keys) {

--- a/test/core/consensus/authority/authority_manager_test.cpp
+++ b/test/core/consensus/authority/authority_manager_test.cpp
@@ -66,7 +66,7 @@ class AuthorityManagerTest : public testing::Test {
     persistent_storage = std::make_shared<storage::InMemoryStorage>();
 
     trie_storage = std::make_shared<storage::trie::TrieStorageMock>();
-    EXPECT_CALL(*trie_storage, getEphemeralBatchAt(_))
+    EXPECT_CALL(*trie_storage, getEphemeralBatchAt(_, _))
         .WillRepeatedly(testing::Invoke([] {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
           EXPECT_CALL(*batch, tryGetMock(_))

--- a/test/core/runtime/executor_test.cpp
+++ b/test/core/runtime/executor_test.cpp
@@ -105,7 +105,7 @@ class ExecutorTest : public testing::Test {
                       weak_env_factory, blockchain_state, storage_state);
               EXPECT_CALL(*env_template, persistent())
                   .WillOnce(ReturnRef(*env_template));
-              EXPECT_CALL(*env_template, make())
+              EXPECT_CALL(*env_template, make(_))
                   .WillOnce(Invoke([this, RESULT_LOCATION, blockchain_state] {
                     auto module_instance =
                         std::make_shared<ModuleInstanceMock>();
@@ -159,7 +159,7 @@ class ExecutorTest : public testing::Test {
               auto env_template =
                   std::make_unique<RuntimeEnvironmentTemplateMock>(
                       weak_env_factory, blockchain_state, storage_state);
-              EXPECT_CALL(*env_template, make())
+              EXPECT_CALL(*env_template, make(_))
                   .WillOnce(Invoke([this, blockchain_state, RESULT_LOCATION] {
                     auto module_instance =
                         std::make_shared<ModuleInstanceMock>();

--- a/test/core/runtime/runtime_test_base.hpp
+++ b/test/core/runtime/runtime_test_base.hpp
@@ -180,8 +180,8 @@ class RuntimeTestBase : public ::testing::Test {
   }
 
   void prepareEphemeralStorageExpects() {
-    EXPECT_CALL(*trie_storage_, getEphemeralBatchAt(_))
-        .WillOnce(testing::Invoke([this](auto &root) {
+    EXPECT_CALL(*trie_storage_, getEphemeralBatchAt(_, _))
+        .WillOnce(testing::Invoke([this]() {
           auto batch = std::make_unique<EphemeralTrieBatchMock>();
           prepareStorageBatchExpectations(*batch);
           return batch;

--- a/test/core/runtime/storage_code_provider_test.cpp
+++ b/test/core/runtime/storage_code_provider_test.cpp
@@ -50,7 +50,7 @@ TEST_F(StorageCodeProviderTest, GetCodeWhenNoStorageUpdates) {
   primitives::BlockInfo block_info(11, primitives::BlockHash{{11, 11, 11, 11}});
 
   // given
-  EXPECT_CALL(*trie_db, getEphemeralBatchAt(first_state_root))
+  EXPECT_CALL(*trie_db, getEphemeralBatchAt(first_state_root, _))
       .WillOnce(Invoke([this]() {
         auto batch = std::make_unique<storage::trie::EphemeralTrieBatchMock>();
         EXPECT_CALL(*batch,
@@ -92,7 +92,7 @@ TEST_F(StorageCodeProviderTest, DISABLED_GetCodeWhenStorageUpdates) {
   storage::trie::RootHash second_state_root{{2, 2, 2, 2}};
 
   // given
-  EXPECT_CALL(*trie_db, getEphemeralBatchAt(first_state_root))
+  EXPECT_CALL(*trie_db, getEphemeralBatchAt(first_state_root, _))
       .WillOnce(Invoke([this]() {
         auto batch = std::make_unique<storage::trie::EphemeralTrieBatchMock>();
         EXPECT_CALL(*batch,
@@ -107,8 +107,8 @@ TEST_F(StorageCodeProviderTest, DISABLED_GetCodeWhenStorageUpdates) {
       std::make_shared<application::ChainSpecMock>());
 
   common::Buffer new_state_code{{1, 3, 3, 8}};
-  EXPECT_CALL(*trie_db, getEphemeralBatchAt(second_state_root))
-      .WillOnce(Invoke([&new_state_code](auto &) {
+  EXPECT_CALL(*trie_db, getEphemeralBatchAt(second_state_root, _))
+      .WillOnce(Invoke([&new_state_code]() {
         auto batch = std::make_unique<storage::trie::EphemeralTrieBatchMock>();
         EXPECT_CALL(*batch,
                     getMock(common::BufferView{storage::kRuntimeCodeKey}))

--- a/test/core/storage/trie/trie_storage/trie_batch_test.cpp
+++ b/test/core/storage/trie/trie_storage/trie_batch_test.cpp
@@ -113,14 +113,14 @@ TEST_F(TrieBatchTest, Put) {
   auto batch = trie->getPersistentBatchAt(empty_hash).value();
   FillSmallTrieWithBatch(*batch);
   // changes are not yet commited
-  auto new_batch = trie->getEphemeralBatchAt(empty_hash).value();
+  auto new_batch = trie->getEphemeralBatchAt(empty_hash, {}).value();
   for (auto &entry : data) {
     ASSERT_OUTCOME_ERROR(new_batch->get(entry.first),
                          kagome::storage::trie::TrieError::NO_VALUE);
   }
   ASSERT_OUTCOME_SUCCESS(root_hash, batch->commit(StateVersion::V0));
   // changes are commited
-  new_batch = trie->getEphemeralBatchAt(root_hash).value();
+  new_batch = trie->getEphemeralBatchAt(root_hash, {}).value();
   for (auto &entry : data) {
     ASSERT_OUTCOME_SUCCESS(res, new_batch->get(entry.first));
     ASSERT_EQ(res, entry.second);
@@ -151,7 +151,7 @@ TEST_F(TrieBatchTest, Remove) {
 
   ASSERT_OUTCOME_SUCCESS(root_hash, batch->commit(StateVersion::V0));
 
-  auto read_batch = trie->getEphemeralBatchAt(root_hash).value();
+  auto read_batch = trie->getEphemeralBatchAt(root_hash, {}).value();
   for (auto i : {2, 3, 4}) {
     ASSERT_OUTCOME_IS_FALSE(read_batch->contains(data[i].first));
   }
@@ -170,7 +170,7 @@ TEST_F(TrieBatchTest, Replace) {
   ASSERT_OUTCOME_SUCCESS_TRY(
       batch->put(data[1].first, BufferView{data[3].second}));
   ASSERT_OUTCOME_SUCCESS(root_hash, batch->commit(StateVersion::V0));
-  auto read_batch = trie->getEphemeralBatchAt(root_hash).value();
+  auto read_batch = trie->getEphemeralBatchAt(root_hash, {}).value();
   ASSERT_OUTCOME_SUCCESS(res, read_batch->get(data[1].first));
   ASSERT_EQ(res, data[3].second);
 }

--- a/test/mock/core/runtime/raw_executor_mock.hpp
+++ b/test/mock/core/runtime/raw_executor_mock.hpp
@@ -18,7 +18,8 @@ namespace kagome::runtime {
                 callAtRaw,
                 (const primitives::BlockHash &,
                  std::string_view,
-                 const common::Buffer &),
+                 const common::Buffer &,
+                 OnDbRead),
                 (override));
   };
 

--- a/test/mock/core/runtime/runtime_environment_factory_mock.hpp
+++ b/test/mock/core/runtime/runtime_environment_factory_mock.hpp
@@ -35,7 +35,7 @@ namespace kagome::runtime {
 
     MOCK_METHOD(outcome::result<std::unique_ptr<RuntimeEnvironment>>,
                 make,
-                (),
+                (OnDbRead),
                 (override));
   };
 

--- a/test/mock/core/runtime/trie_storage_provider_mock.hpp
+++ b/test/mock/core/runtime/trie_storage_provider_mock.hpp
@@ -16,7 +16,7 @@ namespace kagome::runtime {
    public:
     MOCK_METHOD(outcome::result<void>,
                 setToEphemeralAt,
-                (const storage::trie::RootHash &),
+                (const storage::trie::RootHash &, OnDbRead),
                 (override));
 
     MOCK_METHOD(outcome::result<void>,

--- a/test/mock/core/storage/trie/serialization/trie_serializer_mock.hpp
+++ b/test/mock/core/storage/trie/serialization/trie_serializer_mock.hpp
@@ -23,7 +23,7 @@ namespace kagome::storage::trie {
 
     MOCK_METHOD(outcome::result<std::shared_ptr<PolkadotTrie>>,
                 retrieveTrie,
-                (const common::Buffer &),
+                (const common::Buffer &, OnDbRead),
                 (const, override));
   };
 

--- a/test/mock/core/storage/trie/trie_storage_mock.hpp
+++ b/test/mock/core/storage/trie/trie_storage_mock.hpp
@@ -21,7 +21,7 @@ namespace kagome::storage::trie {
 
     MOCK_METHOD(outcome::result<std::unique_ptr<EphemeralTrieBatch>>,
                 getEphemeralBatchAt,
-                (const storage::trie::RootHash &root),
+                (const storage::trie::RootHash &, OnDbRead),
                 (const, override));
   };
 


### PR DESCRIPTION
### Referenced issues
- #1395

### Description of the Change
- Add callback argument to trie class tree.

### Benefits
- Light client protocol will be able to record "proof" (encoded trie nodes) when reading keys and executing wasm.

### Possible Drawbacks