### PR TITLE
external project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ option(EMBEDDINGS   "Embed developers assets"                     ON )
 option(PROFILING    "Enable internal profiling instruments"       OFF)
 option(BACKWARD     "Enable stacktrace logging instruments"       ON )
 option(CLEAR_OBJS   "Clear object files"                          OFF)
+option(EXTERNAL_PROJECT "Build external project"                  OFF)
 
 # sanitizers will be enabled only for Kagome, and will be disabled for dependencies
 option(ASAN         "Enable address sanitizer"                    OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,11 @@ option(EMBEDDINGS   "Embed developers assets"                     ON )
 option(PROFILING    "Enable internal profiling instruments"       OFF)
 option(BACKWARD     "Enable stacktrace logging instruments"       ON )
 option(CLEAR_OBJS   "Clear object files"                          OFF)
-option(EXTERNAL_PROJECT "Build external project"                  OFF)
+
+if(NOT($ENV{CI}) OR NOT($ENV{GITHUB_ACTIONS}))
+  set(_EXTERNAL_PROJECT_DEFAULT ON)
+endif()
+option(EXTERNAL_PROJECT "Build external project" ${_EXTERNAL_PROJECT_DEFAULT})
 
 # sanitizers will be enabled only for Kagome, and will be disabled for dependencies
 option(ASAN         "Enable address sanitizer"                    OFF)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,3 +11,13 @@ include_directories(
 add_subdirectory(core)
 add_subdirectory(deps)
 add_subdirectory(testutil)
+
+if(EXTERNAL_PROJECT)
+  add_executable(external_project external-project-test/src/main.cpp)
+  set(external_project_include ${CMAKE_CURRENT_BINARY_DIR}/external_project_include)
+  file(MAKE_DIRECTORY ${external_project_include})
+  file(CREATE_LINK ${PROJECT_SOURCE_DIR}/core ${external_project_include}/kagome SYMBOLIC)
+  target_include_directories(external_project PRIVATE ${external_project_include})
+  include(external-project-test/link_libraries.cmake)
+  external_project_link_libraries(external_project "")
+endif()

--- a/test/external-project-test/CMakeLists.txt
+++ b/test/external-project-test/CMakeLists.txt
@@ -32,27 +32,5 @@ hunter_add_package(kagome)
 find_package(kagome CONFIG REQUIRED)
 
 add_executable(main src/main.cpp)
-target_link_libraries(main
-    kagome::executor
-    kagome::runtime_wavm
-    kagome::core_api
-    kagome::storage
-    kagome::trie_storage_provider
-    kagome::log_configurator
-    kagome::host_api_factory
-    kagome::chain_spec
-    kagome::crypto_store
-    kagome::key_file_storage
-    kagome::sr25519_provider
-    kagome::ed25519_provider
-    kagome::pbkdf2_provider
-    kagome::hasher
-    kagome::storage
-    kagome::module_repository
-    kagome::storage_code_provider
-    kagome::offchain_persistent_storage
-    kagome::offchain_worker_pool
-    kagome::blockchain
-    kagome::runtime_upgrade_tracker
-    kagome::runtime_properties_cache
-    )
+include(link_libraries.cmake)
+external_project_link_libraries(main kagome::)

--- a/test/external-project-test/link_libraries.cmake
+++ b/test/external-project-test/link_libraries.cmake
@@ -1,0 +1,30 @@
+
+function(external_project_link_libraries target prefix)
+    set(targets
+        executor
+        runtime_wavm
+        core_api
+        storage
+        trie_storage_provider
+        log_configurator
+        host_api_factory
+        chain_spec
+        crypto_store
+        key_file_storage
+        sr25519_provider
+        ed25519_provider
+        pbkdf2_provider
+        hasher
+        storage
+        module_repository
+        storage_code_provider
+        offchain_persistent_storage
+        offchain_worker_pool
+        blockchain
+        runtime_upgrade_tracker
+        runtime_properties_cache
+        )
+    list(TRANSFORM targets PREPEND "${prefix}")
+    target_link_libraries(${target} ${targets})
+endfunction()
+


### PR DESCRIPTION
### Referenced issues
### Description of the Change
- `EXTERNAL_PROJECT` option to build external project test locally.

### Benefits
- Detect and fix external project test compilation errors earlier .

### Possible Drawbacks 
