### PR TITLE
Restrict neighbor messages processing when sync

### DIFF
--- a/core/consensus/grandpa/impl/grandpa_impl.cpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.cpp
@@ -7,6 +7,7 @@
 
 #include <libp2p/basic/scheduler/asio_scheduler_backend.hpp>
 #include <libp2p/basic/scheduler/scheduler_impl.hpp>
+#include <utility>
 
 #include "application/app_state_manager.hpp"
 #include "application/chain_spec.hpp"
@@ -78,6 +79,7 @@ namespace kagome::consensus::grandpa {
       std::shared_ptr<network::PeerManager> peer_manager,
       std::shared_ptr<blockchain::BlockTree> block_tree,
       std::shared_ptr<network::ReputationRepository> reputation_repository,
+      primitives::events::BabeStateSubscriptionEnginePtr babe_status_observable,
       std::shared_ptr<boost::asio::io_context> main_thread_context)
       : round_time_factor_{getGossipDuration(chain_spec)},
         hasher_{std::move(hasher)},
@@ -93,6 +95,7 @@ namespace kagome::consensus::grandpa {
         peer_manager_(std::move(peer_manager)),
         block_tree_(std::move(block_tree)),
         reputation_repository_(std::move(reputation_repository)),
+        babe_status_observable_(std::move(babe_status_observable)),
         execution_thread_pool_{std::make_shared<ThreadPool>(1ull)},
         internal_thread_context_{execution_thread_pool_->handler()},
         main_thread_context_{std::move(main_thread_context)},
@@ -108,6 +111,7 @@ namespace kagome::consensus::grandpa {
     BOOST_ASSERT(synchronizer_ != nullptr);
     BOOST_ASSERT(peer_manager_ != nullptr);
     BOOST_ASSERT(block_tree_ != nullptr);
+    BOOST_ASSERT(babe_status_observable_ != nullptr);
     BOOST_ASSERT(reputation_repository_ != nullptr);
 
     BOOST_ASSERT(app_state_manager != nullptr);
@@ -128,6 +132,26 @@ namespace kagome::consensus::grandpa {
   bool GrandpaImpl::prepare() {
     // Set themselves in environment
     environment_->setJustificationObserver(shared_from_this());
+
+    babe_status_observer_ =
+        std::make_shared<primitives::events::BabeStateEventSubscriber>(
+            babe_status_observable_, false);
+    babe_status_observer_->subscribe(
+        babe_status_observer_->generateSubscriptionSetId(),
+        primitives::events::BabeStateEventType::kSyncState);
+    babe_status_observer_->setCallback(
+        [wself{weak_from_this()}](
+            auto /*set_id*/,
+            bool &synchronized,
+            auto /*event_type*/,
+            const primitives::events::BabeStateEventParams &event) {
+          if (auto self = wself.lock()) {
+            if (event == babe::Babe::State::SYNCHRONIZED) {
+              self->synchronized_once_ = true;
+            }
+          }
+        });
+
     internal_thread_context_->start();
     main_thread_context_.start();
     return true;
@@ -419,19 +443,6 @@ namespace kagome::consensus::grandpa {
 
     auto info = peer_manager_->getPeerState(peer_id);
 
-    // Iff peer just reached one of recent round, then share known votes
-    if (not info.has_value()
-        or (info->get().set_id.has_value()
-            and msg.voter_set_id != info->get().set_id)
-        or (info->get().round_number.has_value()
-            and msg.round_number > info->get().round_number)) {
-      if (auto opt_round = selectRound(msg.round_number, msg.voter_set_id);
-          opt_round.has_value()) {
-        auto &round = opt_round.value();
-        environment_->sendState(peer_id, round->state(), msg.voter_set_id);
-      }
-    }
-
     bool reputation_changed = false;
     if (info.has_value() and info->get().set_id.has_value()
         and info->get().round_number.has_value()) {
@@ -459,6 +470,23 @@ namespace kagome::consensus::grandpa {
     if (not reputation_changed) {
       reputation_repository_->change(
           peer_id, network::reputation::benefit::NEIGHBOR_MESSAGE);
+    }
+
+    // Iff peer just reached one of recent round, then share known votes
+    if (not info.has_value()
+        or (info->get().set_id.has_value()
+            and msg.voter_set_id != info->get().set_id)
+        or (info->get().round_number.has_value()
+            and msg.round_number > info->get().round_number)) {
+      if (auto opt_round = selectRound(msg.round_number, msg.voter_set_id);
+          opt_round.has_value()) {
+        auto &round = opt_round.value();
+        environment_->sendState(peer_id, round->state(), msg.voter_set_id);
+      }
+    }
+
+    if (not synchronized_once_) {
+      return;
     }
 
     // If peer has the same voter set id

--- a/core/consensus/grandpa/impl/grandpa_impl.cpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.cpp
@@ -147,7 +147,7 @@ namespace kagome::consensus::grandpa {
             const primitives::events::BabeStateEventParams &event) {
           if (auto self = wself.lock()) {
             if (event == babe::Babe::State::SYNCHRONIZED) {
-              self->synchronized_once_.test_and_set();
+              self->synchronized_once_.store(true);
             }
           }
         });
@@ -485,7 +485,7 @@ namespace kagome::consensus::grandpa {
       }
     }
 
-    if (synchronized_once_.test()) {
+    if (not synchronized_once_.load()) {
       return;
     }
 

--- a/core/consensus/grandpa/impl/grandpa_impl.cpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.cpp
@@ -147,7 +147,7 @@ namespace kagome::consensus::grandpa {
             const primitives::events::BabeStateEventParams &event) {
           if (auto self = wself.lock()) {
             if (event == babe::Babe::State::SYNCHRONIZED) {
-              self->synchronized_once_ = true;
+              self->synchronized_once_.test_and_set();
             }
           }
         });
@@ -472,7 +472,7 @@ namespace kagome::consensus::grandpa {
           peer_id, network::reputation::benefit::NEIGHBOR_MESSAGE);
     }
 
-    // Iff peer just reached one of recent round, then share known votes
+    // If peer just reached one of recent round, then share known votes
     if (not info.has_value()
         or (info->get().set_id.has_value()
             and msg.voter_set_id != info->get().set_id)
@@ -485,7 +485,7 @@ namespace kagome::consensus::grandpa {
       }
     }
 
-    if (not synchronized_once_) {
+    if (synchronized_once_.test()) {
       return;
     }
 

--- a/core/consensus/grandpa/impl/grandpa_impl.hpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.hpp
@@ -315,11 +315,11 @@ namespace kagome::consensus::grandpa {
     primitives::events::BabeStateSubscriptionEnginePtr babe_status_observable_;
     primitives::events::BabeStateEventSubscriberPtr babe_status_observer_;
 
-    std::atomic_flag synchronized_once_ =
-        ATOMIC_FLAG_INIT;  // declares if initial sync was done, does not
-                           // necessarily mean that node is currently synced.
-                           // Needed for enabling neighbor message processing.
-                           // By default is false
+    std::atomic_bool synchronized_once_ =
+        false;  // declares if initial sync was done, does not
+                // necessarily mean that node is currently synced.
+                // Needed for enabling neighbor message processing.
+                // By default is false
 
     std::shared_ptr<ThreadPool> execution_thread_pool_;
     std::shared_ptr<ThreadHandler> internal_thread_context_;

--- a/core/consensus/grandpa/impl/grandpa_impl.hpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.hpp
@@ -9,6 +9,7 @@
 #include "consensus/grandpa/grandpa.hpp"
 #include "consensus/grandpa/grandpa_observer.hpp"
 
+#include <atomic>
 #include <boost/asio/io_context.hpp>
 #include <libp2p/basic/scheduler.hpp>
 
@@ -314,10 +315,11 @@ namespace kagome::consensus::grandpa {
     primitives::events::BabeStateSubscriptionEnginePtr babe_status_observable_;
     primitives::events::BabeStateEventSubscriberPtr babe_status_observer_;
 
-    bool synchronized_once_{
-        false};  // declares if initial sync was done, does not necessarily mean
-                 // that node is currently synced. Needed for enabling neighbor
-                 // message processing
+    std::atomic_flag synchronized_once_ =
+        ATOMIC_FLAG_INIT;  // declares if initial sync was done, does not
+                           // necessarily mean that node is currently synced.
+                           // Needed for enabling neighbor message processing.
+                           // By default is false
 
     std::shared_ptr<ThreadPool> execution_thread_pool_;
     std::shared_ptr<ThreadHandler> internal_thread_context_;

--- a/core/consensus/grandpa/impl/grandpa_impl.hpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.hpp
@@ -14,6 +14,7 @@
 
 #include "log/logger.hpp"
 #include "metrics/metrics.hpp"
+#include "primitives/event_types.hpp"
 #include "utils/safe_object.hpp"
 #include "utils/thread_pool.hpp"
 
@@ -104,6 +105,8 @@ namespace kagome::consensus::grandpa {
         std::shared_ptr<network::PeerManager> peer_manager,
         std::shared_ptr<blockchain::BlockTree> block_tree,
         std::shared_ptr<network::ReputationRepository> reputation_repository,
+        primitives::events::BabeStateSubscriptionEnginePtr
+            babe_status_observable,
         std::shared_ptr<boost::asio::io_context> main_thread_context);
 
     /**
@@ -308,6 +311,13 @@ namespace kagome::consensus::grandpa {
     std::shared_ptr<network::PeerManager> peer_manager_;
     std::shared_ptr<blockchain::BlockTree> block_tree_;
     std::shared_ptr<network::ReputationRepository> reputation_repository_;
+    primitives::events::BabeStateSubscriptionEnginePtr babe_status_observable_;
+    primitives::events::BabeStateEventSubscriberPtr babe_status_observer_;
+
+    bool synchronized_once_{
+        false};  // declares if initial sync was done, does not necessarily mean
+                 // that node is currently synced. Needed for enabling neighbor
+                 // message processing
 
     std::shared_ptr<ThreadPool> execution_thread_pool_;
     std::shared_ptr<ThreadHandler> internal_thread_context_;

--- a/node/main.cpp
+++ b/node/main.cpp
@@ -34,6 +34,11 @@ int main(int argc, const char **argv) {
 #if defined(BACKWARD_HAS_BACKTRACE)
   backward::SignalHandling sh;
 #endif
+
+  // Needed for zombienet
+  setvbuf(stdout, nullptr, _IOLBF, 0);
+  setvbuf(stderr, nullptr, _IOLBF, 0);
+
   {
     soralog::util::setThreadName("kagome");
 


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

When KAGOME observes neighbor message we do the following:
1. Update state of remote peer about their most recent round
2. Send them our current state (our round number)
3. If we identify that remote peer is far in the future by the finalized block, we send justification sync request. 

2 and 3 is redundant if our node has never been synchronized (for example during fast sync).

### Description of the Change

* We only start sending our neighbor messages (with our state) and justification sync requests only when we synchronized at least once.
* In addition to that we are fixing bufferization of stdout/stderr for #1595 (not related to the main fix in PR)

### Benefits

Less bandwidth

### Possible Drawbacks 

None
