### PR TITLE
Fix atomic linking error on GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,8 @@ link_libraries(Threads::Threads)
 if(THREADS_HAVE_PTHREAD_ARG)
   link_libraries(pthread)
 endif()
-
+link_libraries(atomic)
+g
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # cmake-format: off

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if(THREADS_HAVE_PTHREAD_ARG)
   link_libraries(pthread)
 endif()
 link_libraries(atomic)
-g
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # cmake-format: off

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,10 @@ link_libraries(Threads::Threads)
 if(THREADS_HAVE_PTHREAD_ARG)
   link_libraries(pthread)
 endif()
-link_libraries(atomic)
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+  link_libraries(atomic)
+endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
Non-lock-free atomic operations are not implemented in GCC and require linking to libatomic.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->
