### PR TITLE
fix prevote precommit

### DIFF
--- a/core/consensus/grandpa/impl/grandpa_impl.cpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.cpp
@@ -446,12 +446,18 @@ namespace kagome::consensus::grandpa {
              peer_id);
 
     auto info = peer_manager_->getPeerState(peer_id);
+    std::optional<VoterSetId> info_set;
+    std::optional<RoundNumber> info_round;
+    // copy values before `updatePeerState`
+    if (info) {
+      info_set = info->get().set_id;
+      info_round = info->get().round_number;
+    }
 
     bool reputation_changed = false;
-    if (info.has_value() and info->get().set_id.has_value()
-        and info->get().round_number.has_value()) {
-      const auto prev_set_id = info->get().set_id.value();
-      const auto prev_round_number = info->get().round_number.value();
+    if (info_set and info_round) {
+      const auto prev_set_id = *info_set;
+      const auto prev_round_number = *info_round;
 
       // bad order of set id
       if (msg.voter_set_id < prev_set_id) {
@@ -477,11 +483,8 @@ namespace kagome::consensus::grandpa {
     }
 
     // If peer just reached one of recent round, then share known votes
-    if (not info.has_value()
-        or (info->get().set_id.has_value()
-            and msg.voter_set_id != info->get().set_id)
-        or (info->get().round_number.has_value()
-            and msg.round_number > info->get().round_number)) {
+    if (msg.voter_set_id != info_set or not info_round
+        or msg.round_number > *info_round) {
       if (auto opt_round = selectRound(msg.round_number, msg.voter_set_id);
           opt_round.has_value()) {
         auto &round = opt_round.value();

--- a/core/consensus/grandpa/impl/voting_round_impl.hpp
+++ b/core/consensus/grandpa/impl/voting_round_impl.hpp
@@ -81,6 +81,7 @@ namespace kagome::consensus::grandpa {
       // Stages for precommit mechanism
       START_PRECOMMIT,
       PRECOMMIT_RUNS,
+      PRECOMMIT_WAITS_FOR_PREVOTES,
       END_PRECOMMIT,
 
       // Stages for waiting finalisation

--- a/core/parachain/approval/approval_distribution.cpp
+++ b/core/parachain/approval/approval_distribution.cpp
@@ -1210,6 +1210,7 @@ namespace kagome::parachain {
               "Make exhaustive validation. Candidate hash {}, validator index "
               "{}, block hash {}",
               candidate_hash,
+              validator_index,
               block_hash);
 
           runtime::ValidationCode &validation_code = *result.value();


### PR DESCRIPTION
### Referenced issues
- #1615

### Description of the Change
- Fix prevotes were not send in reply to neighbor message
- Don't precommit until receiving sufficient prevotes

### Benefits
- Finalization works

### Possible Drawbacks
- `StreamEngine` missing message queue and `GrandpaProtocol`'s initial neighbor message may prevent sending prevote
