### PR TITLE
fix rpc timeout

### DIFF
--- a/core/api/transport/impl/ws/ws_session.cpp
+++ b/core/api/transport/impl/ws/ws_session.cpp
@@ -285,6 +285,7 @@ namespace kagome::api {
         stream_.next_layer().buffer(),
         http_request_->get(),
         [self{shared_from_this()}](boost::system::error_code ec, size_t) {
+          self->stream_.next_layer().next_layer().expires_never();
           if (ec) {
             self->httpClose();
             return;
@@ -313,10 +314,12 @@ namespace kagome::api {
 
   void WsSession::httpWrite() {
     http_response_->prepare_payload();
+    stream_.next_layer().next_layer().expires_after(config_.operation_timeout);
     boost::beast::http::async_write(
         stream_.next_layer(),
         *http_response_,
         [self = shared_from_this()](boost::system::error_code ec, size_t) {
+          self->stream_.next_layer().next_layer().expires_never();
           if (ec) {
             self->httpClose();
             return;


### PR DESCRIPTION
### Referenced issues
- #1614

### Description of the Change
- fix session timeout (bug from `HttpSession`)

### Benefits
- rpc doesn't disconnect after 30 seconds

### Possible Drawbacks