### PR TITLE
Revert "Enable parachains only if synchronized (#1566)"

### DIFF
--- a/core/parachain/validator/impl/parachain_processor.cpp
+++ b/core/parachain/validator/impl/parachain_processor.cpp
@@ -147,13 +147,10 @@ namespace kagome::parachain {
                                            bool &synchronized,
                                            auto /*event_type*/,
                                            const primitives::events::
-                                               BabeStateEventParams &event) {
+                                               BabeStateEventParams
+                                                   & /*event*/) {
       if (auto self = wself.lock()) {
-        if (event != consensus::babe::Babe::State::SYNCHRONIZED) {
-          SL_INFO(self->logger_, "Parachains engine turned-off");
-          synchronized = false;
-        } else if (!synchronized) {
-          SL_INFO(self->logger_, "Parachains engine turned-on");
+        if (!synchronized) {
           synchronized = true;
           auto my_view = self->peer_view_->getMyView();
           if (!my_view) {
@@ -436,10 +433,6 @@ namespace kagome::parachain {
   void ParachainProcessorImpl::onValidationProtocolMsg(
       const libp2p::peer::PeerId &peer_id,
       const network::ValidatorProtocolMessage &message) {
-    if (auto r = canProcessParachains(); r.has_error()) {
-      return;
-    }
-
     if (auto m{boost::get<network::BitfieldDistributionMessage>(&message)}) {
       auto bd{boost::get<network::BitfieldDistribution>(m)};
       BOOST_ASSERT_MSG(

--- a/core/parachain/validator/impl/parachain_processor.cpp
+++ b/core/parachain/validator/impl/parachain_processor.cpp
@@ -433,6 +433,10 @@ namespace kagome::parachain {
   void ParachainProcessorImpl::onValidationProtocolMsg(
       const libp2p::peer::PeerId &peer_id,
       const network::ValidatorProtocolMessage &message) {
+    if (auto r = canProcessParachains(); r.has_error()) {
+      return;
+    }
+
     if (auto m{boost::get<network::BitfieldDistributionMessage>(&message)}) {
       auto bd{boost::get<network::BitfieldDistribution>(m)};
       BOOST_ASSERT_MSG(


### PR DESCRIPTION
This reverts commit ee75e517053a91564e2f4194f87363185bfd0ac4.

Signed-off-by: iceseer <iceseer@gmail.com>

### Description of the Change
Parachains always turned-on since synchnonized once.