### PR TITLE
fix tx valid_till

### DIFF
--- a/core/runtime/runtime_api/impl/tagged_transaction_queue.cpp
+++ b/core/runtime/runtime_api/impl/tagged_transaction_queue.cpp
@@ -22,18 +22,20 @@ namespace kagome::runtime {
     block_tree_ = std::move(block_tree);
   }
 
-  outcome::result<primitives::TransactionValidity>
+  outcome::result<TaggedTransactionQueue::TransactionValidityAt>
   TaggedTransactionQueueImpl::validate_transaction(
       primitives::TransactionSource source, const primitives::Extrinsic &ext) {
     BOOST_ASSERT(block_tree_);
     auto block = block_tree_->bestLeaf();
     SL_TRACE(logger_, "Validate transaction called at block {}", block);
-    return executor_->callAt<primitives::TransactionValidity>(
-        block.hash,
-        "TaggedTransactionQueue_validate_transaction",
-        source,
-        ext,
-        block.hash);
+    OUTCOME_TRY(result,
+                executor_->callAt<primitives::TransactionValidity>(
+                    block.hash,
+                    "TaggedTransactionQueue_validate_transaction",
+                    source,
+                    ext,
+                    block.hash));
+    return TransactionValidityAt{block, std::move(result)};
   }
 
 }  // namespace kagome::runtime

--- a/core/runtime/runtime_api/impl/tagged_transaction_queue.hpp
+++ b/core/runtime/runtime_api/impl/tagged_transaction_queue.hpp
@@ -24,7 +24,7 @@ namespace kagome::runtime {
 
     void setBlockTree(std::shared_ptr<blockchain::BlockTree> block_tree);
 
-    outcome::result<primitives::TransactionValidity> validate_transaction(
+    outcome::result<TransactionValidityAt> validate_transaction(
         primitives::TransactionSource source,
         const primitives::Extrinsic &ext) override;
 

--- a/core/runtime/runtime_api/tagged_transaction_queue.hpp
+++ b/core/runtime/runtime_api/tagged_transaction_queue.hpp
@@ -19,15 +19,18 @@ namespace kagome::runtime {
    public:
     virtual ~TaggedTransactionQueue() = default;
 
+    using TransactionValidityAt =
+        std::pair<primitives::BlockInfo, primitives::TransactionValidity>;
+
     /**
      * Calls the TaggedTransactionQueue_validate_transaction function from wasm
      * code
      * @param ext extrinsic containing transaction to be validated
      * @return structure with information about transaction validity
      */
-    virtual outcome::result<primitives::TransactionValidity>
-    validate_transaction(primitives::TransactionSource source,
-                         const primitives::Extrinsic &ext) = 0;
+    virtual outcome::result<TransactionValidityAt> validate_transaction(
+        primitives::TransactionSource source,
+        const primitives::Extrinsic &ext) = 0;
   };
 
 }  // namespace kagome::runtime

--- a/core/transaction_pool/impl/transaction_pool_impl.cpp
+++ b/core/transaction_pool/impl/transaction_pool_impl.cpp
@@ -67,7 +67,7 @@ namespace kagome::transaction_pool {
     OUTCOME_TRY(res, ttq_->validate_transaction(source, extrinsic));
 
     return visit_in_place(
-        res,
+        res.second,
         [&](const primitives::TransactionValidityError &e) {
           return visit_in_place(
               e,
@@ -86,7 +86,7 @@ namespace kagome::transaction_pool {
                                          length,
                                          hash,
                                          v.priority,
-                                         v.longevity,
+                                         res.first.number + v.longevity,
                                          v.requires,
                                          v.provides,
                                          v.propagate};

--- a/core/transaction_pool/impl/transaction_pool_impl.cpp
+++ b/core/transaction_pool/impl/transaction_pool_impl.cpp
@@ -67,7 +67,7 @@ namespace kagome::transaction_pool {
     OUTCOME_TRY(res, ttq_->validate_transaction(source, extrinsic));
 
     return visit_in_place(
-        res.second,
+        std::move(res.second),
         [&](const primitives::TransactionValidityError &e) {
           return visit_in_place(
               e,
@@ -77,7 +77,7 @@ namespace kagome::transaction_pool {
                 return validity_error;
               });
         },
-        [&](const primitives::ValidTransaction &v)
+        [&](primitives::ValidTransaction &&v)
             -> outcome::result<primitives::Transaction> {
           common::Hash256 hash = hasher_->blake2b_256(extrinsic.data);
           size_t length = extrinsic.data.size();
@@ -87,8 +87,8 @@ namespace kagome::transaction_pool {
                                          hash,
                                          v.priority,
                                          res.first.number + v.longevity,
-                                         v.requires,
-                                         v.provides,
+                                         std::move(v.requires),
+                                         std::move(v.provides),
                                          v.propagate};
         });
   }

--- a/test/mock/core/runtime/tagged_transaction_queue_mock.hpp
+++ b/test/mock/core/runtime/tagged_transaction_queue_mock.hpp
@@ -12,7 +12,7 @@
 
 namespace kagome::runtime {
   struct TaggedTransactionQueueMock : public TaggedTransactionQueue {
-    MOCK_METHOD(outcome::result<primitives::TransactionValidity>,
+    MOCK_METHOD(outcome::result<TransactionValidityAt>,
                 validate_transaction,
                 (primitives::TransactionSource, const primitives::Extrinsic &),
                 (override));


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- runtime returned `longevity` is difference, not `valid_till` absolute block

### Benefits
- fix tx pool

### Possible Drawbacks