### PR TITLE
Add first zombienet tests

### DIFF
--- a/zombienet/0001-parachains-smoke-test/0001-parachains-smoke-test.toml
+++ b/zombienet/0001-parachains-smoke-test/0001-parachains-smoke-test.toml
@@ -1,0 +1,33 @@
+[settings]
+timeout = 1000
+
+[relaychain]
+default_image = "docker.io/parity/polkadot:latest"
+chain = "rococo-local"
+default_command = "polkadot"
+
+  [[relaychain.nodes]]
+  name = "alice"
+  args = [ "--alice", "-lruntime=debug,parachain=trace" ]
+
+  [[relaychain.nodes]]
+  name = "bob"
+  args = [ "--bob", "-lruntime=debug,parachain=trace" ]
+  image = "soramitsu/kagome:latest"
+  command = "kagome"
+  prometheus_prefix = "kagome"
+
+[[parachains]]
+id = 100
+add_to_genesis = false
+
+  [parachains.collator]
+  name = "collator01"
+  image = "{{COL_IMAGE}}"
+  command = "adder-collator"
+  args = [ "-lruntime=debug,parachain=trace" ]
+
+[types.Header]
+number = "u64"
+parent_hash = "Hash"
+post_state = "Hash"

--- a/zombienet/0001-parachains-smoke-test/0001-parachains-smoke-test.zndsl
+++ b/zombienet/0001-parachains-smoke-test/0001-parachains-smoke-test.zndsl
@@ -1,0 +1,8 @@
+Description: Smoke Test
+Network: ./0001-parachains-smoke-test.toml
+Creds: config
+
+alice: is up
+bob: is up
+bob: parachain 100 is registered within 225 seconds
+bob: parachain 100 block height is at least 10 within 200 seconds

--- a/zombienet/0002-parachains-upgrade-smoke-tests/0002-parachains-upgrade-smoke-test.toml
+++ b/zombienet/0002-parachains-upgrade-smoke-tests/0002-parachains-upgrade-smoke-test.toml
@@ -1,0 +1,26 @@
+[settings]
+timeout = 1000
+bootnode = true
+
+[relaychain]
+default_image = "docker.io/parity/polkadot:latest"
+chain = "rococo-local"
+default_command = "polkadot"
+
+  [[relaychain.nodes]]
+  name = "alice"
+
+  [[relaychain.nodes]]
+  name = "bob"
+  args = [ "--bob" ]
+  command = "kagome"
+  image = "soramitsu/kagome:latest"
+  prometheus_prefix = "kagome"
+
+[[parachains]]
+id = 100
+
+  [parachains.collator]
+  name = "collator01"
+  image = "docker.io/parity/polkadot-parachain:latest"
+  command = "polkadot-parachain"

--- a/zombienet/0002-parachains-upgrade-smoke-tests/0002-parachains-upgrade-smoke-test.zndsl
+++ b/zombienet/0002-parachains-upgrade-smoke-tests/0002-parachains-upgrade-smoke-test.zndsl
@@ -1,0 +1,10 @@
+Description: Smoke Test
+Network: ./0002-parachains-upgrade-smoke-test.toml
+Creds: config
+
+alice: is up
+bob: is up
+bob: parachain 100 is registered within 225 seconds
+bob: parachain 100 block height is at least 10 within 400 seconds
+bob: parachain 100 perform dummy upgrade within 300 seconds
+bob: parachain 100 block height is at least 14 within 300 seconds

--- a/zombienet/0003-parachains-smoke-test-cumulus/0003-parachains-smoke-test-cumulus.toml
+++ b/zombienet/0003-parachains-smoke-test-cumulus/0003-parachains-smoke-test-cumulus.toml
@@ -1,0 +1,42 @@
+[settings]
+timeout = 1000
+bootnode = false
+
+[relaychain]
+default_image = "docker.io/parity/polkadot:latest"
+chain = "rococo-local"
+default_command = "polkadot"
+
+[relaychain.genesis.runtime.runtime_genesis_config.configuration.config]
+  max_validators_per_core = 2
+  needed_approvals = 2
+
+  [[relaychain.nodes]]
+  name = "alice"
+
+  [[relaychain.nodes]]
+  name = "bob"
+  command = "kagome"
+  image = "soramitsu/kagome:latest"
+  prometheus_prefix = "kagome"
+
+[[parachains]]
+id = 100
+add_to_genesis = true
+
+  [[parachains.collators]]
+    name = "collator-1"
+    command = "polkadot-parachain"
+    image = "docker.io/parity/polkadot-parachain:latest"
+    args = ["-lparachain=debug"]
+
+  [[parachains.collators]]
+    name = "collator-2"
+    command = "polkadot-parachain"
+    image = "docker.io/parity/polkadot-parachain:latest"
+    args = ["-lparachain=debug"]
+
+[types.Header]
+number = "u64"
+parent_hash = "Hash"
+post_state = "Hash"

--- a/zombienet/0003-parachains-smoke-test-cumulus/0003-parachains-smoke-test-cumulus.zndsl
+++ b/zombienet/0003-parachains-smoke-test-cumulus/0003-parachains-smoke-test-cumulus.zndsl
@@ -1,0 +1,10 @@
+Description: Smoke Test
+Network: ./0003-parachains-smoke-test-cumulus.toml
+Creds: config
+
+{% set nodes = ["alice", "bob"] %}
+{% for node in nodes %}
+{{node}}: is up
+{% endfor %}
+bob: parachain 100 is registered within 225 seconds
+bob: parachain 100 block height is at least 10 within 200 seconds

--- a/zombienet/README.md
+++ b/zombienet/README.md
@@ -1,0 +1,42 @@
+# Zombienet tests
+
+## Resources
+
+* [zombienet repo](https://github.com/paritytech/zombienet)
+* [zombienet book](https://paritytech.github.io/zombienet/)
+
+## Running tests locally
+To run any test locally use the native provider (`zombienet test -p native ...`) you need first build the binaries. They are:
+
+* [cumulus](https://github.com/paritytech/cumulus)
+* [polkadot](https://github.com/paritytech/polkadot)
+
+* adder-collator -> polkadot/target/testnet/adder-collator
+* malus -> polkadot/target/testnet/malus
+* polkadot-parachain -> cumulus/target/release/polkadot-parachain
+* undying-collator -> polkadot/target/testnet/undying-collator
+
+To build them use:
+* adder-collator -> `cargo build --profile testnet -p test-parachain-adder-collator`
+* undying-collator -> `cargo build --profile testnet -p test-parachain-undying-collator`
+* malus -> `cargo build --profile testnet -p polkadot-test-malus`
+* polkadot-parachain -> `cargo build --release --bin polkadot-parachain`
+  
+You can run a test locally by executing:
+```sh
+zombienet test -p native 0001-parachains-smoke-test.zndsl
+```
+
+## Kubernetes as provider
+Using kubernetes as provider we can simply spawn this network by running:
+
+```sh
+zombienet test -p kubernetes 0001-parachains-smoke-test.zndsl
+```
+or simplier, since kubernetes is the default provider as:
+
+```sh
+zombienet test 0001-parachains-smoke-test.zndsl
+```
+
+NOTE: Add correct images for tests in confing(toml file) 


### PR DESCRIPTION
### Description of the Change

Add 3 zombienet tests. Create folder for each test. Folder contains: config file (toml) and test with checks (zndsl)

### Benefits

Tests can be included into CI to check builds

### Notes
For Devops: need to add correct images or env variables into config(toml) files
