### PR TITLE
fix wavm try catch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "housekeeping/macos/libunwind/submodule"]
+	path = housekeeping/macos/libunwind/submodule
+	url = https://github.com/apple-oss-distributions/libunwind
+	branch = libunwind-201

--- a/housekeeping/macos/libunwind/README.md
+++ b/housekeeping/macos/libunwind/README.md
@@ -1,0 +1,23 @@
+# MacOS libunwind
+
+MacOS M1 libunwind will crash when throwing c++ exceptions (e.g. WAVM unreachable intrinsic) or getting stack trace when call stack contains WAVM generated code.
+
+## Code
+- https://github.com/apple-oss-distributions/libunwind/tree/libunwind-201
+- [libunwind-201-xpaci.patch](./libunwind-201-xpaci.patch)  
+  ```
+  patch -p1 < libunwind-201-xpaci.patch
+  ```
+
+## Build
+```
+cmake -B build submodule/libunwind
+cmake --build build
+```
+Use "build/lib/libunwind.dylib".
+
+## Use
+Add directory with "libunwind.dylib" path to `DYLD_LIBRARY_PATH`
+```
+DYLD_LIBRARY_PATH=build/lib ../../../build/test/deps/wavm/wavm_try_catch
+```

--- a/housekeeping/macos/libunwind/libunwind-201-xpaci.patch
+++ b/housekeeping/macos/libunwind/libunwind-201-xpaci.patch
@@ -1,0 +1,67 @@
+diff --git a/submodule/libunwind/src/CompactUnwinder.hpp b/submodule/libunwind/src/CompactUnwinder.hpp
+index d09e024..7f48ac6 100644
+--- a/submodule/libunwind/src/CompactUnwinder.hpp
++++ b/submodule/libunwind/src/CompactUnwinder.hpp
+@@ -609,7 +609,7 @@ int CompactUnwinder_arm64<A>::stepWithCompactEncodingFrameless(
+   registers.normalizeNewLinkRegister(linkRegister, procInfoFlags);
+ 
+   // set pc to be value in lr
+-  registers.setIP(linkRegister);
++  registers.setIP(__unw_xpaci(linkRegister));
+ 
+   return UNW_STEP_SUCCESS;
+ }
+@@ -695,7 +695,7 @@ int CompactUnwinder_arm64<A>::stepWithCompactEncodingFrame(
+ 
+   registers.normalizeNewLinkRegister(linkRegister, procInfoFlags);
+ 
+-  registers.setIP(linkRegister);
++  registers.setIP(__unw_xpaci(linkRegister));
+ 
+   return UNW_STEP_SUCCESS;
+ }
+diff --git a/submodule/libunwind/src/DwarfInstructions.hpp b/submodule/libunwind/src/DwarfInstructions.hpp
+index 5b5e00e..ff489e9 100644
+--- a/submodule/libunwind/src/DwarfInstructions.hpp
++++ b/submodule/libunwind/src/DwarfInstructions.hpp
+@@ -268,7 +268,7 @@ int DwarfInstructions<A, R>::stepWithDwarf(A &addressSpace, pint_t pc,
+ 
+       // Return address is address after call site instruction, so setting IP to
+       // that does simualates a return.
+-      newRegisters.setIP(returnAddress);
++      newRegisters.setIP(__unw_xpaci(returnAddress));
+ 
+       // Simulate the step by replacing the register set with the new ones.
+       registers = newRegisters;
+diff --git a/submodule/libunwind/src/UnwindRegistersSave.S b/submodule/libunwind/src/UnwindRegistersSave.S
+index e5a968c..ada415a 100644
+--- a/submodule/libunwind/src/UnwindRegistersSave.S
++++ b/submodule/libunwind/src/UnwindRegistersSave.S
+@@ -699,6 +699,10 @@ DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
+ 
+ #elif defined(__aarch64__)
+ 
++DEFINE_LIBUNWIND_FUNCTION(__unw_xpaci)
++  xpaci x0
++  ret
++
+ //
+ // extern int __unw_getcontext(unw_context_t* thread_state)
+ //
+diff --git a/submodule/libunwind/src/libunwind_ext.h b/submodule/libunwind/src/libunwind_ext.h
+index ba9861d..4352715 100644
+--- a/submodule/libunwind/src/libunwind_ext.h
++++ b/submodule/libunwind/src/libunwind_ext.h
+@@ -23,6 +23,12 @@
+ extern "C" {
+ #endif
+ 
++#ifdef __aarch64__
++extern uint64_t __unw_xpaci(uint64_t);
++#else
++#define __unw_xpaci(x) (x)
++#endif
++
+ extern int __unw_getcontext(unw_context_t *);
+ extern int __unw_init_local(unw_cursor_t *, unw_context_t *);
+ extern int __unw_step(unw_cursor_t *);

--- a/test/deps/CMakeLists.txt
+++ b/test/deps/CMakeLists.txt
@@ -6,5 +6,6 @@ target_link_libraries(outcome_test
 
 addtest(di_test di_test.cpp)
 
-
+add_subdirectory(binaryen)
+add_subdirectory(wavm)
 add_subdirectory(rocksdb)

--- a/test/deps/wavm/CMakeLists.txt
+++ b/test/deps/wavm/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Copyright Soramitsu Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+add_executable(wavm_try_catch
+    try_catch.cpp
+    )
+target_link_libraries(wavm_try_catch
+    WAVM::libWAVM
+    )

--- a/test/deps/wavm/try_catch.cpp
+++ b/test/deps/wavm/try_catch.cpp
@@ -1,0 +1,80 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// See ../../../housekeeping/macos/libunwind/README.md
+
+#ifndef WAVM_API
+#define WAVM_API
+#endif
+
+#include <WAVM/IR/Module.h>
+#include <WAVM/Runtime/Runtime.h>
+#include <WAVM/RuntimeABI/RuntimeABI.h>
+#include <WAVM/WASTParse/WASTParse.h>
+#include <cassert>
+#include <cstdio>
+
+struct Wasm {
+  static void unreachable() {
+    WAVM::Runtime::throwException(
+        WAVM::Runtime::ExceptionTypes::reachedUnreachable);
+  }
+
+  Wasm(const std::string &wast) {
+    std::vector<WAVM::WAST::Error> wast_errors;
+    if (not WAVM::WAST::parseModule(
+            wast.data(), wast.size() + 1, module_ir_, wast_errors)) {
+      WAVM::WAST::reportParseErrors("wast", wast.data(), wast_errors);
+      abort();
+    }
+    module_ref_ = WAVM::Runtime::compileModule(module_ir_);
+    assert(module_ref_);
+    compartment_ = WAVM::Runtime::createCompartment();
+    instance_ =
+        WAVM::Runtime::instantiateModule(compartment_, module_ref_, {}, "");
+    assert(instance_);
+    fn_ = WAVM::Runtime::asFunction(
+        WAVM::Runtime::getInstanceExport(instance_, "main"));
+    assert(fn_);
+    context_ = WAVM::Runtime::createContext(compartment_);
+  }
+
+  void call() {
+    WAVM::Runtime::invokeFunction(context_, fn_);
+  }
+
+  WAVM::IR::Module module_ir_;
+  WAVM::Runtime::ModuleRef module_ref_;
+  WAVM::Runtime::Compartment *compartment_;
+  WAVM::Runtime::Instance *instance_;
+  WAVM::Runtime::Function *fn_;
+  WAVM::Runtime::Context *context_;
+};
+
+int main() {
+  // Can catch wavm unreachable exception?
+  printf("unreachable: throw\n");
+  try {
+    Wasm::unreachable();
+  } catch (WAVM::Runtime::Exception *) {
+    printf("unreachable: catch\n");
+  }
+
+  // Can catch wavm unreachable exception from wasm call stack?
+  // MacOS M1 libunwind crashes.
+  Wasm wasm{R"wast(
+    (module
+      (func (export "main")
+        unreachable
+      )
+    )
+  )wast"};
+  printf("wasm: call\n");
+  try {
+    wasm.call();
+  } catch (WAVM::Runtime::Exception *) {
+    printf("wasm: catch\n");
+  }
+}


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- Couldn't catch WAVM exceptions on MacOS M1.
- Add test for reproduction.
- Add housekeeping/macos/libunwind (fix libunwind).

### Benefits
- Catch WAVM exceptions.

### Possible Drawbacks
- Copy of libunwind code.