### PR TITLE
Implement db-cache cmd line parameter

### DIFF
--- a/core/application/app_configuration.hpp
+++ b/core/application/app_configuration.hpp
@@ -253,6 +253,11 @@ namespace kagome::application {
     virtual StorageBackend storageBackend() const = 0;
 
     /**
+     * @return database state cache size in MiB
+     */
+    virtual uint32_t dbCacheSize() const = 0;
+
+    /**
      * Optional phrase to use dev account (e.g. Alice and Bob)
      */
     virtual std::optional<std::string_view> devMnemonicPhrase() const = 0;

--- a/core/application/impl/app_configuration_impl.cpp
+++ b/core/application/impl/app_configuration_impl.cpp
@@ -98,6 +98,7 @@ namespace {
   const uint32_t def_random_walk_interval = 15;
   const auto def_full_sync = "Full";
   const auto def_wasm_execution = "Interpreted";
+  const uint32_t def_db_cache_size = 1024;
 
   /**
    * Generate once at run random node name if form of UUID
@@ -419,6 +420,7 @@ namespace kagome::application {
         exit(EXIT_FAILURE);
       }
     }
+    load_u32(val, "db-cache", db_cache_size_);
   }
 
   void AppConfigurationImpl::parse_network_segment(
@@ -775,6 +777,7 @@ namespace kagome::application {
         ("keystore", po::value<std::string>(), "required, node keystore")
         ("tmp", "Use temporary storage path")
         ("database", po::value<std::string>()->default_value("rocksdb"), "Database backend to use [rocksdb]")
+        ("db-cache", po::value<uint32_t>()->default_value(def_db_cache_size), "Limit the memory the database cache can use <MiB>")
         ("enable-offchain-indexing", po::value<bool>(), "enable Offchain Indexing API, which allow block import to write to offchain DB)")
         ("recovery", po::value<std::string>(), "recovers block storage to state after provided block presented by number or hash, and stop after that")
         ;
@@ -1035,6 +1038,8 @@ namespace kagome::application {
     if (unknown_database_engine_is_set) {
       return false;
     }
+    find_argument<uint32_t>(
+        vm, "db-cache", [&](uint32_t val) { db_cache_size_ = val; });
 
     std::vector<std::string> boot_nodes;
     find_argument<std::vector<std::string>>(

--- a/core/application/impl/app_configuration_impl.hpp
+++ b/core/application/impl/app_configuration_impl.hpp
@@ -181,6 +181,9 @@ namespace kagome::application {
     StorageBackend storageBackend() const override {
       return storage_backend_;
     }
+    uint32_t dbCacheSize() const override {
+      return db_cache_size_;
+    }
     std::optional<std::string_view> devMnemonicPhrase() const override {
       if (dev_mnemonic_phrase_) {
         return *dev_mnemonic_phrase_;
@@ -333,6 +336,7 @@ namespace kagome::application {
     std::optional<Subcommand> subcommand_;
     std::optional<primitives::BlockId> recovery_state_;
     StorageBackend storage_backend_ = StorageBackend::RocksDB;
+    uint32_t db_cache_size_;
     std::optional<std::string> dev_mnemonic_phrase_;
     std::string node_wss_pem_;
     std::optional<BenchmarkConfigSection> benchmark_config_;

--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -201,7 +201,6 @@ namespace {
 
     auto options = rocksdb::Options{};
     options.create_if_missing = true;
-    options.create_missing_column_families = true;
     options.optimize_filters_for_hits = true;
     options.table_factory.reset(rocksdb::NewBlockBasedTableFactory(
         storage::RocksDb::tableOptionsConfiguration()));

--- a/core/storage/rocksdb/rocksdb.cpp
+++ b/core/storage/rocksdb/rocksdb.cpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <iostream>
+
 #include "storage/rocksdb/rocksdb.hpp"
 #include <rocksdb/filter_policy.h>
 #include <rocksdb/table.h>
@@ -70,6 +72,8 @@ namespace kagome::storage {
 
     std::vector<rocksdb::ColumnFamilyHandle *> column_family_handles;
 
+    std::cout << (int) options.create_missing_column_families << std::endl;
+    options.create_missing_column_families = true;
     auto rocks_db = std::shared_ptr<RocksDb>(new RocksDb);
     auto status = rocksdb::DB::Open(options,
                                     path.native(),
@@ -146,7 +150,6 @@ namespace kagome::storage {
   rocksdb::ColumnFamilyOptions RocksDb::configureColumn(
       uint32_t memory_budget) {
     rocksdb::ColumnFamilyOptions options;
-    options.level_compaction_dynamic_level_bytes = true;
     options.OptimizeLevelStyleCompaction(memory_budget);
     auto table_options = tableOptionsConfiguration(kDefaultLruCacheSizeMiB,
                                                    kDefaultBlockSizeKiB);

--- a/core/storage/rocksdb/rocksdb.cpp
+++ b/core/storage/rocksdb/rocksdb.cpp
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <iostream>
-
 #include "storage/rocksdb/rocksdb.hpp"
 #include <rocksdb/filter_policy.h>
 #include <rocksdb/table.h>
@@ -72,7 +70,6 @@ namespace kagome::storage {
 
     std::vector<rocksdb::ColumnFamilyHandle *> column_family_handles;
 
-    std::cout << (int) options.create_missing_column_families << std::endl;
     options.create_missing_column_families = true;
     auto rocks_db = std::shared_ptr<RocksDb>(new RocksDb);
     auto status = rocksdb::DB::Open(options,
@@ -151,8 +148,7 @@ namespace kagome::storage {
       uint32_t memory_budget) {
     rocksdb::ColumnFamilyOptions options;
     options.OptimizeLevelStyleCompaction(memory_budget);
-    auto table_options = tableOptionsConfiguration(kDefaultLruCacheSizeMiB,
-                                                   kDefaultBlockSizeKiB);
+    auto table_options = tableOptionsConfiguration();
     options.table_factory.reset(NewBlockBasedTableFactory(table_options));
     return options;
   }

--- a/test/core/application/app_config_test.cpp
+++ b/test/core/application/app_config_test.cpp
@@ -637,3 +637,21 @@ TEST_F(AppConfigurationTest, SetRandomWalk) {
   ASSERT_TRUE(app_config_->initializeFromArgs(std::size(args), args));
   ASSERT_EQ(app_config_->getRandomWalkInterval(), std::chrono::seconds(30));
 }
+
+/**
+ * @given an instance of AppConfigurationImpl
+ * @when --db-cache flag is specified with a value
+ * @then the value is correctly passed to the program
+ */
+TEST_F(AppConfigurationTest, SetDbCacheSize) {
+  const char *args[] = {"/path/",
+                        "--chain",
+                        chain_path.native().c_str(),
+                        "--base-path",
+                        base_path.native().c_str(),
+                        "--db-cache",
+                        "30"};
+
+  ASSERT_TRUE(app_config_->initializeFromArgs(std::size(args), args));
+  ASSERT_EQ(app_config_->dbCacheSize(), 30);
+}

--- a/test/mock/core/application/app_configuration_mock.hpp
+++ b/test/mock/core/application/app_configuration_mock.hpp
@@ -146,6 +146,8 @@ namespace kagome::application {
 
     MOCK_METHOD(StorageBackend, storageBackend, (), (const, override));
 
+    MOCK_METHOD(uint32_t, dbCacheSize, (), (const, override));
+
     MOCK_METHOD(std::optional<std::string_view>,
                 devMnemonicPhrase,
                 (),


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

Resolves #1515

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change

Add `--db-cache` parameter to configure database state cache size. Values are in MiB.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

A step towards more compatibility with substrate

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

(to be confirmed) database binary compatibility is an open question

### Usage Examples or Tests <!-- Optional -->

```
./kagome --base-path node1 --chain polkadot.json --db-cache 1024
```
