### PR TITLE
fix audi ws

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -31,7 +31,7 @@ hunter_config(
 
 hunter_config(
     libp2p
-    VERSION 0.1.11
+    VERSION 0.1.12
     KEEP_PACKAGE_SOURCES
 )
 

--- a/cmake/Hunter/hunter-gate-url.cmake
+++ b/cmake/Hunter/hunter-gate-url.cmake
@@ -1,5 +1,5 @@
 HunterGate(
-  URL  "https://github.com/soramitsu/soramitsu-hunter/archive/refs/tags/v0.23.257-soramitsu48.zip"
-  SHA1 "1f5e4196684cc8997bffcdd06715eede1070930d"
+  URL  "https://github.com/soramitsu/soramitsu-hunter/archive/refs/tags/v0.23.257-soramitsu50.zip"
+  SHA1 "de462e98481cf4d0d3a355797456bf96e66f7c99"
   LOCAL
 )


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- fix libp2p publishing broken ws address (zombienet uses libp2p ws transport by default)
- add peer id to audi addresses

### Benefits
- better zombienet parachain compatibility

### Possible Drawbacks