### PR TITLE
allow unsafe rpc

### DIFF
--- a/core/api/allow_unsafe.hpp
+++ b/core/api/allow_unsafe.hpp
@@ -12,14 +12,18 @@
 
 namespace kagome::api {
   struct AllowUnsafe {
+    using Config = application::AppConfiguration::AllowUnsafeRpc;
     AllowUnsafe(const application::AppConfiguration &config)
         : config{config.allowUnsafeRpc()} {}
 
     bool allow(const boost::asio::ip::tcp::endpoint &endpoint) const {
-      return config ? *config : endpoint.address().is_loopback();
+      if (config == Config::kAuto) {
+        return endpoint.address().is_loopback();
+      }
+      return config == Config::kUnsafe;
     }
 
-    std::optional<bool> config;
+    Config config;
   };
 }  // namespace kagome::api
 

--- a/core/api/allow_unsafe.hpp
+++ b/core/api/allow_unsafe.hpp
@@ -1,0 +1,26 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_API_ALLOW_UNSAFE_HPP
+#define KAGOME_API_ALLOW_UNSAFE_HPP
+
+#include <boost/asio/ip/tcp.hpp>
+
+#include "application/app_configuration.hpp"
+
+namespace kagome::api {
+  struct AllowUnsafe {
+    AllowUnsafe(const application::AppConfiguration &config)
+        : config{config.allowUnsafeRpc()} {}
+
+    bool allow(const boost::asio::ip::tcp::endpoint &endpoint) const {
+      return config ? *config : endpoint.address().is_loopback();
+    }
+
+    std::optional<bool> config;
+  };
+}  // namespace kagome::api
+
+#endif  // KAGOME_API_ALLOW_UNSAFE_HPP

