### PR TITLE
Fix forced change

### DIFF
--- a/core/consensus/babe/impl/block_header_appender_impl.cpp
+++ b/core/consensus/babe/impl/block_header_appender_impl.cpp
@@ -87,8 +87,7 @@ namespace kagome::consensus::babe {
         consistency_guard,
         appender_->observeDigestsAndValidateHeader(block, block_context));
 
-    OUTCOME_TRY(appender_->applyJustifications(block_info,
-                                               justification));
+    OUTCOME_TRY(appender_->applyJustifications(block_info, justification));
 
     auto now = std::chrono::high_resolution_clock::now();
 
@@ -102,14 +101,17 @@ namespace kagome::consensus::babe {
     auto block_delta = block_info.number - speed_data_.block_number;
     auto time_delta = now - speed_data_.time;
     if (block_delta >= 10000 or time_delta >= std::chrono::minutes(1)) {
-      SL_LOG(logger_,
-             speed_data_.block_number ? log::Level::INFO
-                                      : static_cast<log::Level>(-1),
-             "Imported {} more headers of blocks. Average speed is {} bps",
-             block_delta,
-             block_delta
-                 / std::chrono::duration_cast<std::chrono::seconds>(time_delta)
-                       .count());
+      SL_LOG(
+          logger_,
+          speed_data_.block_number ? log::Level::INFO
+                                   : static_cast<log::Level>(-1),
+          "Imported {} more headers of blocks {}-{}. Average speed is {} bps",
+          block_delta,
+          speed_data_.block_number,
+          block_info.number,
+          block_delta
+              / std::chrono::duration_cast<std::chrono::seconds>(time_delta)
+                    .count());
       speed_data_.block_number = block_info.number;
       speed_data_.time = now;
     }

--- a/core/consensus/grandpa/impl/authority_manager_impl.cpp
+++ b/core/consensus/grandpa/impl/authority_manager_impl.cpp
@@ -636,39 +636,33 @@ namespace kagome::consensus::grandpa {
       const primitives::AuthorityList &authorities,
       primitives::BlockNumber delay_start,
       size_t delay) {
+    auto forced_number = delay_start + delay;
     SL_DEBUG(logger_,
              "Applying forced change (delay start: {}, delay: {}) on block {} "
              "to activate at block {}",
              delay_start,
              delay,
              context.block_info,
-             delay_start + delay);
-    if (delay_start < root_->block.number) {
-      auto lag = root_->block.number - delay_start;
-      if (delay > lag) {
-        delay_start = root_->block.number;
-        delay -= lag;
-      } else {
-        delay_start = context.block_info.number;
-        delay = 0;
-      }
+             forced_number);
+    if (forced_number < root_->block.number) {
       SL_DEBUG(
           logger_,
           "Applying forced change on block {} is delayed {} blocks. "
           "Normalized to (delay start: {}, delay: {}) to activate at block {}",
           context.block_info,
-          lag,
+          root_->block.number - forced_number,
           delay_start,
           delay,
-          delay_start + delay);
+          root_->block.number);
+      forced_number = root_->block.number;
     }
-    auto delay_start_hash_res = header_repo_->getHashByNumber(delay_start);
+    auto delay_start_hash_res = header_repo_->getHashByNumber(forced_number);
     if (delay_start_hash_res.has_error()) {
-      SL_ERROR(logger_, "Failed to obtain hash by number {}", delay_start);
+      SL_ERROR(logger_, "Failed to obtain hash by number {}", forced_number);
     }
     OUTCOME_TRY(delay_start_hash, delay_start_hash_res);
     auto ancestor_node =
-        getNode({.block_info = {delay_start, delay_start_hash}});
+        getNode({.block_info = {forced_number, delay_start_hash}});
 
     if (not ancestor_node) {
       return AuthorityManagerError::ORPHAN_BLOCK_OR_ALREADY_FINALIZED;
@@ -695,21 +689,11 @@ namespace kagome::consensus::grandpa {
 
       node->forced_digests.emplace_back(context.block_info);
 
-      // Force changes
-      if (node->block.number >= delay_start + delay) {
-        node->authorities = new_authorities;
-        SL_VERBOSE(logger_,
-                   "Change has been forced on block #{} (set id={})",
-                   delay_start + delay,
-                   node->authorities->id);
-      } else {
-        node->action =
-            ScheduleNode::ForcedChange{delay_start, delay, new_authorities};
-        SL_VERBOSE(logger_,
-                   "Change will be forced on block #{} (set id={})",
-                   delay_start + delay,
-                   new_authorities->id);
-      }
+      node->authorities = new_authorities;
+      SL_VERBOSE(logger_,
+                 "Change has been forced on block #{} (set id={})",
+                 forced_number,
+                 node->authorities->id);
 
       size_t index = 0;
       for (auto &authority : *new_authorities) {
@@ -725,7 +709,7 @@ namespace kagome::consensus::grandpa {
     };
 
     auto new_node =
-        ancestor_node->makeDescendant({delay_start, delay_start_hash}, true);
+        ancestor_node->makeDescendant({forced_number, delay_start_hash}, true);
 
     OUTCOME_TRY(force_change(new_node));
 
@@ -1038,14 +1022,6 @@ namespace kagome::consensus::grandpa {
           new_node->block.number < descendant->block.number ? new_node : node;
 
       // Apply if delay will be passed for descendant
-      if (auto *forced_change =
-              boost::get<ScheduleNode::ForcedChange>(&ancestor->action)) {
-        if (descendant->block.number
-            >= forced_change->delay_start + forced_change->delay_length) {
-          descendant->authorities = forced_change->new_authorities;
-          descendant->action = ScheduleNode::NoAction{};
-        }
-      }
       if (auto *resume = boost::get<ScheduleNode::Resume>(&ancestor->action)) {
         if (descendant->block.number >= resume->applied_block) {
           descendant->enabled = true;

--- a/core/consensus/grandpa/impl/authority_manager_impl.cpp
+++ b/core/consensus/grandpa/impl/authority_manager_impl.cpp
@@ -33,7 +33,6 @@ namespace kagome::consensus::grandpa {
       Config config,
       std::shared_ptr<application::AppStateManager> app_state_manager,
       std::shared_ptr<blockchain::BlockTree> block_tree,
-      std::shared_ptr<storage::trie::TrieStorage> trie_storage,
       std::shared_ptr<runtime::GrandpaApi> grandpa_api,
       std::shared_ptr<crypto::Hasher> hasher,
       std::shared_ptr<storage::SpacedStorage> persistent_storage,
@@ -41,7 +40,6 @@ namespace kagome::consensus::grandpa {
       primitives::events::ChainSubscriptionEnginePtr chain_events_engine)
       : config_{std::move(config)},
         block_tree_(std::move(block_tree)),
-        trie_storage_(std::move(trie_storage)),
         grandpa_api_(std::move(grandpa_api)),
         hasher_(std::move(hasher)),
         persistent_storage_{
@@ -55,7 +53,6 @@ namespace kagome::consensus::grandpa {
         logger_{log::createLogger("AuthorityManager", "authority")} {
     BOOST_ASSERT(block_tree_ != nullptr);
     BOOST_ASSERT(grandpa_api_ != nullptr);
-    BOOST_ASSERT(trie_storage_ != nullptr);
     BOOST_ASSERT(hasher_ != nullptr);
     BOOST_ASSERT(persistent_storage_ != nullptr);
     BOOST_ASSERT(header_repo_ != nullptr);

--- a/core/consensus/grandpa/impl/authority_manager_impl.hpp
+++ b/core/consensus/grandpa/impl/authority_manager_impl.hpp
@@ -41,10 +41,6 @@ namespace kagome::runtime {
   class Executor;
 }  // namespace kagome::runtime
 
-namespace kagome::storage::trie {
-  class TrieStorage;
-}
-
 namespace kagome::consensus::grandpa {
 
   class AuthorityManagerImpl final
@@ -69,7 +65,6 @@ namespace kagome::consensus::grandpa {
         Config config,
         std::shared_ptr<application::AppStateManager> app_state_manager,
         std::shared_ptr<blockchain::BlockTree> block_tree,
-        std::shared_ptr<storage::trie::TrieStorage> trie_storage,
         std::shared_ptr<runtime::GrandpaApi> grandpa_api,
         std::shared_ptr<crypto::Hasher> hash,
         std::shared_ptr<storage::SpacedStorage> persistent_storage,
@@ -153,7 +148,6 @@ namespace kagome::consensus::grandpa {
 
     Config config_;
     std::shared_ptr<const blockchain::BlockTree> block_tree_;
-    std::shared_ptr<storage::trie::TrieStorage> trie_storage_;
     std::shared_ptr<runtime::GrandpaApi> grandpa_api_;
     std::shared_ptr<crypto::Hasher> hasher_;
     std::shared_ptr<storage::BufferStorage> persistent_storage_;

--- a/core/consensus/grandpa/impl/grandpa_impl.cpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.cpp
@@ -36,6 +36,15 @@ namespace {
 }  // namespace
 
 namespace kagome::consensus::grandpa {
+  inline auto &westendPastRound() {
+    static primitives::BlockInfo block{
+        198785,
+        primitives::BlockHash::fromHex(
+            "62caf6a8c99d63744f7093bceead8fdf4c7d8ef74f16163ed58b1c1aec67bf18")
+            .value(),
+    };
+    return block;
+  }
 
   namespace {
     Clock::Duration getGossipDuration(const application::ChainSpec &chain) {
@@ -1252,7 +1261,9 @@ namespace kagome::consensus::grandpa {
         }
         if (authority_set->id == current_round_->voterSetId()
             && justification.round_number < current_round_->roundNumber()) {
-          return VotingRoundError::JUSTIFICATION_FOR_ROUND_IN_PAST;
+          if (justification.block_info != westendPastRound()) {
+            return VotingRoundError::JUSTIFICATION_FOR_ROUND_IN_PAST;
+          }
         }
 
         if (authority_set->id > current_round_->voterSetId() + 1) {

--- a/core/consensus/grandpa/impl/grandpa_impl.cpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.cpp
@@ -36,14 +36,19 @@ namespace {
 }  // namespace
 
 namespace kagome::consensus::grandpa {
-  inline auto &westendPastRound() {
-    static primitives::BlockInfo block{
+  inline bool isWestendPastRound(const primitives::BlockHash &genesis,
+                                 const primitives::BlockInfo &block) {
+    static auto westend_genesis =
+        primitives::BlockHash::fromHex(
+            "e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e")
+            .value();
+    static primitives::BlockInfo past_round{
         198785,
         primitives::BlockHash::fromHex(
             "62caf6a8c99d63744f7093bceead8fdf4c7d8ef74f16163ed58b1c1aec67bf18")
             .value(),
     };
-    return block;
+    return genesis == westend_genesis && block == past_round;
   }
 
   namespace {
@@ -1261,7 +1266,8 @@ namespace kagome::consensus::grandpa {
         }
         if (authority_set->id == current_round_->voterSetId()
             && justification.round_number < current_round_->roundNumber()) {
-          if (justification.block_info != westendPastRound()) {
+          if (not isWestendPastRound(block_tree_->getGenesisBlockHash(),
+                                     justification.block_info)) {
             return VotingRoundError::JUSTIFICATION_FOR_ROUND_IN_PAST;
           }
         }

--- a/core/consensus/grandpa/impl/schedule_node.cpp
+++ b/core/consensus/grandpa/impl/schedule_node.cpp
@@ -38,13 +38,6 @@ namespace kagome::consensus::grandpa {
         enabled = false;
         action = NoAction{};
       }
-    } else if (auto forced_change = boost::get<ForcedChange>(&action);
-               forced_change != nullptr) {
-      if (forced_change->delay_start + forced_change->delay_length
-          <= block.number) {
-        authorities = std::move(forced_change->new_authorities);
-        action = NoAction{};
-      }
     } else if (auto resume = boost::get<Resume>(&action); resume != nullptr) {
       if (resume->applied_block <= block.number) {
         enabled = true;

--- a/core/consensus/grandpa/impl/schedule_node.cpp
+++ b/core/consensus/grandpa/impl/schedule_node.cpp
@@ -30,6 +30,7 @@ namespace kagome::consensus::grandpa {
       if (scheduled_change->applied_block <= block.number) {
         authorities = std::move(scheduled_change->new_authorities);
         action = NoAction{};
+        forced_digests = {};
       }
     } else if (auto pause = boost::get<Pause>(&action);
                finalized && pause != nullptr) {
@@ -60,6 +61,7 @@ namespace kagome::consensus::grandpa {
     node->authorities = authorities;
     node->enabled = enabled;
     node->action = action;
+    node->forced_digests = forced_digests;
     node->adjust(finalized);
     return node;
   }

--- a/core/consensus/grandpa/impl/schedule_node.hpp
+++ b/core/consensus/grandpa/impl/schedule_node.hpp
@@ -74,15 +74,15 @@ namespace kagome::consensus::grandpa {
 
     friend inline ::scale::ScaleEncoderStream &operator<<(
         ::scale::ScaleEncoderStream &s, const ScheduleNode &node) {
-      return s << node.enabled << node.block << *node.authorities
-               << node.action;
+      return s << node.enabled << node.block << *node.authorities << node.action
+               << node.forced_digests;
     }
 
     friend inline ::scale::ScaleDecoderStream &operator>>(
         ::scale::ScaleDecoderStream &s, ScheduleNode &node) {
       return s >> node.enabled
-             >> const_cast<primitives::BlockInfo &>(node.block)
-             >> node.authorities >> node.action;
+          >> const_cast<primitives::BlockInfo &>(node.block) >> node.authorities
+          >> node.action >> node.forced_digests;
     }
 
     const primitives::BlockInfo block{};
@@ -91,6 +91,7 @@ namespace kagome::consensus::grandpa {
 
     boost::variant<NoAction, ScheduledChange, ForcedChange, Pause, Resume>
         action;
+    std::vector<primitives::BlockInfo> forced_digests;
     std::shared_ptr<const primitives::AuthoritySet> authorities;
     bool enabled = true;
   };

--- a/core/consensus/grandpa/impl/schedule_node.hpp
+++ b/core/consensus/grandpa/impl/schedule_node.hpp
@@ -52,14 +52,6 @@ namespace kagome::consensus::grandpa {
       std::shared_ptr<const primitives::AuthoritySet> new_authorities{};
     };
 
-    struct ForcedChange {
-      SCALE_TIE(3);
-
-      primitives::BlockNumber delay_start{};
-      size_t delay_length{};
-      std::shared_ptr<const primitives::AuthoritySet> new_authorities{};
-    };
-
     struct Pause {
       SCALE_TIE(1);
 
@@ -89,8 +81,7 @@ namespace kagome::consensus::grandpa {
     std::weak_ptr<const ScheduleNode> parent;
     std::vector<std::shared_ptr<ScheduleNode>> descendants{};
 
-    boost::variant<NoAction, ScheduledChange, ForcedChange, Pause, Resume>
-        action;
+    boost::variant<NoAction, ScheduledChange, Pause, Resume> action;
     std::vector<primitives::BlockInfo> forced_digests;
     std::shared_ptr<const primitives::AuthoritySet> authorities;
     bool enabled = true;

--- a/core/network/warp/cache.cpp
+++ b/core/network/warp/cache.cpp
@@ -60,7 +60,8 @@ namespace kagome::network {
       auto r = start(std::move(chain_sub_engine));
       if (not r) {
         SL_WARN(log_, "start error {}", r.error());
-        return false;
+        // TODO(turuslan): #1536 warp sync forced change
+        return true;
       }
       return true;
     });

--- a/core/utils/storage_explorer.cpp
+++ b/core/utils/storage_explorer.cpp
@@ -573,7 +573,6 @@ int storage_explorer_main(int argc, const char **argv) {
       std::make_shared<AuthorityManagerImpl>(AuthorityManagerImpl::Config{},
                                              app_state_manager,
                                              block_tree,
-                                             trie_storage,
                                              grandpa_api,
                                              hasher,
                                              persistent_storage,

--- a/test/core/consensus/authority/authority_manager_test.cpp
+++ b/test/core/consensus/authority/authority_manager_test.cpp
@@ -15,8 +15,6 @@
 #include "mock/core/runtime/grandpa_api_mock.hpp"
 #include "mock/core/storage/persistent_map_mock.hpp"
 #include "mock/core/storage/spaced_storage_mock.hpp"
-#include "mock/core/storage/trie/trie_batches_mock.hpp"
-#include "mock/core/storage/trie/trie_storage_mock.hpp"
 #include "primitives/digest.hpp"
 #include "runtime/common/executor.hpp"
 #include "storage/in_memory/in_memory_storage.hpp"
@@ -29,7 +27,6 @@
 using namespace kagome;
 using consensus::grandpa::AuthorityManagerImpl;
 using consensus::grandpa::IsBlockFinalized;
-using kagome::storage::trie::TrieBatchMock;
 using primitives::AuthorityList;
 using primitives::AuthoritySet;
 using primitives::events::ChainSubscriptionEngine;
@@ -70,16 +67,6 @@ class AuthorityManagerTest : public testing::Test {
     EXPECT_CALL(*spaced_storage, getSpace(kagome::storage::Space::kDefault))
         .WillRepeatedly(Return(persistent_storage));
 
-    trie_storage = std::make_shared<storage::trie::TrieStorageMock>();
-    EXPECT_CALL(*trie_storage, getEphemeralBatchAt(_))
-        .WillRepeatedly(testing::Invoke([] {
-          auto batch = std::make_unique<TrieBatchMock>();
-          EXPECT_CALL(*batch, tryGetMock(_))
-              .WillRepeatedly(
-                  Return(storage::Buffer::fromHex("0000000000000000").value()));
-          return batch;
-        }));
-
     grandpa_api = std::make_shared<runtime::GrandpaApiMock>();
     EXPECT_CALL(*grandpa_api, authorities(_))
         .WillRepeatedly(Return(authorities->authorities));
@@ -97,7 +84,6 @@ class AuthorityManagerTest : public testing::Test {
         std::make_shared<AuthorityManagerImpl>(AuthorityManagerImpl::Config{},
                                                app_state_manager,
                                                block_tree,
-                                               trie_storage,
                                                grandpa_api,
                                                hasher,
                                                spaced_storage,
@@ -176,7 +162,6 @@ class AuthorityManagerTest : public testing::Test {
   std::shared_ptr<application::AppStateManagerMock> app_state_manager;
   std::shared_ptr<blockchain::BlockHeaderRepositoryMock> header_repo;
   std::shared_ptr<blockchain::BlockTreeMock> block_tree;
-  std::shared_ptr<storage::trie::TrieStorageMock> trie_storage;
   std::shared_ptr<storage::SpacedStorageMock> spaced_storage;
   std::shared_ptr<storage::BufferStorage> persistent_storage;
   std::shared_ptr<runtime::GrandpaApiMock> grandpa_api;

--- a/test/core/consensus/authority/authority_manager_test.cpp
+++ b/test/core/consensus/authority/authority_manager_test.cpp
@@ -424,9 +424,8 @@ TEST_F(AuthorityManagerTest, OnConsensus_ForcedChange) {
   ASSERT_TRUE(old_auth_opt.has_value());
   auto &old_authorities = *old_auth_opt.value();
 
-  primitives::BlockInfo target_block{10, "B"_hash256};
-  EXPECT_CALL(*header_repo, getHashByNumber(target_block.number))
-      .WillOnce(Return(target_block.hash));
+  primitives::BlockInfo target_block{5, "A"_hash256};
+  EXPECT_CALL(*header_repo, getHashByNumber(10)).WillOnce(Return("B"_hash256));
   primitives::AuthorityList new_authorities{makeAuthority("Auth1", 123)};
   uint32_t subchain_length = 5;
 
@@ -438,7 +437,7 @@ TEST_F(AuthorityManagerTest, OnConsensus_ForcedChange) {
               new_authorities, subchain_length, target_block.number)));
 
   examine({5, "A"_hash256}, old_authorities.authorities);
-  examine({10, "B"_hash256}, old_authorities.authorities);
+  examine({10, "B"_hash256}, new_authorities);
   examine({15, "C"_hash256}, new_authorities);
   examine({20, "D"_hash256}, new_authorities);
   examine({25, "E"_hash256}, new_authorities);


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- Allow westend block 198785 past round.
- Select round by set id.
- Remember included forced changes.
  - Apply forced change once.
  - Don't apply scheduled changes if forced.
- Apply forced change immediately (when two forced changes had same "target" and "delay", "adjust" never applied "node.action" for first, so set id was off).

### Benefits
- Westend syncs.

### Possible Drawbacks