### PR TITLE
Temporary fix for binaryen memory

### DIFF
--- a/core/runtime/binaryen/memory_impl.cpp
+++ b/core/runtime/binaryen/memory_impl.cpp
@@ -15,9 +15,9 @@ namespace kagome::runtime::binaryen {
       : memory_{memory},
         allocator_{std::move(allocator)},
         logger_{log::createLogger("Binaryen Memory", "binaryen")} {
-    // TODO(Harrm): #1714 temporary fix because binaryen doesn't recognize 
+    // TODO(Harrm): #1714 temporary fix because binaryen doesn't recognize
     // our memory resizes from our allocator
-    memory_->resize(kInitialMemorySize); 
+    memory_->resize(kInitialMemorySize);
   }
 
   MemoryImpl::MemoryImpl(RuntimeExternalInterface::InternalMemory *memory,

--- a/core/runtime/binaryen/memory_impl.cpp
+++ b/core/runtime/binaryen/memory_impl.cpp
@@ -15,7 +15,9 @@ namespace kagome::runtime::binaryen {
       : memory_{memory},
         allocator_{std::move(allocator)},
         logger_{log::createLogger("Binaryen Memory", "binaryen")} {
-    resize(kInitialMemorySize);
+    // TODO(Harrm): temporary fix because binaryen doesn't recognize 
+    // our memory resizes from our allocator
+    memory_->resize(kInitialMemorySize); 
   }
 
   MemoryImpl::MemoryImpl(RuntimeExternalInterface::InternalMemory *memory,

--- a/core/runtime/binaryen/memory_impl.cpp
+++ b/core/runtime/binaryen/memory_impl.cpp
@@ -15,7 +15,7 @@ namespace kagome::runtime::binaryen {
       : memory_{memory},
         allocator_{std::move(allocator)},
         logger_{log::createLogger("Binaryen Memory", "binaryen")} {
-    // TODO(Harrm): temporary fix because binaryen doesn't recognize 
+    // TODO(Harrm): #1714 temporary fix because binaryen doesn't recognize 
     // our memory resizes from our allocator
     memory_->resize(kInitialMemorySize); 
   }


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
Force resize memory to initial size so that it hopefully doesn't get resized past binaryen's limits.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

Temporary fix for #1714 

### Benefits
Kagome stops crashing at binaryen assert.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
It's a crutch.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->


<!-- Explain what other alternates were considered and why the proposed version was selected -->