--- a/core/api/jrpc/jrpc_server.hpp
+++ b/core/api/jrpc/jrpc_server.hpp
@@ -30,10 +30,20 @@ namespace kagome::api {
      * @brief registers rpc request handler lambda
      * @param name rpc method name
      * @param method handler functor
+     * @param unsafe method is unsafe
      */
     virtual void registerHandler(const std::string &name,
                                  Method method,
                                  bool unsafe = false) = 0;
+
+    /**
+     * @brief registers unsafe rpc request handler lambda
+     * @param name rpc method name
+     * @param method handler functor
+     */
+    void registerHandlerUnsafe(const std::string &name, Method method) {
+      registerHandler(name, std::move(method), true);
+    }
 
     /**
      * @return name of handlers
@@ -60,6 +70,7 @@ namespace kagome::api {
     /**
      * @brief handles decoded network message
      * @param request json request string
+     * @param allow_unsafe allow unsafe methods
      * @param cb callback
      */
     virtual void processData(std::string_view request,

--- a/core/api/jrpc/jrpc_server.hpp
+++ b/core/api/jrpc/jrpc_server.hpp
@@ -31,7 +31,9 @@ namespace kagome::api {
      * @param name rpc method name
      * @param method handler functor
      */
-    virtual void registerHandler(const std::string &name, Method method) = 0;
+    virtual void registerHandler(const std::string &name,
+                                 Method method,
+                                 bool unsafe = false) = 0;
 
     /**
      * @return name of handlers
@@ -61,6 +63,7 @@ namespace kagome::api {
      * @param cb callback
      */
     virtual void processData(std::string_view request,
+                             bool allow_unsafe,
                              const ResponseHandler &cb) = 0;
   };
 

--- a/core/api/jrpc/jrpc_server_impl.hpp
+++ b/core/api/jrpc/jrpc_server_impl.hpp
@@ -21,13 +21,6 @@ namespace kagome::api {
 
     JRpcServerImpl();
 
-    ~JRpcServerImpl() override = default;
-
-    /**
-     * @brief registers rpc request handler lambda
-     * @param name rpc method name
-     * @param method handler functor
-     */
     void registerHandler(const std::string &name,
                          Method method,
                          bool unsafe) override;
@@ -37,11 +30,6 @@ namespace kagome::api {
      */
     std::vector<std::string> getHandlerNames() override;
 
-    /**
-     * @brief handles decoded network message
-     * @param request json request string
-     * @param cb callback
-     */
     void processData(std::string_view request,
                      bool allow_unsafe,
                      const ResponseHandler &cb) override;

--- a/core/api/jrpc/jrpc_server_impl.hpp
+++ b/core/api/jrpc/jrpc_server_impl.hpp
@@ -28,7 +28,9 @@ namespace kagome::api {
      * @param name rpc method name
      * @param method handler functor
      */
-    void registerHandler(const std::string &name, Method method) override;
+    void registerHandler(const std::string &name,
+                         Method method,
+                         bool unsafe) override;
 
     /**
      * @return name of handlers
@@ -41,6 +43,7 @@ namespace kagome::api {
      * @param cb callback
      */
     void processData(std::string_view request,
+                     bool allow_unsafe,
                      const ResponseHandler &cb) override;
 
     /**
@@ -55,6 +58,8 @@ namespace kagome::api {
    private:
     /// json rpc server instance
     jsonrpc::Server jsonrpc_handler_{};
+    /// json rpc server instance for subset of safe methods
+    jsonrpc::Server jsonrpc_handler_safe_{};
     /// format handler instance
     jsonrpc::JsonFormatHandler format_handler_{};
 

--- a/core/api/service/author/author_jrpc_processor.cpp
+++ b/core/api/service/author/author_jrpc_processor.cpp
@@ -31,17 +31,17 @@ namespace kagome::api::author {
     server_->registerHandler("author_submitExtrinsic",
                              Handler<request::SubmitExtrinsic>(api_));
 
-    server_->registerHandler(
-        "author_insertKey", Handler<request::InsertKey>(api_), true);
+    server_->registerHandlerUnsafe("author_insertKey",
+                                   Handler<request::InsertKey>(api_));
 
-    server_->registerHandler(
-        "author_hasSessionKeys", Handler<request::HasSessionKeys>(api_), true);
+    server_->registerHandlerUnsafe("author_hasSessionKeys",
+                                   Handler<request::HasSessionKeys>(api_));
 
-    server_->registerHandler(
-        "author_hasKey", Handler<request::HasKey>(api_), true);
+    server_->registerHandlerUnsafe("author_hasKey",
+                                   Handler<request::HasKey>(api_));
 
-    server_->registerHandler(
-        "author_rotateKeys", Handler<request::RotateKeys>(api_), true);
+    server_->registerHandlerUnsafe("author_rotateKeys",
+                                   Handler<request::RotateKeys>(api_));
 
     server_->registerHandler("author_submitAndWatchExtrinsic",
                              Handler<request::SubmitAndWatchExtrinsic>(api_));

--- a/core/api/service/author/author_jrpc_processor.cpp
+++ b/core/api/service/author/author_jrpc_processor.cpp
@@ -31,16 +31,17 @@ namespace kagome::api::author {
     server_->registerHandler("author_submitExtrinsic",
                              Handler<request::SubmitExtrinsic>(api_));
 
-    server_->registerHandler("author_insertKey",
-                             Handler<request::InsertKey>(api_));
+    server_->registerHandler(
+        "author_insertKey", Handler<request::InsertKey>(api_), true);
 
-    server_->registerHandler("author_hasSessionKeys",
-                             Handler<request::HasSessionKeys>(api_));
+    server_->registerHandler(
+        "author_hasSessionKeys", Handler<request::HasSessionKeys>(api_), true);
 
-    server_->registerHandler("author_hasKey", Handler<request::HasKey>(api_));
+    server_->registerHandler(
+        "author_hasKey", Handler<request::HasKey>(api_), true);
 
-    server_->registerHandler("author_rotateKeys",
-                             Handler<request::RotateKeys>(api_));
+    server_->registerHandler(
+        "author_rotateKeys", Handler<request::RotateKeys>(api_), true);
 
     server_->registerHandler("author_submitAndWatchExtrinsic",
                              Handler<request::SubmitAndWatchExtrinsic>(api_));

--- a/core/api/service/impl/api_service_impl.cpp
+++ b/core/api/service/impl/api_service_impl.cpp
@@ -511,7 +511,7 @@ namespace kagome::api {
 
     // process new request
     server_->processData(str_request,
-                         session->allowUnsafe(),
+                         session->isUnsafeAllowed(),
                          [&](std::string_view response) mutable {
                            // process response
                            session->respond(response);

--- a/core/api/service/impl/api_service_impl.cpp
+++ b/core/api/service/impl/api_service_impl.cpp
@@ -510,10 +510,12 @@ namespace kagome::api {
     boost::replace_first(str_request, "\"params\":null", "\"params\":[null]");
 
     // process new request
-    server_->processData(str_request, [&](std::string_view response) mutable {
-      // process response
-      session->respond(response);
-    });
+    server_->processData(str_request,
+                         session->allowUnsafe(),
+                         [&](std::string_view response) mutable {
+                           // process response
+                           session->respond(response);
+                         });
 
     try {
       withSession(session->id(), [&](SessionSubscriptions &session_context) {

--- a/core/api/service/internal/internal_jrpc_processor.cpp
+++ b/core/api/service/internal/internal_jrpc_processor.cpp
@@ -21,8 +21,8 @@ namespace kagome::api::internal {
   using Handler = Method<Request, InternalApi>;
 
   void InternalJrpcProcessor::registerHandlers() {
-    server_->registerHandler(
-        "internal_setLogLevel", Handler<request::SetLogLevel>(api_), true);
+    server_->registerHandlerUnsafe("internal_setLogLevel",
+                                   Handler<request::SetLogLevel>(api_));
   }
 
 }  // namespace kagome::api::internal

--- a/core/api/service/internal/internal_jrpc_processor.cpp
+++ b/core/api/service/internal/internal_jrpc_processor.cpp
@@ -21,8 +21,8 @@ namespace kagome::api::internal {
   using Handler = Method<Request, InternalApi>;
 
   void InternalJrpcProcessor::registerHandlers() {
-    server_->registerHandler("internal_setLogLevel",
-                             Handler<request::SetLogLevel>(api_));
+    server_->registerHandler(
+        "internal_setLogLevel", Handler<request::SetLogLevel>(api_), true);
   }
 
 }  // namespace kagome::api::internal

--- a/core/api/service/state/state_jrpc_processor.cpp
+++ b/core/api/service/state/state_jrpc_processor.cpp
@@ -44,8 +44,8 @@ namespace kagome::api::state {
     server_->registerHandler("state_getStorageAt",
                              Handler<request::GetStorage>(api_));
 
-    server_->registerHandler("state_queryStorage",
-                             Handler<request::QueryStorage>(api_));
+    server_->registerHandler(
+        "state_queryStorage", Handler<request::QueryStorage>(api_), true);
     server_->registerHandler("state_queryStorageAt",
                              Handler<request::QueryStorageAt>(api_));
 

--- a/core/api/service/state/state_jrpc_processor.cpp
+++ b/core/api/service/state/state_jrpc_processor.cpp
@@ -44,8 +44,8 @@ namespace kagome::api::state {
     server_->registerHandler("state_getStorageAt",
                              Handler<request::GetStorage>(api_));
 
-    server_->registerHandler(
-        "state_queryStorage", Handler<request::QueryStorage>(api_), true);
+    server_->registerHandlerUnsafe("state_queryStorage",
+                                   Handler<request::QueryStorage>(api_));
     server_->registerHandler("state_queryStorageAt",
                              Handler<request::QueryStorageAt>(api_));
 

--- a/core/api/service/system/system_jrpc_processor.cpp
+++ b/core/api/service/system/system_jrpc_processor.cpp
@@ -48,7 +48,8 @@ namespace kagome::api::system {
         "account_nextIndex",
         Handler<request::AccountNextIndex>(api_));  // an alias
 
-    server_->registerHandler("system_peers", Handler<request::Peers>(api_));
+    server_->registerHandler(
+        "system_peers", Handler<request::Peers>(api_), true);
   }
 
 }  // namespace kagome::api::system

--- a/core/api/service/system/system_jrpc_processor.cpp
+++ b/core/api/service/system/system_jrpc_processor.cpp
@@ -48,8 +48,8 @@ namespace kagome::api::system {
         "account_nextIndex",
         Handler<request::AccountNextIndex>(api_));  // an alias
 
-    server_->registerHandler(
-        "system_peers", Handler<request::Peers>(api_), true);
+    server_->registerHandlerUnsafe("system_peers",
+                                   Handler<request::Peers>(api_));
   }
 
 }  // namespace kagome::api::system

--- a/core/api/transport/impl/http/http_listener_impl.cpp
+++ b/core/api/transport/impl/http/http_listener_impl.cpp
@@ -20,6 +20,7 @@ namespace kagome::api {
       const application::AppConfiguration &app_config,
       SessionImpl::Configuration session_config)
       : context_{std::move(context)},
+        allow_unsafe_{app_config},
         endpoint_(app_config.rpcHttpEndpoint()),
         session_config_{session_config},
         logger_{log::createLogger("RpcHttpListener", "rpc_transport")} {
@@ -77,7 +78,8 @@ namespace kagome::api {
   }
 
   void HttpListenerImpl::acceptOnce() {
-    new_session_ = std::make_shared<SessionImpl>(*context_, session_config_);
+    new_session_ = std::make_shared<SessionImpl>(
+        *context_, allow_unsafe_, session_config_);
 
     auto on_accept = [wp = weak_from_this()](boost::system::error_code ec) {
       if (auto self = wp.lock()) {

--- a/core/api/transport/impl/http/http_listener_impl.hpp
+++ b/core/api/transport/impl/http/http_listener_impl.hpp
@@ -49,6 +49,7 @@ namespace kagome::api {
     void acceptOnce() override;
 
     std::shared_ptr<Context> context_;
+    AllowUnsafe allow_unsafe_;
     const Endpoint endpoint_;
     const SessionImpl::Configuration session_config_;
 

--- a/core/api/transport/impl/http/http_session.cpp
+++ b/core/api/transport/impl/http/http_session.cpp
@@ -11,8 +11,11 @@
 
 namespace kagome::api {
 
-  HttpSession::HttpSession(Context &context, Configuration config)
+  HttpSession::HttpSession(Context &context,
+                           AllowUnsafe allow_unsafe,
+                           Configuration config)
       : strand_(boost::asio::make_strand(context)),
+        allow_unsafe_{allow_unsafe},
         config_{config},
         stream_(boost::asio::ip::tcp::socket(strand_)) {}
 
@@ -132,5 +135,9 @@ namespace kagome::api {
 
   void HttpSession::post(std::function<void()> cb) {
     boost::asio::post(strand_, std::move(cb));
+  }
+
+  bool HttpSession::allowUnsafe() const {
+    return allow_unsafe_.allow(stream_.socket().remote_endpoint());
   }
 }  // namespace kagome::api

--- a/core/api/transport/impl/http/http_session.cpp
+++ b/core/api/transport/impl/http/http_session.cpp
@@ -137,7 +137,7 @@ namespace kagome::api {
     boost::asio::post(strand_, std::move(cb));
   }
 
-  bool HttpSession::allowUnsafe() const {
+  bool HttpSession::isUnsafeAllowed() const {
     return allow_unsafe_.allow(stream_.socket().remote_endpoint());
   }
 }  // namespace kagome::api

--- a/core/api/transport/impl/http/http_session.hpp
+++ b/core/api/transport/impl/http/http_session.hpp
@@ -90,7 +90,7 @@ namespace kagome::api {
 
     void post(std::function<void()> cb) override;
 
-    bool allowUnsafe() const override;
+    bool isUnsafeAllowed() const override;
 
    private:
     /**

--- a/core/api/transport/impl/http/http_session.hpp
+++ b/core/api/transport/impl/http/http_session.hpp
@@ -12,6 +12,7 @@
 #include <cstdlib>
 #include <memory>
 
+#include "api/allow_unsafe.hpp"
 #include "api/transport/session.hpp"
 #include "log/logger.hpp"
 
@@ -52,7 +53,9 @@ namespace kagome::api {
      * @param socket socket instance
      * @param config session configuration
      */
-    HttpSession(Context &context, Configuration config);
+    HttpSession(Context &context,
+                AllowUnsafe allow_unsafe,
+                Configuration config);
 
     Socket &socket() override {
       return stream_.socket();
@@ -86,6 +89,8 @@ namespace kagome::api {
     }
 
     void post(std::function<void()> cb) override;
+
+    bool allowUnsafe() const override;
 
    private:
     /**
@@ -148,6 +153,7 @@ namespace kagome::api {
     /// Strand to ensure the connection's handlers are not called concurrently.
     boost::asio::strand<boost::asio::io_context::executor_type> strand_;
 
+    AllowUnsafe allow_unsafe_;
     Configuration config_;              ///< session configuration
     boost::beast::tcp_stream stream_;   ///< stream
     boost::beast::flat_buffer buffer_;  ///< read buffer

--- a/core/api/transport/impl/ws/ws_listener_impl.hpp
+++ b/core/api/transport/impl/ws/ws_listener_impl.hpp
@@ -51,6 +51,7 @@ namespace kagome::api {
     void acceptOnce() override;
 
     std::shared_ptr<Context> context_;
+    AllowUnsafe allow_unsafe_;
     const Endpoint endpoint_;
     const SessionImpl::Configuration session_config_;
     const uint32_t max_ws_connections_;

--- a/core/api/transport/impl/ws/ws_session.cpp
+++ b/core/api/transport/impl/ws/ws_session.cpp
@@ -170,7 +170,7 @@ namespace kagome::api {
     boost::asio::post(strand_, std::move(cb));
   }
 
-  bool WsSession::allowUnsafe() const {
+  bool WsSession::isUnsafeAllowed() const {
     return allow_unsafe_.allow(socket_.remote_endpoint());
   }
 }  // namespace kagome::api

--- a/core/api/transport/impl/ws/ws_session.cpp
+++ b/core/api/transport/impl/ws/ws_session.cpp
@@ -12,9 +12,13 @@
 
 namespace kagome::api {
 
-  WsSession::WsSession(Context &context, Configuration config, SessionId id)
+  WsSession::WsSession(Context &context,
+                       AllowUnsafe allow_unsafe,
+                       Configuration config,
+                       SessionId id)
       : strand_(boost::asio::make_strand(context)),
         socket_(strand_),
+        allow_unsafe_{allow_unsafe},
         config_{config},
         stream_(socket_),
         id_(id) {}
@@ -164,5 +168,9 @@ namespace kagome::api {
 
   void WsSession::post(std::function<void()> cb) {
     boost::asio::post(strand_, std::move(cb));
+  }
+
+  bool WsSession::allowUnsafe() const {
+    return allow_unsafe_.allow(socket_.remote_endpoint());
   }
 }  // namespace kagome::api

--- a/core/api/transport/impl/ws/ws_session.hpp
+++ b/core/api/transport/impl/ws/ws_session.hpp
@@ -16,6 +16,7 @@
 #include <boost/beast/core/tcp_stream.hpp>
 #include <boost/beast/websocket.hpp>
 
+#include "api/allow_unsafe.hpp"
 #include "api/transport/session.hpp"
 #include "log/logger.hpp"
 
@@ -43,7 +44,10 @@ namespace kagome::api {
      * @param config session configuration
      * @param id session id
      */
-    WsSession(Context &context, Configuration config, SessionId id);
+    WsSession(Context &context,
+              AllowUnsafe allow_unsafe,
+              Configuration config,
+              SessionId id);
 
     Socket &socket() override {
       return socket_;
@@ -75,6 +79,8 @@ namespace kagome::api {
     void respond(std::string_view response) override;
 
     void post(std::function<void()> cb) override;
+
+    bool allowUnsafe() const override;
 
     /**
      * @brief Closes the incoming connection with "try again later" response
@@ -150,6 +156,7 @@ namespace kagome::api {
     /// Socket for the connection.
     boost::asio::ip::tcp::socket socket_;
 
+    AllowUnsafe allow_unsafe_;
     Configuration config_;  ///< session configuration
     boost::beast::websocket::stream<boost::asio::ip::tcp::socket &> stream_;
     boost::beast::flat_buffer rbuffer_;  ///< read buffer
@@ -159,7 +166,7 @@ namespace kagome::api {
     bool writing_in_progress_ = false;
     std::atomic_bool stopped_ = false;
 
-    SessionId const id_;
+    const SessionId id_;
     OnWsSessionCloseHandler on_ws_close_;
     log::Logger logger_ = log::createLogger("WsSession", "rpc_transport");
   };

--- a/core/api/transport/impl/ws/ws_session.hpp
+++ b/core/api/transport/impl/ws/ws_session.hpp
@@ -80,7 +80,7 @@ namespace kagome::api {
 
     void post(std::function<void()> cb) override;
 
-    bool allowUnsafe() const override;
+    bool isUnsafeAllowed() const override;
 
     /**
      * @brief Closes the incoming connection with "try again later" response

--- a/core/api/transport/session.hpp
+++ b/core/api/transport/session.hpp
@@ -91,7 +91,9 @@ namespace kagome::api {
      * @param type type of the closed session
      */
     void notifyOnClose(SessionId id, SessionType type) {
-      if (nullptr != on_close_) on_close_(id, type);
+      if (nullptr != on_close_) {
+        on_close_(id, type);
+      }
     }
 
     /**
@@ -114,6 +116,11 @@ namespace kagome::api {
      * queued writes will complete.
      */
     virtual void post(std::function<void()> cb) = 0;
+
+    /**
+     * Can call unsafe methods
+     */
+    virtual bool allowUnsafe() const = 0;
 
    private:
     std::function<OnRequestSignature> on_request_;  ///< `on request` callback

--- a/core/api/transport/session.hpp
+++ b/core/api/transport/session.hpp
@@ -120,7 +120,7 @@ namespace kagome::api {
     /**
      * Can call unsafe methods
      */
-    virtual bool allowUnsafe() const = 0;
+    virtual bool isUnsafeAllowed() const = 0;
 
    private:
     std::function<OnRequestSignature> on_request_;  ///< `on request` callback

--- a/core/application/app_configuration.hpp
+++ b/core/application/app_configuration.hpp
@@ -254,7 +254,9 @@ namespace kagome::application {
 
     virtual std::string nodeWssPem() const = 0;
 
-    virtual std::optional<bool> allowUnsafeRpc() const = 0;
+    enum class AllowUnsafeRpc : uint8_t { kAuto, kUnsafe, kSafe };
+
+    virtual AllowUnsafeRpc allowUnsafeRpc() const = 0;
   };
 
 }  // namespace kagome::application

--- a/core/application/app_configuration.hpp
+++ b/core/application/app_configuration.hpp
@@ -253,6 +253,8 @@ namespace kagome::application {
     virtual std::optional<std::string_view> devMnemonicPhrase() const = 0;
 
     virtual std::string nodeWssPem() const = 0;
+
+    virtual std::optional<bool> allowUnsafeRpc() const = 0;
   };
 
 }  // namespace kagome::application

--- a/core/application/impl/app_configuration_impl.cpp
+++ b/core/application/impl/app_configuration_impl.cpp
@@ -789,11 +789,11 @@ namespace kagome::application {
         ("random-walk-interval", po::value<uint32_t>()->default_value(def_random_walk_interval), "Kademlia random walk interval")
         ("node-wss-pem", po::value<std::string>(), "Path to pem file with SSL certificate for libp2p wss")
         ("rpc-cors", po::value<std::string>(), "(unused, zombienet stub)")
-        ("unsafe-rpc-external", po::bool_switch())
+        ("unsafe-rpc-external", po::bool_switch(), "alias for \"--rpc-host 0.0.0.0\"")
         ("rpc-methods", po::value<std::string>(), "\"auto\" (default), \"unsafe\", \"safe\"")
-        ("unsafe-ws-external", po::bool_switch())
+        ("unsafe-ws-external", po::bool_switch(), "alias for \"--ws-host 0.0.0.0\"")
         ("no-mdns", po::bool_switch(), "(unused, zombienet stub)")
-        ("prometheus-external", po::bool_switch())
+        ("prometheus-external", po::bool_switch(), "alias for \"--prometheus-host 0.0.0.0\"")
         ;
 
     po::options_description development_desc("Additional options");

--- a/core/application/impl/app_configuration_impl.hpp
+++ b/core/application/impl/app_configuration_impl.hpp
@@ -195,6 +195,10 @@ namespace kagome::application {
       return node_wss_pem_;
     }
 
+    std::optional<bool> allowUnsafeRpc() const override {
+      return allow_unsafe_rpc_;
+    }
+
    private:
     void parse_general_segment(const rapidjson::Value &val);
     void parse_blockchain_segment(const rapidjson::Value &val);
@@ -206,7 +210,7 @@ namespace kagome::application {
     /// member-function ptrs
     struct SegmentHandler {
       using Handler = std::function<void(rapidjson::Value &)>;
-      char const *segment_name;
+      const char *segment_name;
       Handler handler;
     };
 
@@ -225,28 +229,28 @@ namespace kagome::application {
     void read_config_from_file(const std::string &filepath);
 
     bool load_ms(const rapidjson::Value &val,
-                 char const *name,
+                 const char *name,
                  std::vector<std::string> &target);
 
     bool load_ma(const rapidjson::Value &val,
-                 char const *name,
+                 const char *name,
                  std::vector<libp2p::multi::Multiaddress> &target);
     bool load_telemetry_uris(const rapidjson::Value &val,
-                             char const *name,
+                             const char *name,
                              std::vector<telemetry::TelemetryEndpoint> &target);
     bool load_str(const rapidjson::Value &val,
-                  char const *name,
+                  const char *name,
                   std::string &target);
     bool load_u16(const rapidjson::Value &val,
-                  char const *name,
+                  const char *name,
                   uint16_t &target);
     bool load_u32(const rapidjson::Value &val,
-                  char const *name,
+                  const char *name,
                   uint32_t &target);
     bool load_i32(const rapidjson::Value &val,
-                  char const *name,
+                  const char *name,
                   int32_t &target);
-    bool load_bool(const rapidjson::Value &val, char const *name, bool &target);
+    bool load_bool(const rapidjson::Value &val, const char *name, bool &target);
 
     /**
      * Convert given values into boost tcp::endpoint representation format
@@ -334,6 +338,7 @@ namespace kagome::application {
     StorageBackend storage_backend_ = StorageBackend::RocksDB;
     std::optional<std::string> dev_mnemonic_phrase_;
     std::string node_wss_pem_;
+    std::optional<bool> allow_unsafe_rpc_;
   };
 
 }  // namespace kagome::application

--- a/core/application/impl/app_configuration_impl.hpp
+++ b/core/application/impl/app_configuration_impl.hpp
@@ -195,7 +195,7 @@ namespace kagome::application {
       return node_wss_pem_;
     }
 
-    std::optional<bool> allowUnsafeRpc() const override {
+    AllowUnsafeRpc allowUnsafeRpc() const override {
       return allow_unsafe_rpc_;
     }
 
@@ -338,7 +338,7 @@ namespace kagome::application {
     StorageBackend storage_backend_ = StorageBackend::RocksDB;
     std::optional<std::string> dev_mnemonic_phrase_;
     std::string node_wss_pem_;
-    std::optional<bool> allow_unsafe_rpc_;
+    AllowUnsafeRpc allow_unsafe_rpc_ = AllowUnsafeRpc::kAuto;
   };
 
 }  // namespace kagome::application

--- a/core/application/impl/kagome_application_impl.cpp
+++ b/core/application/impl/kagome_application_impl.cpp
@@ -44,6 +44,9 @@ namespace kagome::application {
     auto io_context = injector_->injectIoContext();
     auto clock = injector_->injectSystemClock();
 
+    injector_->injectOpenMetricsService();
+    injector_->injectRpcApiService();
+
     kagome::telemetry::setTelemetryService(injector_->injectTelemetryService());
 
     injector_->injectAddressPublisher();

--- a/test/core/api/service/state/state_jrpc_processor_test.cpp
+++ b/test/core/api/service/state/state_jrpc_processor_test.cpp
@@ -56,78 +56,79 @@ class StateJrpcProcessorTest : public testing::Test {
 
   void registerHandlers() {
     call_contexts_.clear();
-    EXPECT_CALL(*server, registerHandler("state_call", _))
-        .WillOnce(testing::Invoke([&](auto &name, auto &&f) {
+    EXPECT_CALL(*server, registerHandler("state_call", _, _))
+        .WillOnce(testing::Invoke([&](auto &name, auto &&f, bool) {
           call_contexts_.emplace(std::make_pair(CallType::kCallType_Call,
                                                 CallContext{.handler = f}));
         }));
-    EXPECT_CALL(*server, registerHandler("state_getRuntimeVersion", _))
-        .WillOnce(testing::Invoke([&](auto &name, auto &&f) {
+    EXPECT_CALL(*server, registerHandler("state_getRuntimeVersion", _, _))
+        .WillOnce(testing::Invoke([&](auto &name, auto &&f, bool) {
           call_contexts_.emplace(
               std::make_pair(CallType::kCallType_GetRuntimeVersion,
                              CallContext{.handler = f}));
         }));
-    EXPECT_CALL(*server, registerHandler("chain_getRuntimeVersion", _))
-        .WillOnce(testing::Invoke([&](auto &name, auto &&f) {
+    EXPECT_CALL(*server, registerHandler("chain_getRuntimeVersion", _, _))
+        .WillOnce(testing::Invoke([&](auto &name, auto &&f, bool) {
           call_contexts_.emplace(
               std::make_pair(CallType::kCallType_SubscribeRuntimeVersion,
                              CallContext{.handler = f}));
         }));
-    EXPECT_CALL(*server, registerHandler("state_subscribeRuntimeVersion", _))
-        .WillOnce(testing::Invoke([&](auto &name, auto &&f) {
+    EXPECT_CALL(*server, registerHandler("state_subscribeRuntimeVersion", _, _))
+        .WillOnce(testing::Invoke([&](auto &name, auto &&f, bool) {
           call_contexts_.emplace(
               std::make_pair(CallType::kCallType_SubscribeRuntimeVersion,
                              CallContext{.handler = f}));
         }));
-    EXPECT_CALL(*server, registerHandler("state_unsubscribeRuntimeVersion", _))
-        .WillOnce(testing::Invoke([&](auto &name, auto &&f) {
+    EXPECT_CALL(*server,
+                registerHandler("state_unsubscribeRuntimeVersion", _, _))
+        .WillOnce(testing::Invoke([&](auto &name, auto &&f, bool) {
           call_contexts_.emplace(
               std::make_pair(CallType::kCallType_UnsubscribeRuntimeVersion,
                              CallContext{.handler = f}));
         }));
-    EXPECT_CALL(*server, registerHandler("state_getKeysPaged", _))
-        .WillOnce(testing::Invoke([&](auto &name, auto &&f) {
+    EXPECT_CALL(*server, registerHandler("state_getKeysPaged", _, _))
+        .WillOnce(testing::Invoke([&](auto &name, auto &&f, bool) {
           call_contexts_.emplace(std::make_pair(
               CallType::kCallType_GetKeysPaged, CallContext{.handler = f}));
         }));
-    EXPECT_CALL(*server, registerHandler("state_getStorage", _))
-        .WillOnce(testing::Invoke([&](auto &name, auto &&f) {
+    EXPECT_CALL(*server, registerHandler("state_getStorage", _, _))
+        .WillOnce(testing::Invoke([&](auto &name, auto &&f, bool) {
           call_contexts_.emplace(std::make_pair(CallType::kCallType_GetStorage,
                                                 CallContext{.handler = f}));
         }));
-    EXPECT_CALL(*server, registerHandler("state_getStorageAt", _))
-        .WillOnce(testing::Invoke([&](auto &name, auto &&f) {
+    EXPECT_CALL(*server, registerHandler("state_getStorageAt", _, _))
+        .WillOnce(testing::Invoke([&](auto &name, auto &&f, bool) {
           call_contexts_.emplace(std::make_pair(CallType::kCallType_GetStorage,
                                                 CallContext{.handler = f}));
         }));
-    EXPECT_CALL(*server, registerHandler("state_queryStorage", _))
-        .WillOnce(testing::Invoke([&](auto &name, auto &&f) {
+    EXPECT_CALL(*server, registerHandler("state_queryStorage", _, _))
+        .WillOnce(testing::Invoke([&](auto &name, auto &&f, bool) {
           call_contexts_.emplace(std::make_pair(
               CallType::kCallType_QueryStorage, CallContext{.handler = f}));
         }));
-    EXPECT_CALL(*server, registerHandler("state_queryStorageAt", _))
-        .WillOnce(testing::Invoke([&](auto &name, auto &&f) {
+    EXPECT_CALL(*server, registerHandler("state_queryStorageAt", _, _))
+        .WillOnce(testing::Invoke([&](auto &name, auto &&f, bool) {
           call_contexts_.emplace(std::make_pair(
               CallType::kCallType_QueryStorageAt, CallContext{.handler = f}));
         }));
-    EXPECT_CALL(*server, registerHandler("state_getReadProof", _))
-        .WillOnce(testing::Invoke([&](auto &name, auto &&f) {
+    EXPECT_CALL(*server, registerHandler("state_getReadProof", _, _))
+        .WillOnce(testing::Invoke([&](auto &name, auto &&f, bool) {
           call_contexts_.emplace(std::make_pair(
               CallType::kCallType_GetReadProof, CallContext{.handler = f}));
         }));
-    EXPECT_CALL(*server, registerHandler("state_subscribeStorage", _))
-        .WillOnce(testing::Invoke([&](auto &name, auto &&f) {
+    EXPECT_CALL(*server, registerHandler("state_subscribeStorage", _, _))
+        .WillOnce(testing::Invoke([&](auto &name, auto &&f, bool) {
           call_contexts_.emplace(std::make_pair(
               CallType::kCallType_StorageSubscribe, CallContext{.handler = f}));
         }));
-    EXPECT_CALL(*server, registerHandler("state_unsubscribeStorage", _))
-        .WillOnce(testing::Invoke([&](auto &name, auto &&f) {
+    EXPECT_CALL(*server, registerHandler("state_unsubscribeStorage", _, _))
+        .WillOnce(testing::Invoke([&](auto &name, auto &&f, bool) {
           call_contexts_.emplace(
               std::make_pair(CallType::kCallType_StorageUnsubscribe,
                              CallContext{.handler = f}));
         }));
-    EXPECT_CALL(*server, registerHandler("state_getMetadata", _))
-        .WillOnce(testing::Invoke([&](auto &name, auto &&f) {
+    EXPECT_CALL(*server, registerHandler("state_getMetadata", _, _))
+        .WillOnce(testing::Invoke([&](auto &name, auto &&f, bool) {
           call_contexts_.emplace(std::make_pair(CallType::kCallType_GetMetadata,
                                                 CallContext{.handler = f}));
         }));

--- a/test/mock/core/api/jrpc/jrpc_server_mock.hpp
+++ b/test/mock/core/api/jrpc/jrpc_server_mock.hpp
@@ -18,21 +18,21 @@ namespace kagome::api {
 
     MOCK_METHOD(void,
                 registerHandler,
-                (const std::string &name, Method method),
+                (const std::string &name, Method method, bool),
                 (override));
 
     MOCK_METHOD(std::vector<std::string>, getHandlerNames, (), (override));
 
     MOCK_METHOD(void,
                 processData,
-                (std::string_view request, const ResponseHandler &cb),
+                (std::string_view, bool, const ResponseHandler &),
                 (override));
 
     MOCK_METHOD(void,
                 processJsonData,
                 (std::string,
                  const jsonrpc::Request::Parameters &,
-                 FormatterHandler const &cb),
+                 const FormatterHandler &cb),
                 (override));
   };
 

--- a/test/mock/core/application/app_configuration_mock.hpp
+++ b/test/mock/core/application/app_configuration_mock.hpp
@@ -160,6 +160,8 @@ namespace kagome::application {
                 (const, override));
 
     MOCK_METHOD(std::string, nodeWssPem, (), (const, override));
+
+    MOCK_METHOD(std::optional<bool>, allowUnsafeRpc, (), (const, override));
   };
 
 }  // namespace kagome::application

--- a/test/mock/core/application/app_configuration_mock.hpp
+++ b/test/mock/core/application/app_configuration_mock.hpp
@@ -161,7 +161,7 @@ namespace kagome::application {
 
     MOCK_METHOD(std::string, nodeWssPem, (), (const, override));
 
-    MOCK_METHOD(std::optional<bool>, allowUnsafeRpc, (), (const, override));
+    MOCK_METHOD(AllowUnsafeRpc, allowUnsafeRpc, (), (const, override));
   };
 
 }  // namespace kagome::application


### PR DESCRIPTION
### Referenced issues
- #1570

### Description of the Change
- `allow_unsafe` for api listener and session
- `--rpc-methods`
- add zombienet flags

### Benefits
- accept zombienet flags

### Possible Drawbacks