### PR TITLE
Fix audi publish

### DIFF
--- a/core/authority_discovery/publisher/address_publisher.cpp
+++ b/core/authority_discovery/publisher/address_publisher.cpp
@@ -85,7 +85,7 @@ namespace kagome::authority_discovery {
   }
 
   outcome::result<void> AddressPublisher::publishOwnAddress() {
-    auto addresses = host_.getAddresses();
+    auto addresses = host_.getPeerInfo().addresses;
     // TODO(turuslan): #1357, filter local addresses
     if (addresses.empty()) {
       SL_ERROR(log_, "No listening addresses");

--- a/core/network/impl/peer_manager_impl.cpp
+++ b/core/network/impl/peer_manager_impl.cpp
@@ -120,7 +120,6 @@ namespace kagome::network {
       log_->critical(
           "Does not have any bootstrap nodes. "
           "Provide them by chain spec or CLI argument `--bootnodes'");
-      return false;
     }
 
     return true;

--- a/core/network/impl/peer_manager_impl.cpp
+++ b/core/network/impl/peer_manager_impl.cpp
@@ -34,8 +34,8 @@ namespace {
 
   template <typename P, typename F>
   bool openOutgoing(std::shared_ptr<kagome::network::StreamEngine> &se,
-                    std::shared_ptr<P> const &protocol,
-                    kagome::network::PeerManager::PeerInfo const &pi,
+                    const std::shared_ptr<P> &protocol,
+                    const kagome::network::PeerManager::PeerInfo &pi,
                     F &&func) {
     BOOST_ASSERT(se);
     BOOST_ASSERT(protocol);
@@ -255,7 +255,7 @@ namespace kagome::network {
 
   void PeerManagerImpl::setCollating(
       const PeerId &peer_id,
-      network::CollatorPublicKey const &collator_id,
+      const network::CollatorPublicKey &collator_id,
       network::ParachainId para_id) {
     if (auto it = peer_states_.find(peer_id); it != peer_states_.end()) {
       it->second.collator_state =
@@ -272,7 +272,7 @@ namespace kagome::network {
   }
 
   outcome::result<
-      std::pair<network::CollatorPublicKey const &, network::ParachainId>>
+      std::pair<const network::CollatorPublicKey &, network::ParachainId>>
   PeerManagerImpl::retrieveCollatorData(
       PeerState &peer_state, const primitives::BlockHash &relay_parent) {
     if (!peer_state.collator_state) {
@@ -300,15 +300,15 @@ namespace kagome::network {
     std::vector<ItemType> peers_list;
     peers_list.reserve(active_peers_.size());
 
-    uint64_t const now_ms =
+    const uint64_t now_ms =
         std::chrono::time_point_cast<std::chrono::milliseconds>(clock_->now())
             .time_since_epoch()
             .count();
-    uint64_t const idle_ms =
+    const uint64_t idle_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(peer_ttl).count();
 
     for (const auto &[peer_id, desc] : active_peers_) {
-      uint64_t const last_activity_ms =
+      const uint64_t last_activity_ms =
           std::chrono::time_point_cast<std::chrono::milliseconds>(
               desc.time_point)
               .time_since_epoch()
@@ -333,7 +333,7 @@ namespace kagome::network {
 
     std::sort(peers_list.begin(),
               peers_list.end(),
-              [](auto const &l, auto const &r) { return r.first < l.first; });
+              [](const auto &l, const auto &r) { return r.first < l.first; });
 
     for (; !peers_list.empty()
            && (peers_list.size() > hard_limit
@@ -585,8 +585,8 @@ namespace kagome::network {
 
   template <typename F>
   void PeerManagerImpl::openBlockAnnounceProtocol(
-      PeerInfo const &peer_info,
-      libp2p::network::ConnectionManager::ConnectionSPtr const &connection,
+      const PeerInfo &peer_info,
+      const libp2p::network::ConnectionManager::ConnectionSPtr &connection,
       F &&opened_callback) {
     auto block_announce_protocol = router_->getBlockAnnounceProtocol();
     BOOST_ASSERT_MSG(block_announce_protocol,
@@ -665,7 +665,7 @@ namespace kagome::network {
     }
   }
 
-  void PeerManagerImpl::tryOpenGrandpaProtocol(PeerInfo const &peer_info,
+  void PeerManagerImpl::tryOpenGrandpaProtocol(const PeerInfo &peer_info,
                                                PeerState &r_info) {
     if (auto o_info_opt = getPeerState(own_peer_info_.id);
         o_info_opt.has_value()) {
@@ -683,7 +683,7 @@ namespace kagome::network {
     }
   }
 
-  void PeerManagerImpl::tryOpenValidationProtocol(PeerInfo const &peer_info,
+  void PeerManagerImpl::tryOpenValidationProtocol(const PeerInfo &peer_info,
                                                   PeerState &peer_state) {
     /// If validator start validation protocol
     if (peer_state.roles.flags.authority) {
@@ -786,7 +786,7 @@ namespace kagome::network {
         peer_info,
         connection,
         [](std::shared_ptr<PeerManagerImpl> &self,
-           PeerInfo const &peer_info,
+           const PeerInfo &peer_info,
            std::optional<std::reference_wrapper<PeerState>> peer_state) {
           if (peer_state.has_value()) {
             self->tryOpenGrandpaProtocol(peer_info, peer_state.value().get());

--- a/test/core/authority_discovery/address_publisher_test.cpp
+++ b/test/core/authority_discovery/address_publisher_test.cpp
@@ -37,6 +37,8 @@ using libp2p::HostMock;
 using libp2p::basic::SchedulerMock;
 using libp2p::crypto::marshaller::KeyMarshallerMock;
 using libp2p::multi::Multiaddress;
+using libp2p::peer::PeerId;
+using libp2p::peer::PeerInfo;
 using libp2p::protocol::kademlia::KademliaMock;
 using testing::_;
 using testing::Return;
@@ -53,7 +55,8 @@ struct AddressPublisherTest : public testing::Test {
     libp2p_key_.privateKey.type = libp2p::crypto::Key::Type::Ed25519;
     libp2p_key_.privateKey.data.resize(Ed25519PrivateKey::size());
     libp2p_key_.publicKey.data.resize(Ed25519PublicKey::size());
-    addresses_.push_back(Multiaddress::create("/ip4/127.0.0.1").value());
+    peer_info_.addresses.push_back(
+        Multiaddress::create("/ip4/127.0.0.1").value());
 
     EXPECT_CALL(*app_state_manager_, atLaunch(_));
     EXPECT_CALL(*key_marshaller_, marshal(libp2p_key_.publicKey))
@@ -95,7 +98,11 @@ struct AddressPublisherTest : public testing::Test {
   std::shared_ptr<SchedulerMock> scheduler_ = std::make_shared<SchedulerMock>();
   std::shared_ptr<CryptoStoreMock> crypto_store_ =
       std::make_shared<CryptoStoreMock>();
-  std::vector<Multiaddress> addresses_;
+  PeerInfo peer_info_{
+      PeerId::fromBase58("12D3KooWGYLoNGrZn2nwewBiPFZuKHZebPDL9QAF26cVgLxwuiTZ")
+          .value(),
+      {}};
+
   Sr25519PublicKey audi_key_;
   std::shared_ptr<AddressPublisher> publisher_;
 };
@@ -106,7 +113,7 @@ struct AddressPublisherTest : public testing::Test {
  * @then success
  */
 TEST_F(AddressPublisherTest, Success) {
-  EXPECT_CALL(*host_, getAddresses()).WillOnce(Return(addresses_));
+  EXPECT_CALL(*host_, getPeerInfo()).WillOnce(Return(peer_info_));
   EXPECT_CALL(*crypto_store_, getSr25519PublicKeys(_))
       .WillOnce(Return(std::vector{audi_key_}));
   EXPECT_CALL(*crypto_store_, findSr25519Keypair(_, _))


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- don't exit if there is no bootstrap peers
- audi publish [all addresses](https://github.com/libp2p/cpp-libp2p/blob/3c5276de3429c3500b6e308241581c79bfdf4f43/src/host/basic_host/basic_host.cpp#L44-L47)

### Benefits
- maybe collation will work on production server with `--public-addr`

### Possible Drawbacks