### PR TITLE
fix babe catch up

### DIFF
--- a/core/consensus/babe/impl/babe_impl.cpp
+++ b/core/consensus/babe/impl/babe_impl.cpp
@@ -584,7 +584,8 @@ namespace kagome::consensus::babe {
             }
 
             // Caught up some block, possible block of current slot
-            if (self->current_state_ == Babe::State::CATCHING_UP) {
+            if (self->current_state_ == Babe::State::CATCHING_UP
+                or self->current_state_ == State::WAIT_REMOTE_STATUS) {
               self->onCaughtUp(block);
             }
 


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- `onCaughtUp` changed state to `WAIT_REMOTE_STATUS`, which was not handled, so never changed to `SYNCHRONIZED`.

### Benefits
- fix babe catch up not starting block production

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests <!-- Optional -->

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs <!-- Optional -->

<!-- Explain what other alternates were considered and why the proposed version was selected -->
