### PR TITLE
fix/neighbor-messages-to-ourselves

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,3 +8,4 @@ BinPackArguments: false
 BinPackParameters: false
 AllowShortFunctionsOnASingleLine: Empty
 IncludeBlocks: Preserve
+InsertBraces: true

--- a/core/network/impl/protocols/grandpa_protocol.cpp
+++ b/core/network/impl/protocols/grandpa_protocol.cpp
@@ -329,12 +329,13 @@ namespace kagome::network {
             self->grandpa_observer_->onCommitMessage(peer_id, commit_message);
           },
           [&](const GrandpaNeighborMessage &neighbor_message) {
-            if (peer_id != self->own_info_.id)
+            if (peer_id != self->own_info_.id) {
               SL_VERBOSE(self->base_.logger(),
                          "NeighborMessage has received from {}",
                          peer_id);
-            self->grandpa_observer_->onNeighborMessage(peer_id,
-                                                       neighbor_message);
+              self->grandpa_observer_->onNeighborMessage(peer_id,
+                                                         neighbor_message);
+            }
           },
           [&](const network::CatchUpRequest &catch_up_request) {
             SL_VERBOSE(self->base_.logger(),


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

-

### Description of the Change

Disable sending neighbor messages to ourselves. Force using {} with ifs

### Benefits

Less messages in the network

### Possible Drawbacks 

None


