### PR TITLE
Performace fixups

### DIFF
--- a/cmake/Hunter/hunter-gate-url.cmake
+++ b/cmake/Hunter/hunter-gate-url.cmake
@@ -1,5 +1,5 @@
 HunterGate(
-  URL  "https://github.com/soramitsu/soramitsu-hunter/archive/refs/tags/v0.23.257-soramitsu50.zip"
-  SHA1 "de462e98481cf4d0d3a355797456bf96e66f7c99"
+  URL  "https://github.com/soramitsu/soramitsu-hunter/archive/refs/tags/v0.23.257-soramitsu51.zip"
+  SHA1 "1839ed95f13509c4767216ee17b9793798e08a6f"
   LOCAL
 )

--- a/core/common/buffer_view.hpp
+++ b/core/common/buffer_view.hpp
@@ -31,6 +31,10 @@ namespace kagome::common {
       return hex_lower(*this);
     }
 
+    std::string_view toStringView() const {
+      return {(const char*)data(), (size_t)size()};
+    }
+
     bool operator==(const Span &other) const noexcept {
       return std::equal(
           Span::cbegin(), Span::cend(), other.cbegin(), other.cend());

--- a/core/common/buffer_view.hpp
+++ b/core/common/buffer_view.hpp
@@ -8,6 +8,7 @@
 
 #include <gsl/span>
 
+#include "common/bytestr.hpp"
 #include "common/hexutil.hpp"
 #include "macro/endianness_utils.hpp"
 
@@ -32,7 +33,7 @@ namespace kagome::common {
     }
 
     std::string_view toStringView() const {
-      return {(const char *)data(), (size_t)size()};
+      return byte2str(*this);
     }
 
     bool operator==(const Span &other) const noexcept {

--- a/core/common/buffer_view.hpp
+++ b/core/common/buffer_view.hpp
@@ -32,7 +32,7 @@ namespace kagome::common {
     }
 
     std::string_view toStringView() const {
-      return {(const char*)data(), (size_t)size()};
+      return {(const char *)data(), (size_t)size()};
     }
 
     bool operator==(const Span &other) const noexcept {

--- a/core/host_api/impl/crypto_extension.cpp
+++ b/core/host_api/impl/crypto_extension.cpp
@@ -259,8 +259,7 @@ namespace kagome::host_api {
       runtime::WasmPointer pubkey_data) {
     auto [msg_data, msg_len] = runtime::PtrSize(msg_span);
     auto msg = getMemory().loadN(msg_data, msg_len);
-    auto sig_bytes =
-        getMemory().loadN(sig, ed25519_constants::SIGNATURE_SIZE);
+    auto sig_bytes = getMemory().loadN(sig, ed25519_constants::SIGNATURE_SIZE);
 
     auto signature_res = crypto::Ed25519Signature::fromSpan(sig_bytes);
     if (!signature_res) {
@@ -268,8 +267,8 @@ namespace kagome::host_api {
     }
     auto &&signature = signature_res.value();
 
-    auto pubkey_bytes = getMemory()
-                            .loadN(pubkey_data, ed25519_constants::PUBKEY_SIZE);
+    auto pubkey_bytes =
+        getMemory().loadN(pubkey_data, ed25519_constants::PUBKEY_SIZE);
     auto pubkey_res = crypto::Ed25519PublicKey::fromSpan(pubkey_bytes);
     if (!pubkey_res) {
       BOOST_UNREACHABLE_RETURN(kVerifyFail);

--- a/core/host_api/impl/crypto_extension.cpp
+++ b/core/host_api/impl/crypto_extension.cpp
@@ -260,7 +260,7 @@ namespace kagome::host_api {
     auto [msg_data, msg_len] = runtime::PtrSize(msg_span);
     auto msg = getMemory().loadN(msg_data, msg_len);
     auto sig_bytes =
-        getMemory().loadN(sig, ed25519_constants::SIGNATURE_SIZE).toVector();
+        getMemory().loadN(sig, ed25519_constants::SIGNATURE_SIZE);
 
     auto signature_res = crypto::Ed25519Signature::fromSpan(sig_bytes);
     if (!signature_res) {
@@ -269,8 +269,7 @@ namespace kagome::host_api {
     auto &&signature = signature_res.value();
 
     auto pubkey_bytes = getMemory()
-                            .loadN(pubkey_data, ed25519_constants::PUBKEY_SIZE)
-                            .toVector();
+                            .loadN(pubkey_data, ed25519_constants::PUBKEY_SIZE);
     auto pubkey_res = crypto::Ed25519PublicKey::fromSpan(pubkey_bytes);
     if (!pubkey_res) {
       BOOST_UNREACHABLE_RETURN(kVerifyFail);

--- a/core/host_api/impl/misc_extension.cpp
+++ b/core/host_api/impl/misc_extension.cpp
@@ -82,7 +82,7 @@ namespace kagome::host_api {
       runtime::WasmSpan data) const {
     auto [ptr, len] = runtime::splitSpan(data);
     auto buf = memory_provider_->getCurrentMemory()->get().loadN(ptr, len);
-    logger_->info("utf8: {}", buf.toString());
+    logger_->info("utf8: {}", buf.toStringView());
   }
 
 }  // namespace kagome::host_api

--- a/core/host_api/impl/offchain_extension.cpp
+++ b/core/host_api/impl/offchain_extension.cpp
@@ -240,40 +240,40 @@ namespace kagome::host_api {
 
     auto [uri_ptr, uri_size] = runtime::PtrSize(uri_pos);
     auto uri_buffer = memory.loadN(uri_ptr, uri_size);
-    auto uri = uri_buffer.toString();
+    auto uri = uri_buffer.toStringView();
 
     auto [meta_ptr, meta_size] = runtime::PtrSize(meta_pos);
     [[maybe_unused]]  // It is future-reserved field, is not used now
     auto meta_buffer = memory.loadN(meta_ptr, meta_size);
 
     HttpMethod method = HttpMethod::Undefined;
-    if (method_buffer.toString() == "Get") {
+    if (method_buffer.toStringView() == "Get") {
       method = HttpMethod::Get;
-    } else if (method_buffer.toString() == "Post") {
+    } else if (method_buffer.toStringView() == "Post") {
       method = HttpMethod::Post;
     } else {
       SL_TRACE(
           log_,
           "ext_offchain_http_request_start_version_1( {}, {}, {} ) failed: "
           "Reason: unknown method",
-          method_buffer.toString(),
+          method_buffer.toStringView(),
           uri,
-          meta_buffer.toString());
+          meta_buffer.toStringView());
     }
 
     auto result = worker->httpRequestStart(method, uri, meta_buffer);
 
     if (result.isSuccess()) {
       SL_TRACE_FUNC_CALL(
-          log_, result.value(), method_buffer.toString(), uri, meta_buffer);
+          log_, result.value(), method_buffer.toStringView(), uri, meta_buffer);
 
     } else {
       SL_TRACE(log_,
                "ext_offchain_http_request_start_version_1( {}, {}, {} ) failed "
                "during execution",
-               method_buffer.toString(),
+               method_buffer.toStringView(),
                uri,
-               meta_buffer.toString());
+               meta_buffer.toStringView());
     }
 
     return memory.storeBuffer(scale::encode(result).value());
@@ -290,11 +290,11 @@ namespace kagome::host_api {
 
     auto [name_ptr, name_size] = runtime::PtrSize(name_pos);
     auto name_buffer = memory.loadN(name_ptr, name_size);
-    auto name = name_buffer.toString();
+    auto name = name_buffer.toStringView();
 
     auto [value_ptr, value_size] = runtime::PtrSize(value_pos);
     auto value_buffer = memory.loadN(value_ptr, value_size);
-    auto value = value_buffer.toString();
+    auto value = value_buffer.toStringView();
 
     auto result = worker->httpRequestAddHeader(request_id, name, value);
 

--- a/core/runtime/binaryen/memory_impl.cpp
+++ b/core/runtime/binaryen/memory_impl.cpp
@@ -76,7 +76,7 @@ namespace kagome::runtime::binaryen {
   common::BufferView MemoryImpl::loadN(kagome::runtime::WasmPointer addr,
                                        kagome::runtime::WasmSize n) const {
     BOOST_ASSERT(size_ > addr and size_ - addr >= n);
-    return common::BufferView{memory_->getBuffer(addr), n};
+    return common::BufferView{memory_->getBuffer<const uint8_t>(addr, n)};
   }
 
   std::string MemoryImpl::loadStr(kagome::runtime::WasmPointer addr,

--- a/core/runtime/binaryen/memory_impl.cpp
+++ b/core/runtime/binaryen/memory_impl.cpp
@@ -74,7 +74,7 @@ namespace kagome::runtime::binaryen {
   }
 
   common::BufferView MemoryImpl::loadN(kagome::runtime::WasmPointer addr,
-                                   kagome::runtime::WasmSize n) const {
+                                       kagome::runtime::WasmSize n) const {
     BOOST_ASSERT(size_ > addr and size_ - addr >= n);
     return common::BufferView{memory_->getBuffer(addr), n};
   }

--- a/core/runtime/binaryen/memory_impl.cpp
+++ b/core/runtime/binaryen/memory_impl.cpp
@@ -73,15 +73,10 @@ namespace kagome::runtime::binaryen {
     return memory_->get<std::array<uint8_t, 16>>(addr);
   }
 
-  common::Buffer MemoryImpl::loadN(kagome::runtime::WasmPointer addr,
+  common::BufferView MemoryImpl::loadN(kagome::runtime::WasmPointer addr,
                                    kagome::runtime::WasmSize n) const {
     BOOST_ASSERT(size_ > addr and size_ - addr >= n);
-    common::Buffer res;
-    res.reserve(n);
-    for (auto i = addr; i < addr + n; i++) {
-      res.putUint8(memory_->get<uint8_t>(i));
-    }
-    return res;
+    return common::BufferView{memory_->getBuffer(addr), n};
   }
 
   std::string MemoryImpl::loadStr(kagome::runtime::WasmPointer addr,

--- a/core/runtime/binaryen/memory_impl.hpp
+++ b/core/runtime/binaryen/memory_impl.hpp
@@ -60,7 +60,7 @@ namespace kagome::runtime::binaryen {
     int64_t load64s(WasmPointer addr) const override;
     uint64_t load64u(WasmPointer addr) const override;
     std::array<uint8_t, 16> load128(WasmPointer addr) const override;
-    common::Buffer loadN(kagome::runtime::WasmPointer addr,
+    common::BufferView loadN(kagome::runtime::WasmPointer addr,
                          kagome::runtime::WasmSize n) const override;
     std::string loadStr(kagome::runtime::WasmPointer addr,
                         kagome::runtime::WasmSize length) const override;

--- a/core/runtime/binaryen/memory_impl.hpp
+++ b/core/runtime/binaryen/memory_impl.hpp
@@ -61,7 +61,7 @@ namespace kagome::runtime::binaryen {
     uint64_t load64u(WasmPointer addr) const override;
     std::array<uint8_t, 16> load128(WasmPointer addr) const override;
     common::BufferView loadN(kagome::runtime::WasmPointer addr,
-                         kagome::runtime::WasmSize n) const override;
+                             kagome::runtime::WasmSize n) const override;
     std::string loadStr(kagome::runtime::WasmPointer addr,
                         kagome::runtime::WasmSize length) const override;
 

--- a/core/runtime/binaryen/runtime_external_interface.hpp
+++ b/core/runtime/binaryen/runtime_external_interface.hpp
@@ -89,6 +89,10 @@ namespace kagome::runtime::binaryen {
           return loaded;
         }
       }
+
+      const uint8_t *getBuffer(size_t address) const {
+        return (const uint8_t *)&memory[address];
+      }
     } memory;
 
     std::vector<wasm::Name> table;

--- a/core/runtime/binaryen/runtime_external_interface.hpp
+++ b/core/runtime/binaryen/runtime_external_interface.hpp
@@ -90,8 +90,10 @@ namespace kagome::runtime::binaryen {
         }
       }
 
-      const uint8_t *getBuffer(size_t address) const {
-        return (const uint8_t *)&memory[address];
+      template <typename T, typename = std::enable_if_t<std::is_pod_v<T>>>
+      gsl::span<T> getBuffer(size_t address, size_t n) const {
+        return gsl::span<T>((T *)&memory[address], n);
+        ;
       }
     } memory;
 

--- a/core/runtime/binaryen/runtime_external_interface.hpp
+++ b/core/runtime/binaryen/runtime_external_interface.hpp
@@ -63,7 +63,7 @@ namespace kagome::runtime::binaryen {
         return memory.size();
       }
       auto getData() const {
-        return gsl::span<Mem::value_type const>(memory);
+        return gsl::span<const Mem::value_type>(memory);
       }
       template <typename T>
       void set(size_t address, T value) {

--- a/core/runtime/memory.hpp
+++ b/core/runtime/memory.hpp
@@ -17,14 +17,14 @@
 
 namespace kagome::runtime {
 
-  constexpr inline size_t kInitialMemorySize = []() {
+  inline constexpr size_t kInitialMemorySize = []() {
     using kagome::common::literals::operator""_MB;
     return 2_MB;
   }();
 
   // according to $3.1.2.1 in the Polkadot Host Spec
   // https://webassembly.github.io/spec/core/exec/runtime.html#memory-instances
-  constexpr inline size_t kMemoryPageSize = []() {
+  inline constexpr size_t kMemoryPageSize = []() {
     using kagome::common::literals::operator""_kB;
     return 64_kB;
   }();
@@ -41,7 +41,7 @@ namespace kagome::runtime {
    public:
     virtual ~Memory() = default;
 
-    constexpr static uint32_t kMaxMemorySize =
+    static constexpr uint32_t kMaxMemorySize =
         std::numeric_limits<uint32_t>::max();
 
     /**

--- a/core/runtime/memory.hpp
+++ b/core/runtime/memory.hpp
@@ -88,9 +88,9 @@ namespace kagome::runtime {
      * Load bytes from provided address into the buffer of size n
      * @param addr address in memory to load bytes
      * @param n number of bytes to be loaded
-     * @return Buffer of length N
+     * @return BufferView of length N
      */
-    virtual common::Buffer loadN(WasmPointer addr, WasmSize n) const = 0;
+    virtual common::BufferView loadN(WasmPointer addr, WasmSize n) const = 0;
     /**
      * Load string from address into buffer of size n
      * @param addr address in memory to load bytes

--- a/core/runtime/wavm/memory_impl.cpp
+++ b/core/runtime/wavm/memory_impl.cpp
@@ -66,11 +66,11 @@ namespace kagome::runtime::wavm {
     return array;
   }
 
-  common::Buffer MemoryImpl::loadN(kagome::runtime::WasmPointer addr,
+  common::BufferView MemoryImpl::loadN(kagome::runtime::WasmPointer addr,
                                    kagome::runtime::WasmSize n) const {
     common::Buffer res;
     auto byte_array = loadArray<uint8_t>(addr, n);
-    return common::Buffer{byte_array, byte_array + n};
+    return common::BufferView{common::BufferView{byte_array, byte_array + n}};
   }
 
   std::string MemoryImpl::loadStr(kagome::runtime::WasmPointer addr,

--- a/core/runtime/wavm/memory_impl.cpp
+++ b/core/runtime/wavm/memory_impl.cpp
@@ -67,7 +67,7 @@ namespace kagome::runtime::wavm {
   }
 
   common::BufferView MemoryImpl::loadN(kagome::runtime::WasmPointer addr,
-                                   kagome::runtime::WasmSize n) const {
+                                       kagome::runtime::WasmSize n) const {
     common::Buffer res;
     auto byte_array = loadArray<uint8_t>(addr, n);
     return common::BufferView{common::BufferView{byte_array, byte_array + n}};

--- a/core/runtime/wavm/memory_impl.cpp
+++ b/core/runtime/wavm/memory_impl.cpp
@@ -62,15 +62,13 @@ namespace kagome::runtime::wavm {
   std::array<uint8_t, 16> MemoryImpl::load128(WasmPointer addr) const {
     auto byte_array = loadArray<uint8_t>(addr, 16);
     std::array<uint8_t, 16> array;
-    std::copy_n(byte_array, 16, array.begin());
+    memcpy(array.data(), byte_array.data(), 16);
     return array;
   }
 
   common::BufferView MemoryImpl::loadN(kagome::runtime::WasmPointer addr,
                                        kagome::runtime::WasmSize n) const {
-    common::Buffer res;
-    auto byte_array = loadArray<uint8_t>(addr, n);
-    return common::BufferView{common::BufferView{byte_array, byte_array + n}};
+    return loadArray<uint8_t>(addr, n);
   }
 
   std::string MemoryImpl::loadStr(kagome::runtime::WasmPointer addr,

--- a/core/runtime/wavm/memory_impl.hpp
+++ b/core/runtime/wavm/memory_impl.hpp
@@ -45,11 +45,12 @@ namespace kagome::runtime::wavm {
       return res;
     }
 
-    template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-    T *loadArray(WasmPointer addr, size_t num) const {
+    template <typename T, typename = std::enable_if_t<std::is_pod_v<T>>>
+    gsl::span<T> loadArray(WasmPointer addr, size_t num) const {
       auto res = WAVM::Runtime::memoryArrayPtr<T>(memory_, addr, num);
-      SL_TRACE_FUNC_CALL(logger_, gsl::span<T>(res, num), this, addr);
-      return res;
+      gsl::span<T> buffer(res, num);
+      SL_TRACE_FUNC_CALL(logger_, buffer, this, addr);
+      return buffer;
     }
 
     int8_t load8s(WasmPointer addr) const override;

--- a/core/runtime/wavm/memory_impl.hpp
+++ b/core/runtime/wavm/memory_impl.hpp
@@ -62,7 +62,7 @@ namespace kagome::runtime::wavm {
     uint64_t load64u(WasmPointer addr) const override;
     std::array<uint8_t, 16> load128(WasmPointer addr) const override;
 
-    common::Buffer loadN(WasmPointer addr, WasmSize n) const override;
+    common::BufferView loadN(WasmPointer addr, WasmSize n) const override;
 
     std::string loadStr(WasmPointer addr, WasmSize n) const override;
 

--- a/test/mock/core/runtime/memory_mock.hpp
+++ b/test/mock/core/runtime/memory_mock.hpp
@@ -47,7 +47,7 @@ namespace kagome::runtime {
                 (WasmPointer),
                 (const, override));
 
-    MOCK_METHOD(common::Buffer,
+    MOCK_METHOD(common::BufferView,
                 loadN,
                 (WasmPointer, WasmSize),
                 (const, override));


### PR DESCRIPTION
### Description of the Change
Updated to binaryen with performance fixes.
Remove buffers allocations on wasm memory IO operations.
Schnorrkel-crust linkes correctly.