### PR TITLE
Improve error handling in babe_config_repository_impl

### DIFF
--- a/core/consensus/babe/impl/babe_config_repository_impl.cpp
+++ b/core/consensus/babe/impl/babe_config_repository_impl.cpp
@@ -213,8 +213,10 @@ namespace kagome::consensus::babe {
         }
       }
       if (not slot1 and trie_storage_->getEphemeralBatchAt(parent.state_root)) {
-        OUTCOME_TRY(epoch, babe_api_->next_epoch(parent_info.hash));
-        slot1 = epoch.start_slot - epoch.epoch_index * epoch.duration;
+        if (auto epoch_res = babe_api_->next_epoch(parent_info.hash)) {
+          auto &epoch = epoch_res.value();
+          slot1 = epoch.start_slot - epoch.epoch_index * epoch.duration;
+        }
       }
       if (not slot1) {
         auto header1 = parent;

--- a/core/consensus/babe/impl/babe_config_repository_impl.cpp
+++ b/core/consensus/babe/impl/babe_config_repository_impl.cpp
@@ -213,7 +213,7 @@ namespace kagome::consensus::babe {
         }
       }
       if (not slot1 and trie_storage_->getEphemeralBatchAt(parent.state_root)) {
-        if (auto epoch_res = babe_api_->next_epoch(parent_info.hash)) {
+        if (auto epoch_res = babe_api_->next_epoch(parent_info.hash); epoch_res.has_value()) {
           auto &epoch = epoch_res.value();
           slot1 = epoch.start_slot - epoch.epoch_index * epoch.duration;
         }

--- a/core/consensus/babe/impl/babe_config_repository_impl.cpp
+++ b/core/consensus/babe/impl/babe_config_repository_impl.cpp
@@ -213,7 +213,8 @@ namespace kagome::consensus::babe {
         }
       }
       if (not slot1 and trie_storage_->getEphemeralBatchAt(parent.state_root)) {
-        if (auto epoch_res = babe_api_->next_epoch(parent_info.hash); epoch_res.has_value()) {
+        if (auto epoch_res = babe_api_->next_epoch(parent_info.hash);
+            epoch_res.has_value()) {
           auto &epoch = epoch_res.value();
           slot1 = epoch.start_slot - epoch.epoch_index * epoch.duration;
         }


### PR DESCRIPTION
This change ensures errors in babe_api_->next_epoch are handled gracefully. Instead of using OUTCOME_TRY that could potentially terminate the process on failure, the new code checks if the 'next_epoch' method call was successful and only then proceeds with calculations. This aims to increase code's reliability by avoiding unexpected crashes in case of unsuccessful 'next_epoch' call.

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

None

### Description of the Change

Handle error of babe next epoch properly

### Benefits

Sync of Kusama from scratch works again

### Possible Drawbacks

None
