### PR TITLE
Feature: fast sync without downloading state

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,4 +8,4 @@ BinPackArguments: false
 BinPackParameters: false
 AllowShortFunctionsOnASingleLine: Empty
 IncludeBlocks: Preserve
-InsertBraces: true
+#InsertBraces: true

--- a/core/application/app_configuration.hpp
+++ b/core/application/app_configuration.hpp
@@ -204,7 +204,7 @@ namespace kagome::application {
     virtual const std::vector<telemetry::TelemetryEndpoint>
         &telemetryEndpoints() const = 0;
 
-    enum class SyncMethod { Full, Fast };
+    enum class SyncMethod { Full, Fast, FastWithoutState };
     /**
      * @return enum constant of the chosen sync method
      */

--- a/core/application/impl/app_configuration_impl.cpp
+++ b/core/application/impl/app_configuration_impl.cpp
@@ -115,6 +115,9 @@ namespace {
     if (str == "Fast") {
       return SM::Fast;
     }
+    if (str == "FastWithoutState") {
+      return SM::FastWithoutState;
+    }
     return std::nullopt;
   }
 

--- a/core/consensus/babe/impl/babe_impl.cpp
+++ b/core/consensus/babe/impl/babe_impl.cpp
@@ -63,6 +63,7 @@ namespace kagome::consensus::babe {
       std::shared_ptr<ConsistencyKeeper> consistency_keeper,
       std::shared_ptr<storage::trie::TrieStorage> trie_storage)
       : app_config_(app_config),
+        app_state_manager_(app_state_manager),
         lottery_{std::move(lottery)},
         babe_config_repo_{std::move(babe_config_repo)},
         proposer_{std::move(proposer)},
@@ -88,6 +89,7 @@ namespace kagome::consensus::babe {
         trie_storage_(std::move(trie_storage)),
         log_{log::createLogger("Babe", "babe")},
         telemetry_{telemetry::createTelemetryService()} {
+    BOOST_ASSERT(app_state_manager_);
     BOOST_ASSERT(lottery_);
     BOOST_ASSERT(babe_config_repo_);
     BOOST_ASSERT(proposer_);
@@ -115,7 +117,7 @@ namespace kagome::consensus::babe {
         kBlockProposalTime,
         {0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10});
 
-    app_state_manager->takeControl(*this);
+    app_state_manager_->takeControl(*this);
   }
 
   bool BabeImpl::prepare() {
@@ -128,7 +130,7 @@ namespace kagome::consensus::babe {
     best_block_ = block_tree_->bestLeaf();
 
     // Check if best block has state for usual sync method
-    if (app_config_.syncMethod() != SyncMethod::Fast) {
+    if (app_config_.syncMethod() == SyncMethod::Full) {
       auto best_block_header_res =
           block_tree_->getBlockHeader(best_block_.hash);
       if (best_block_header_res.has_error()) {
@@ -235,6 +237,10 @@ namespace kagome::consensus::babe {
           // No incomplete downloading state; load headers first
           current_state_ = State::HEADERS_LOADING;
         }
+        break;
+
+      case SyncMethod::FastWithoutState:
+        current_state_ = State::HEADERS_LOADING;
         break;
     }
 
@@ -560,6 +566,13 @@ namespace kagome::consensus::babe {
         affected = true;
       }
     } while (affected);
+
+    if (app_config_.syncMethod() == SyncMethod::FastWithoutState) {
+      SL_INFO(log_, "Stateless fast sync is finished; Application is stopping");
+      log_->flush();
+      app_state_manager_->shutdown();
+      return;
+    }
 
     SL_TRACE(log_,
              "Trying to sync state on block {} from {}",

--- a/core/consensus/babe/impl/babe_impl.hpp
+++ b/core/consensus/babe/impl/babe_impl.hpp
@@ -177,6 +177,7 @@ namespace kagome::consensus::babe {
         const primitives::Block &block) const;
 
     const application::AppConfiguration &app_config_;
+    std::shared_ptr<application::AppStateManager> app_state_manager_;
     std::shared_ptr<BabeLottery> lottery_;
     std::shared_ptr<BabeConfigRepository> babe_config_repo_;
     std::shared_ptr<authorship::Proposer> proposer_;

--- a/core/network/impl/synchronizer_impl.cpp
+++ b/core/network/impl/synchronizer_impl.cpp
@@ -58,6 +58,7 @@ namespace {
       case SM::Full:
         return kagome::network::BlocksRequest::kBasicAttributes;
       case SM::Fast:
+      case SM::FastWithoutState:
         return kagome::network::BlockAttribute::HEADER
                | kagome::network::BlockAttribute::JUSTIFICATION;
     }


### PR DESCRIPTION
Signed-off-by: Dmitriy Khaustov aka xDimon <khaustov.dm@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues
No issues

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change 
PR presented new hidden --sync option FastWithoutState.
After header will be loaded, applications stops. After that user can dump database without extra data (state on last block).

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Ability to make stateless database
