### PR TITLE
rollback and dont push bad tx

### DIFF
--- a/core/host_api/impl/storage_extension.cpp
+++ b/core/host_api/impl/storage_extension.cpp
@@ -37,7 +37,7 @@ namespace kagome::host_api {
   void StorageExtension::reset() {
     // rollback will have value until there are opened transactions that need
     // to be closed
-    while (true) {
+    for (; transactions_ != 0; --transactions_) {
       if (auto res = storage_provider_->rollbackTransaction();
           res.has_error()) {
         if (res.error()
@@ -298,6 +298,7 @@ namespace kagome::host_api {
       logger_->error("Storage transaction start has failed: {}", res.error());
       throw std::runtime_error(res.error().message());
     }
+    ++transactions_;
   }
 
   void StorageExtension::ext_storage_commit_transaction_version_1() {
@@ -308,6 +309,7 @@ namespace kagome::host_api {
                      res.error());
       throw std::runtime_error(res.error().message());
     }
+    --transactions_;
   }
 
   void StorageExtension::ext_storage_rollback_transaction_version_1() {
@@ -317,6 +319,7 @@ namespace kagome::host_api {
       logger_->error("Storage transaction commit has failed: {}", res.error());
       throw std::runtime_error(res.error().message());
     }
+    --transactions_;
   }
 
   namespace {

--- a/core/host_api/impl/storage_extension.hpp
+++ b/core/host_api/impl/storage_extension.hpp
@@ -170,7 +170,9 @@ namespace kagome::host_api {
     storage::trie::PolkadotCodec codec_;
     log::Logger logger_;
 
-    constexpr static auto kDefaultLoggerTag = "WASM Runtime [StorageExtension]";
+    size_t transactions_ = 0;
+
+    static constexpr auto kDefaultLoggerTag = "WASM Runtime [StorageExtension]";
   };
 
 }  // namespace kagome::host_api

--- a/test/core/authorship/block_builder_test.cpp
+++ b/test/core/authorship/block_builder_test.cpp
@@ -126,8 +126,8 @@ TEST_F(BlockBuilderTest, PushWhenApplySucceedsWithFalse) {
   auto res = block_builder_->pushExtrinsic(xt);
 
   // then
-  ASSERT_TRUE(res);
+  ASSERT_FALSE(res);
   EXPECT_OUTCOME_TRUE(block, block_builder_->bake());
   ASSERT_EQ(block.header, expected_header_);
-  ASSERT_THAT(block.body, testing::Not(IsEmpty()));
+  ASSERT_THAT(block.body, IsEmpty());
 }


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- rollback bad extrinsic
- don't include bad extrinsic (even `DispatchError`) to block
- `StorageExtension` rollbacks only own transactions

### Benefits
- fix hash mismatch

### Possible Drawbacks