### PR TITLE
lru put mutex

### DIFF
--- a/core/common/lru_cache.hpp
+++ b/core/common/lru_cache.hpp
@@ -107,6 +107,7 @@ namespace kagome {
 
     template <typename ValueArg>
     std::shared_ptr<const Value> put(const Key &key, ValueArg &&value) {
+      LockGuard lg(*this);
       static_assert(std::is_convertible_v<ValueArg, Value>
                     || std::is_constructible_v<ValueArg, Value>);
       if (cache_.size() >= kMaxSize) {


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- `put` didn't use mutex

### Benefits

### Possible Drawbacks