### PR TITLE
lru runtime

### DIFF
--- a/core/injector/calculate_genesis_state.hpp
+++ b/core/injector/calculate_genesis_state.hpp
@@ -7,7 +7,6 @@
 #define KAGOME_CORE_INJECTOR_GET_GENESIS_STATE_HPP
 
 #include "application/chain_spec.hpp"
-#include "runtime/executor.hpp"
 #include "runtime/runtime_api/impl/core.hpp"
 #include "storage/predefined_keys.hpp"
 #include "storage/trie/polkadot_trie/polkadot_trie_impl.hpp"
@@ -15,12 +14,6 @@
 #include "storage/trie_pruner/trie_pruner.hpp"
 
 namespace kagome::injector {
-
-  outcome::result<primitives::Version> callCoreVersion(
-      runtime::Executor &executor, runtime::RuntimeContext &ctx) {
-    return executor.decodedCallWithCtx<primitives::Version>(ctx, "Core_version");
-  }
-
   inline outcome::result<storage::trie::RootHash> calculate_genesis_state(
       const application::ChainSpec &chain_spec,
       const runtime::ModuleFactory &module_factory,
@@ -36,12 +29,8 @@ namespace kagome::injector {
     auto top_trie = trie_from(chain_spec.getGenesisTopSection());
     OUTCOME_TRY(code, top_trie->get(storage::kRuntimeCodeKey));
 
-    runtime::Executor executor{nullptr, runtime_cache};
-    OUTCOME_TRY(ctx,
-                runtime::RuntimeContextFactory::fromCode(module_factory, code));
-    OUTCOME_TRY(
-        runtime_version,
-        callCoreVersion(executor, ctx));
+    OUTCOME_TRY(runtime_version,
+                runtime::callCoreVersion(module_factory, code, runtime_cache));
     auto version = storage::trie::StateVersion{runtime_version.state_version};
     std::vector<std::shared_ptr<storage::trie::PolkadotTrie>> child_tries;
     for (auto &[child, kv] : chain_spec.getGenesisChildrenDefaultSection()) {

--- a/core/network/CMakeLists.txt
+++ b/core/network/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(network
     warp/sync.cpp
     )
 target_link_libraries(network
+    core_api
     light_api_proto
     p2p::p2p_basic_scheduler
     executor

--- a/core/network/impl/state_sync_request_flow.hpp
+++ b/core/network/impl/state_sync_request_flow.hpp
@@ -15,8 +15,8 @@
 #include "storage/trie/polkadot_trie/polkadot_trie_impl.hpp"
 
 namespace kagome::runtime {
-  class Core;
   class ModuleFactory;
+  class RuntimePropertiesCache;
 }  // namespace kagome::runtime
 
 namespace kagome::storage::trie {
@@ -66,7 +66,8 @@ namespace kagome::network {
 
     outcome::result<void> commit(
         const runtime::ModuleFactory &module_factory,
-        runtime::Core &core_api,
+        const std::shared_ptr<runtime::RuntimePropertiesCache>
+            &runtime_properties_cache,
         storage::trie::TrieSerializer &trie_serializer);
 
    private:

--- a/core/network/impl/synchronizer_impl.cpp
+++ b/core/network/impl/synchronizer_impl.cpp
@@ -87,7 +87,7 @@ namespace kagome::network {
       std::shared_ptr<libp2p::basic::Scheduler> scheduler,
       std::shared_ptr<crypto::Hasher> hasher,
       std::shared_ptr<runtime::ModuleFactory> module_factory,
-      std::shared_ptr<runtime::Core> core_api,
+      std::shared_ptr<runtime::RuntimePropertiesCache> runtime_properties_cache,
       primitives::events::ChainSubscriptionEnginePtr chain_sub_engine,
       std::shared_ptr<consensus::grandpa::Environment> grandpa_environment)
       : app_state_manager_(std::move(app_state_manager)),
@@ -102,7 +102,7 @@ namespace kagome::network {
         scheduler_(std::move(scheduler)),
         hasher_(std::move(hasher)),
         module_factory_(std::move(module_factory)),
-        core_api_(std::move(core_api)),
+        runtime_properties_cache_{std::move(runtime_properties_cache)},
         grandpa_environment_{std::move(grandpa_environment)},
         chain_sub_engine_(std::move(chain_sub_engine)) {
     BOOST_ASSERT(app_state_manager_);
@@ -115,7 +115,7 @@ namespace kagome::network {
     BOOST_ASSERT(scheduler_);
     BOOST_ASSERT(hasher_);
     BOOST_ASSERT(module_factory_);
-    BOOST_ASSERT(core_api_);
+    BOOST_ASSERT(runtime_properties_cache_);
     BOOST_ASSERT(grandpa_environment_);
     BOOST_ASSERT(chain_sub_engine_);
 
@@ -1048,8 +1048,8 @@ namespace kagome::network {
       syncState();
       return outcome::success();
     }
-    OUTCOME_TRY(
-        state_sync_flow_->commit(*module_factory_, *core_api_, *serializer_));
+    OUTCOME_TRY(state_sync_flow_->commit(
+        *module_factory_, runtime_properties_cache_, *serializer_));
     auto block = state_sync_flow_->blockInfo();
     state_sync_flow_.reset();
     SL_INFO(log_, "State syncing block {} has finished.", block);

--- a/core/network/impl/synchronizer_impl.hpp
+++ b/core/network/impl/synchronizer_impl.hpp
@@ -100,7 +100,8 @@ namespace kagome::network {
         std::shared_ptr<libp2p::basic::Scheduler> scheduler,
         std::shared_ptr<crypto::Hasher> hasher,
         std::shared_ptr<runtime::ModuleFactory> module_factory,
-        std::shared_ptr<runtime::Core> core_api,
+        std::shared_ptr<runtime::RuntimePropertiesCache>
+            runtime_properties_cache,
         primitives::events::ChainSubscriptionEnginePtr chain_sub_engine,
         std::shared_ptr<consensus::grandpa::Environment> grandpa_environment);
 
@@ -223,7 +224,7 @@ namespace kagome::network {
     std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
     std::shared_ptr<crypto::Hasher> hasher_;
     std::shared_ptr<runtime::ModuleFactory> module_factory_;
-    std::shared_ptr<runtime::Core> core_api_;
+    std::shared_ptr<runtime::RuntimePropertiesCache> runtime_properties_cache_;
     std::shared_ptr<consensus::grandpa::Environment> grandpa_environment_;
     primitives::events::ChainSubscriptionEnginePtr chain_sub_engine_;
 

--- a/core/primitives/babe_configuration.hpp
+++ b/core/primitives/babe_configuration.hpp
@@ -78,6 +78,9 @@ namespace kagome::primitives {
          and authorities == rhs.authorities and randomness == rhs.randomness
          and allowed_slots == rhs.allowed_slots;
     }
+    bool operator!=(const BabeConfiguration &rhs) const {
+      return !operator==(rhs);
+    }
   };
 
   template <class Stream,

--- a/core/runtime/binaryen/core_api_factory_impl.cpp
+++ b/core/runtime/binaryen/core_api_factory_impl.cpp
@@ -9,10 +9,10 @@
 #include "runtime/binaryen/instance_environment_factory.hpp"
 #include "runtime/binaryen/module/module_impl.hpp"
 #include "runtime/common/constant_code_provider.hpp"
-#include "runtime/module_repository.hpp"
-#include "runtime/executor.hpp"
 #include "runtime/common/runtime_properties_cache_impl.hpp"
 #include "runtime/common/trie_storage_provider_impl.hpp"
+#include "runtime/executor.hpp"
+#include "runtime/module_repository.hpp"
 #include "runtime/runtime_api/impl/core.hpp"
 
 namespace kagome::runtime::binaryen {
@@ -71,7 +71,7 @@ namespace kagome::runtime::binaryen {
         header_repo_);
     auto executor = std::make_unique<Executor>(ctx_factory, cache_);
     return std::make_unique<CoreImpl>(
-        std::move(executor), ctx_factory, header_repo_);
+        std::move(executor), ctx_factory, header_repo_, nullptr);
   }
 
 }  // namespace kagome::runtime::binaryen

--- a/core/runtime/executor.hpp
+++ b/core/runtime/executor.hpp
@@ -126,19 +126,17 @@ namespace kagome::runtime {
           });
     }
 
-   private:
     template <typename... Args>
     static outcome::result<common::Buffer> encodeArgs(Args &&...args) {
-      common::Buffer encoded_args{};
       if constexpr (sizeof...(args) > 0) {
         OUTCOME_TRY(res, scale::encode(std::forward<Args>(args)...));
-        encoded_args.put(std::move(res));
+        return Buffer{std::move(res)};
       }
-      return encoded_args;
+      return Buffer{};
     }
 
     template <typename Result>
-    static outcome::result<Result> decodeResult(common::Buffer &&result) {
+    static outcome::result<Result> decodeResult(common::BufferView result) {
       if constexpr (std::is_void_v<Result>) {
         return outcome::success();
       } else {

--- a/core/runtime/runtime_api/core.hpp
+++ b/core/runtime/runtime_api/core.hpp
@@ -6,22 +6,14 @@
 #ifndef KAGOME_RUNTIME_CORE_HPP
 #define KAGOME_RUNTIME_CORE_HPP
 
-#include <vector>
-
 #include <optional>
-#include <outcome/outcome.hpp>
 
 #include "primitives/block.hpp"
-#include "primitives/block_id.hpp"
 #include "primitives/common.hpp"
-#include "primitives/transaction_validity.hpp"
 #include "primitives/version.hpp"
-#include "runtime/runtime_context.hpp"
 #include "storage/changes_trie/changes_tracker.hpp"
 
 namespace kagome::runtime {
-  class ModuleInstance;
-  class RuntimeCodeProvider;
   class RuntimeContext;
 
   /**
@@ -30,13 +22,6 @@ namespace kagome::runtime {
   class Core {
    public:
     virtual ~Core() = default;
-
-    /**
-     * @brief Returns the version of the runtime
-     * @return runtime version
-     */
-    virtual outcome::result<primitives::Version> version(
-        std::shared_ptr<ModuleInstance> instance) = 0;
 
     /**
      * @brief Returns the version of the runtime

--- a/core/runtime/runtime_api/impl/authority_discovery_api.cpp
+++ b/core/runtime/runtime_api/impl/authority_discovery_api.cpp
@@ -16,10 +16,9 @@ namespace kagome::runtime {
 
   outcome::result<std::vector<primitives::AuthorityDiscoveryId>>
   AuthorityDiscoveryApiImpl::authorities(const primitives::BlockHash &block) {
-    OUTCOME_TRY(ref, cache_.get_else(block, [&] {
-      return executor_->callAt<std::vector<primitives::AuthorityDiscoveryId>>(
-          block, "AuthorityDiscoveryApi_authorities");
-    }));
+    OUTCOME_TRY(
+        ref,
+        cache_.call(*executor_, block, "AuthorityDiscoveryApi_authorities"));
     return *ref;
   }
 }  // namespace kagome::runtime

--- a/core/runtime/runtime_api/impl/authority_discovery_api.hpp
+++ b/core/runtime/runtime_api/impl/authority_discovery_api.hpp
@@ -6,8 +6,8 @@
 #ifndef KAGOME_RUNTIME_RUNTIME_API_IMPL_AUTHORITY_DISCOVERY_API_HPP
 #define KAGOME_RUNTIME_RUNTIME_API_IMPL_AUTHORITY_DISCOVERY_API_HPP
 
-#include "common/lru_cache.hpp"
 #include "runtime/runtime_api/authority_discovery_api.hpp"
+#include "runtime/runtime_api/impl/lru.hpp"
 
 namespace kagome::runtime {
   class Executor;
@@ -23,7 +23,7 @@ namespace kagome::runtime {
     std::shared_ptr<Executor> executor_;
 
     using Auths = std::vector<primitives::AuthorityDiscoveryId>;
-    LruCache<primitives::BlockHash, Auths> cache_{10};
+    RuntimeApiLruBlock<Auths> cache_{10};
   };
 }  // namespace kagome::runtime
 

--- a/core/runtime/runtime_api/impl/core.hpp
+++ b/core/runtime/runtime_api/impl/core.hpp
@@ -8,26 +8,25 @@
 
 #include "runtime/runtime_api/core.hpp"
 
-#include "common/lru_cache.hpp"
-
-namespace kagome::blockchain {
-  class BlockHeaderRepository;
-}
+#include "runtime/runtime_api/impl/lru.hpp"
 
 namespace kagome::runtime {
 
   class Executor;
   class RuntimePropertiesCache;
 
+  outcome::result<primitives::Version> callCoreVersion(
+      const ModuleFactory &module_factory,
+      common::BufferView code,
+      const std::shared_ptr<RuntimePropertiesCache> &runtime_properties_cache);
+
   class CoreImpl final : public Core {
    public:
     CoreImpl(
         std::shared_ptr<Executor> executor,
         std::shared_ptr<RuntimeContextFactory> ctx_factory,
-        std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo);
-
-    outcome::result<primitives::Version> version(
-        std::shared_ptr<ModuleInstance> instance) override;
+        std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo,
+        std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker);
 
     outcome::result<primitives::Version> version(
         const primitives::BlockHash &block) override;
@@ -50,8 +49,9 @@ namespace kagome::runtime {
     std::shared_ptr<Executor> executor_;
     std::shared_ptr<RuntimeContextFactory> ctx_factory_;
     std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo_;
+    std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker_;
 
-    LruCache<primitives::BlockHash, primitives::Version> version_{10};
+    RuntimeApiLruCode<primitives::Version> version_{10};
   };
 
 }  // namespace kagome::runtime

--- a/core/runtime/runtime_api/impl/lru.hpp
+++ b/core/runtime/runtime_api/impl/lru.hpp
@@ -1,0 +1,142 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "blockchain/block_header_repository.hpp"
+#include "runtime/executor.hpp"
+#include "runtime/runtime_upgrade_tracker.hpp"
+#include "utils/lru_encoded.hpp"
+#include "utils/safe_object.hpp"
+
+namespace kagome::runtime {
+  /**
+   * Cache runtime calls without arguments.
+   */
+  template <typename V>
+  class RuntimeApiLruBlock {
+   public:
+    RuntimeApiLruBlock(size_t capacity) : lru_{capacity} {}
+
+    outcome::result<std::shared_ptr<V>> call(Executor &executor,
+                                             const primitives::BlockHash &block,
+                                             std::string_view name) {
+      if (auto r =
+              lru_.exclusiveAccess([&](typename decltype(lru_)::Type &lru_) {
+                return lru_.get(block);
+              })) {
+        return *r;
+      }
+      OUTCOME_TRY(raw, executor.callAt(block, name, {}));
+      OUTCOME_TRY(r, Executor::decodeResult<V>(raw));
+      return lru_.exclusiveAccess([&](typename decltype(lru_)::Type &lru_) {
+        return lru_.put(block, std::move(r), raw);
+      });
+    }
+
+    void erase(const std::vector<primitives::BlockHash> &blocks) {
+      lru_.exclusiveAccess([&](typename decltype(lru_)::Type &lru_) {
+        for (auto &block : blocks) {
+          lru_.erase(block);
+        }
+      });
+    }
+
+   private:
+    SafeObject<LruEncoded<primitives::BlockHash, V>> lru_;
+  };
+
+  template <typename Arg>
+  struct RuntimeApiLruBlockArgKey : std::pair<primitives::BlockHash, Arg> {};
+
+  /**
+   * Cache runtime calls with arguments.
+   */
+  template <typename Arg, typename V>
+  class RuntimeApiLruBlockArg {
+   public:
+    using Key = RuntimeApiLruBlockArgKey<Arg>;
+
+    RuntimeApiLruBlockArg(size_t capacity) : lru_{capacity} {}
+
+    outcome::result<std::shared_ptr<V>> call(Executor &executor,
+                                             const primitives::BlockHash &block,
+                                             std::string_view name,
+                                             const Arg &arg) {
+      Key key{{block, arg}};
+      if (auto r =
+              lru_.exclusiveAccess([&](typename decltype(lru_)::Type &lru_) {
+                return lru_.get(key);
+              })) {
+        return *r;
+      }
+      OUTCOME_TRY(raw_arg, Executor::encodeArgs(arg));
+      OUTCOME_TRY(raw, executor.callAt(block, name, raw_arg));
+      OUTCOME_TRY(r, Executor::decodeResult<V>(raw));
+      return lru_.exclusiveAccess([&](typename decltype(lru_)::Type &lru_) {
+        return lru_.put(key, std::move(r), raw);
+      });
+    }
+
+    void erase(const std::vector<primitives::BlockHash> &blocks) {
+      lru_.exclusiveAccess([&](typename decltype(lru_)::Type &lru_) {
+        lru_.erase_if([&](const Key &key, const std::shared_ptr<V> &) {
+          return std::find_if(blocks.begin(),
+                              blocks.end(),
+                              [&](const primitives::BlockHash &block) {
+                                return block == std::get<0>(key);
+                              })
+              != blocks.end();
+        });
+      });
+    }
+
+   private:
+    SafeObject<LruEncoded<Key, V>> lru_;
+  };
+
+  /**
+   * Only code upgrade changes `Core_version` and `Metadata_metadata` results.
+   */
+  template <typename V>
+  class RuntimeApiLruCode {
+   public:
+    RuntimeApiLruCode(size_t capacity) : lru_{capacity} {}
+
+    outcome::result<V> call(
+        const blockchain::BlockHeaderRepository &block_header_repository,
+        RuntimeUpgradeTracker &upgrades,
+        Executor &executor,
+        const primitives::BlockHash &block_hash,
+        std::string_view name) {
+      OUTCOME_TRY(block_number,
+                  block_header_repository.getNumberByHash(block_hash));
+      OUTCOME_TRY(hash,
+                  upgrades.getLastCodeUpdateState({block_number, block_hash}));
+      if (auto r =
+              lru_.exclusiveAccess([&](typename decltype(lru_)::Type &lru_) {
+                auto r = lru_.get(hash);
+                return r ? std::make_optional(r->get()) : std::nullopt;
+              })) {
+        return *r;
+      }
+      OUTCOME_TRY(r, executor.callAt<V>(block_hash, name));
+      return lru_.exclusiveAccess([&](typename decltype(lru_)::Type &lru_) {
+        return lru_.put(hash, std::move(r));
+      });
+    }
+
+   private:
+    SafeObject<Lru<common::Hash256, V>> lru_;
+  };
+}  // namespace kagome::runtime
+
+template <typename Arg>
+struct std::hash<kagome::runtime::RuntimeApiLruBlockArgKey<Arg>> {
+  size_t operator()(
+      const kagome::runtime::RuntimeApiLruBlockArgKey<Arg> &x) const {
+    return boost::hash_value(std::tie(x.first, x.second));
+  }
+};

--- a/core/runtime/runtime_api/impl/lru.hpp
+++ b/core/runtime/runtime_api/impl/lru.hpp
@@ -117,8 +117,8 @@ namespace kagome::runtime {
                   upgrades.getLastCodeUpdateState({block_number, block_hash}));
       if (auto r =
               lru_.exclusiveAccess([&](typename decltype(lru_)::Type &lru_) {
-                auto r = lru_.get(hash);
-                return r ? std::make_optional(r->get()) : std::nullopt;
+                auto v = lru_.get(hash);
+                return v ? std::make_optional(v->get()) : std::nullopt;
               })) {
         return *r;
       }

--- a/core/runtime/runtime_api/impl/metadata.cpp
+++ b/core/runtime/runtime_api/impl/metadata.cpp
@@ -9,17 +9,23 @@
 
 namespace kagome::runtime {
 
-  MetadataImpl::MetadataImpl(std::shared_ptr<Executor> executor)
-      : executor_{std::move(executor)} {
+  MetadataImpl::MetadataImpl(
+      std::shared_ptr<Executor> executor,
+      std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo,
+      std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker)
+      : executor_{std::move(executor)},
+        header_repo_{std::move(header_repo)},
+        runtime_upgrade_tracker_{std::move(runtime_upgrade_tracker)} {
     BOOST_ASSERT(executor_);
   }
 
   outcome::result<Metadata::OpaqueMetadata> MetadataImpl::metadata(
       const primitives::BlockHash &block_hash) {
-    OUTCOME_TRY(ref, metadata_.get_else(block_hash, [&] {
-      return executor_->callAt<OpaqueMetadata>(block_hash, "Metadata_metadata");
-    }));
-    return *ref;
+    return metadata_.call(*header_repo_,
+                          *runtime_upgrade_tracker_,
+                          *executor_,
+                          block_hash,
+                          "Metadata_metadata");
   }
 
 }  // namespace kagome::runtime

--- a/core/runtime/runtime_api/impl/metadata.hpp
+++ b/core/runtime/runtime_api/impl/metadata.hpp
@@ -8,8 +8,7 @@
 
 #include "runtime/runtime_api/metadata.hpp"
 
-#include "blockchain/block_header_repository.hpp"
-#include "common/lru_cache.hpp"
+#include "runtime/runtime_api/impl/lru.hpp"
 
 namespace kagome::runtime {
 
@@ -17,15 +16,20 @@ namespace kagome::runtime {
 
   class MetadataImpl final : public Metadata {
    public:
-    MetadataImpl(std::shared_ptr<Executor> executor);
+    MetadataImpl(
+        std::shared_ptr<Executor> executor,
+        std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo,
+        std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker);
 
     outcome::result<OpaqueMetadata> metadata(
         const primitives::BlockHash &block_hash) override;
 
    private:
     std::shared_ptr<Executor> executor_;
+    std::shared_ptr<const blockchain::BlockHeaderRepository> header_repo_;
+    std::shared_ptr<RuntimeUpgradeTracker> runtime_upgrade_tracker_;
 
-    LruCache<primitives::BlockHash, OpaqueMetadata> metadata_{10};
+    RuntimeApiLruCode<OpaqueMetadata> metadata_{10};
   };
 
 }  // namespace kagome::runtime

--- a/core/runtime/runtime_api/impl/parachain_host.cpp
+++ b/core/runtime/runtime_api/impl/parachain_host.cpp
@@ -108,8 +108,8 @@ namespace kagome::runtime {
     if (auto r = validation_code_by_hash_.exclusiveAccess(
             [&](typename decltype(validation_code_by_hash_)::Type
                     &validation_code_by_hash_) {
-              auto r = validation_code_by_hash_.get(hash);
-              return r ? std::make_optional(r->get()) : std::nullopt;
+              auto v = validation_code_by_hash_.get(hash);
+              return v ? std::make_optional(v->get()) : std::nullopt;
             })) {
       return *r;
     }

--- a/core/runtime/runtime_api/impl/parachain_host.cpp
+++ b/core/runtime/runtime_api/impl/parachain_host.cpp
@@ -11,69 +11,60 @@
 
 namespace kagome::runtime {
 
-  ParachainHostImpl::ParachainHostImpl(std::shared_ptr<Executor> executor)
-      : executor_{std::move(executor)} {
+  ParachainHostImpl::ParachainHostImpl(
+      std::shared_ptr<Executor> executor,
+      primitives::events::ChainSubscriptionEnginePtr chain_events_engine)
+      : executor_{std::move(executor)},
+        chain_events_engine_{std::move(chain_events_engine)} {
     BOOST_ASSERT(executor_);
-  }
-
-  outcome::result<DutyRoster> ParachainHostImpl::duty_roster(
-      const primitives::BlockHash &block) {
-    return executor_->callAt<DutyRoster>(block, "ParachainHost_duty_roster");
   }
 
   outcome::result<std::vector<ParachainId>>
   ParachainHostImpl::active_parachains(const primitives::BlockHash &block) {
-    OUTCOME_TRY(ref, active_parachains_.get_else(block, [&] {
-      return executor_->callAt<std::vector<ParachainId>>(
-          block, "ParachainHost_active_parachains");
-    }));
+    OUTCOME_TRY(ref,
+                active_parachains_.call(
+                    *executor_, block, "ParachainHost_active_parachains"));
     return *ref;
   }
 
   outcome::result<std::optional<common::Buffer>>
   ParachainHostImpl::parachain_head(const primitives::BlockHash &block,
                                     ParachainId id) {
-    OUTCOME_TRY(ref, parachain_head_.get_else(block, [&] {
-      return executor_->callAt<std::optional<Buffer>>(
-          block, "ParachainHost_parachain_head", id);
-    }));
+    OUTCOME_TRY(ref,
+                parachain_head_.call(
+                    *executor_, block, "ParachainHost_parachain_head", id));
     return *ref;
   }
 
   outcome::result<std::optional<common::Buffer>>
   ParachainHostImpl::parachain_code(const primitives::BlockHash &block,
                                     ParachainId id) {
-    OUTCOME_TRY(ref, parachain_code_.get_else(std::tie(block, id), [&] {
-      return executor_->callAt<std::optional<common::Buffer>>(
-          block, "ParachainHost_parachain_code", id);
-    }));
+    OUTCOME_TRY(ref,
+                parachain_code_.call(
+                    *executor_, block, "ParachainHost_parachain_code", id));
     return *ref;
   }
 
   outcome::result<std::vector<ValidatorId>> ParachainHostImpl::validators(
       const primitives::BlockHash &block) {
-    OUTCOME_TRY(ref, validators_.get_else(block, [&] {
-      return executor_->callAt<std::vector<ValidatorId>>(
-          block, "ParachainHost_validators");
-    }));
+    OUTCOME_TRY(
+        ref, validators_.call(*executor_, block, "ParachainHost_validators"));
     return *ref;
   }
 
   outcome::result<ValidatorGroupsAndDescriptor>
   ParachainHostImpl::validator_groups(const primitives::BlockHash &block) {
-    OUTCOME_TRY(ref, validator_groups_.get_else(block, [&] {
-      return executor_->callAt<ValidatorGroupsAndDescriptor>(
-          block, "ParachainHost_validator_groups");
-    }));
+    OUTCOME_TRY(ref,
+                validator_groups_.call(
+                    *executor_, block, "ParachainHost_validator_groups"));
     return *ref;
   }
 
   outcome::result<std::vector<CoreState>> ParachainHostImpl::availability_cores(
       const primitives::BlockHash &block) {
-    OUTCOME_TRY(ref, availability_cores_.get_else(block, [&] {
-      return executor_->callAt<std::vector<CoreState>>(
-          block, "ParachainHost_availability_cores");
-    }));
+    OUTCOME_TRY(ref,
+                availability_cores_.call(
+                    *executor_, block, "ParachainHost_availability_cores"));
     return *ref;
   }
 
@@ -96,10 +87,10 @@ namespace kagome::runtime {
 
   outcome::result<SessionIndex> ParachainHostImpl::session_index_for_child(
       const primitives::BlockHash &block) {
-    OUTCOME_TRY(ref, session_index_for_child_.get_else(block, [&] {
-      return executor_->callAt<SessionIndex>(
-          block, "ParachainHost_session_index_for_child");
-    }));
+    OUTCOME_TRY(
+        ref,
+        session_index_for_child_.call(
+            *executor_, block, "ParachainHost_session_index_for_child"));
     return *ref;
   }
 
@@ -114,68 +105,79 @@ namespace kagome::runtime {
   outcome::result<std::optional<ValidationCode>>
   ParachainHostImpl::validation_code_by_hash(const primitives::BlockHash &block,
                                              ValidationCodeHash hash) {
-    OUTCOME_TRY(ref,
-                validation_code_by_hash_.get_else(std::tie(block, hash), [&] {
-                  return executor_->callAt<std::optional<ValidationCode>>(
-                      block, "ParachainHost_validation_code_by_hash", hash);
-                }));
-    return *ref;
+    if (auto r = validation_code_by_hash_.exclusiveAccess(
+            [&](typename decltype(validation_code_by_hash_)::Type
+                    &validation_code_by_hash_) {
+              auto r = validation_code_by_hash_.get(hash);
+              return r ? std::make_optional(r->get()) : std::nullopt;
+            })) {
+      return *r;
+    }
+    OUTCOME_TRY(code,
+                executor_->callAt<std::optional<ValidationCode>>(
+                    block, "ParachainHost_validation_code_by_hash", hash));
+    if (code) {
+      return validation_code_by_hash_.exclusiveAccess(
+          [&](typename decltype(validation_code_by_hash_)::Type
+                  &validation_code_by_hash_) {
+            return validation_code_by_hash_.put(hash, std::move(*code));
+          });
+    }
+    return std::nullopt;
   }
 
   outcome::result<std::optional<CommittedCandidateReceipt>>
   ParachainHostImpl::candidate_pending_availability(
       const primitives::BlockHash &block, ParachainId id) {
-    OUTCOME_TRY(
-        ref, candidate_pending_availability_.get_else(std::tie(block, id), [&] {
-          return executor_->callAt<std::optional<CommittedCandidateReceipt>>(
-              block, "ParachainHost_candidate_pending_availability", id);
-        }));
+    OUTCOME_TRY(ref,
+                candidate_pending_availability_.call(
+                    *executor_,
+                    block,
+                    "ParachainHost_candidate_pending_availability",
+                    id));
     return *ref;
   }
 
   outcome::result<std::vector<CandidateEvent>>
   ParachainHostImpl::candidate_events(const primitives::BlockHash &block) {
-    OUTCOME_TRY(ref, candidate_events_.get_else(block, [&] {
-      return executor_->callAt<std::vector<CandidateEvent>>(
-          block, "ParachainHost_candidate_events");
-    }));
+    OUTCOME_TRY(ref,
+                candidate_events_.call(
+                    *executor_, block, "ParachainHost_candidate_events"));
     return *ref;
   }
 
   outcome::result<std::optional<SessionInfo>> ParachainHostImpl::session_info(
       const primitives::BlockHash &block, SessionIndex index) {
-    OUTCOME_TRY(ref, session_info_.get_else(std::tie(block, index), [&] {
-      return executor_->callAt<std::optional<SessionInfo>>(
-          block, "ParachainHost_session_info", index);
-    }));
+    OUTCOME_TRY(ref,
+                session_info_.call(
+                    *executor_, block, "ParachainHost_session_info", index));
     return *ref;
   }
 
   outcome::result<std::vector<InboundDownwardMessage>>
   ParachainHostImpl::dmq_contents(const primitives::BlockHash &block,
                                   ParachainId id) {
-    OUTCOME_TRY(ref, dmq_contents_.get_else(std::tie(block, id), [&] {
-      return executor_->callAt<std::vector<InboundDownwardMessage>>(
-          block, "ParachainHost_dmq_contents", id);
-    }));
+    OUTCOME_TRY(ref,
+                dmq_contents_.call(
+                    *executor_, block, "ParachainHost_dmq_contents", id));
     return *ref;
   }
 
   outcome::result<std::map<ParachainId, std::vector<InboundHrmpMessage>>>
   ParachainHostImpl::inbound_hrmp_channels_contents(
       const primitives::BlockHash &block, ParachainId id) {
-    OUTCOME_TRY(
-        ref, inbound_hrmp_channels_contents_.get_else(std::tie(block, id), [&] {
-          return executor_
-              ->callAt<std::map<ParachainId, std::vector<InboundHrmpMessage>>>(
-                  block, "ParachainHost_inbound_hrmp_channels_contents", id);
-        }));
+    OUTCOME_TRY(ref,
+                inbound_hrmp_channels_contents_.call(
+                    *executor_,
+                    block,
+                    "ParachainHost_inbound_hrmp_channels_contents",
+                    id));
     return *ref;
   }
 
   bool ParachainHostImpl::prepare() {
     chain_sub_ = std::make_shared<primitives::events::ChainEventSubscriber>(
-        peer_view_->intoChainEventsEngine());
+        chain_events_engine_);
     chain_sub_->subscribe(
         chain_sub_->generateSubscriptionSetId(),
         primitives::events::ChainEventType::kDeactivateAfterFinalization);
@@ -200,33 +202,25 @@ namespace kagome::runtime {
 
   void ParachainHostImpl::clearCaches(
       const std::vector<primitives::BlockHash> &blocks) {
-    for (auto &block : blocks) {
-      auto by_block = [&](auto &key, auto &) {
-        return std::get<0>(key) == block;
-      };
-
-      active_parachains_.erase(block);
-      parachain_head_.erase(block);
-      parachain_code_.erase_if(by_block);
-      validators_.erase(block);
-      validator_groups_.erase(block);
-      availability_cores_.erase(block);
-      session_index_for_child_.erase(block);
-      validation_code_by_hash_.erase_if(by_block);
-      candidate_pending_availability_.erase_if(by_block);
-      candidate_events_.erase(block);
-      session_info_.erase_if(by_block);
-      dmq_contents_.erase_if(by_block);
-      inbound_hrmp_channels_contents_.erase_if(by_block);
-    }
+    active_parachains_.erase(blocks);
+    parachain_head_.erase(blocks);
+    parachain_code_.erase(blocks);
+    validators_.erase(blocks);
+    validator_groups_.erase(blocks);
+    availability_cores_.erase(blocks);
+    session_index_for_child_.erase(blocks);
+    candidate_pending_availability_.erase(blocks);
+    candidate_events_.erase(blocks);
+    session_info_.erase(blocks);
+    dmq_contents_.erase(blocks);
+    inbound_hrmp_channels_contents_.erase(blocks);
   }
 
   outcome::result<std::optional<std::vector<ExecutorParam>>>
   ParachainHostImpl::session_executor_params(const primitives::BlockHash &block,
                                              SessionIndex idx) {
-    return executor_
-        ->callAt<std::optional<std::vector<ExecutorParam>>>(
-            block, "ParachainHost_session_executor_params", idx);
+    return executor_->callAt<std::optional<std::vector<ExecutorParam>>>(
+        block, "ParachainHost_session_executor_params", idx);
   }
 
   outcome::result<std::optional<dispute::ScrapedOnChainVotes>>

--- a/core/runtime/runtime_api/parachain_host.hpp
+++ b/core/runtime/runtime_api/parachain_host.hpp
@@ -23,13 +23,6 @@ namespace kagome::runtime {
     virtual ~ParachainHost() = default;
 
     /**
-     * @brief Calls the ParachainHost_duty_roster function from wasm code
-     * @return DutyRoster structure or error if fails
-     */
-    virtual outcome::result<DutyRoster> duty_roster(
-        const primitives::BlockHash &block) = 0;
-
-    /**
      * @brief Calls the ParachainHost_active_parachains function from wasm code
      * @return vector of ParachainId items or error if fails
      */

--- a/core/runtime/runtime_api/parachain_host_types.hpp
+++ b/core/runtime/runtime_api/parachain_host_types.hpp
@@ -285,6 +285,9 @@ namespace kagome::runtime {
          and no_show_slots == rhs.no_show_slots
          and needed_approvals == rhs.needed_approvals;
     }
+    bool operator!=(const SessionInfo &rhs) const {
+      return !operator==(rhs);
+    }
   };
 
   using InboundDownwardMessage = network::InboundDownwardMessage;

--- a/core/runtime/wavm/core_api_factory_impl.cpp
+++ b/core/runtime/wavm/core_api_factory_impl.cpp
@@ -6,9 +6,9 @@
 #include "runtime/wavm/core_api_factory_impl.hpp"
 
 #include "runtime/common/constant_code_provider.hpp"
-#include "runtime/executor.hpp"
 #include "runtime/common/runtime_properties_cache_impl.hpp"
 #include "runtime/common/trie_storage_provider_impl.hpp"
+#include "runtime/executor.hpp"
 #include "runtime/module_repository.hpp"
 #include "runtime/runtime_api/impl/core.hpp"
 #include "runtime/runtime_context.hpp"
@@ -120,7 +120,7 @@ namespace kagome::runtime::wavm {
         block_header_repo_);
     auto executor = std::make_unique<runtime::Executor>(ctx_factory, cache_);
     return std::make_unique<CoreImpl>(
-        std::move(executor), ctx_factory, block_header_repo_);
+        std::move(executor), ctx_factory, block_header_repo_, nullptr);
   }
 
 }  // namespace kagome::runtime::wavm

--- a/core/utils/lru.hpp
+++ b/core/utils/lru.hpp
@@ -55,6 +55,27 @@ namespace kagome {
       return put2(k, std::move(v)).first->second->v;
     }
 
+    void erase(const K &k) {
+      auto it = map_.find(k);
+      if (it == map_.end()) {
+        return;
+      }
+      lru_extract(*it->second);
+      map_.erase(it);
+    }
+
+    template <typename F>
+    void erase_if(const F &f) {
+      for (auto it = map_.begin(); it != map_.end();) {
+        if (f(it->first, it->second->v)) {
+          ++it;
+        } else {
+          lru_extract(*it->second);
+          it = map_.erase(it);
+        }
+      }
+    }
+
    private:
     static auto empty(const It &it) {
       return it == It{};

--- a/core/utils/lru_encoded.hpp
+++ b/core/utils/lru_encoded.hpp
@@ -1,0 +1,78 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <scale/scale.hpp>
+
+#include <boost/container_hash/hash.hpp>
+
+#include "common/buffer_view.hpp"
+#include "utils/lru.hpp"
+
+namespace kagome {
+  /**
+   * LRU with encoded value deduplication.
+   * Used to cache runtime call results.
+   */
+  template <typename K, typename V>
+  class LruEncoded {
+   public:
+    LruEncoded(size_t capacity) : values_{capacity}, hashes_{capacity} {}
+
+    std::optional<std::shared_ptr<V>> get(const K &k) {
+      return values_.get(k);
+    }
+
+    std::shared_ptr<V> put(const K &k, const V &v) {
+      return put(k, V{v});
+    }
+
+    std::shared_ptr<V> put(const K &k, V &&v) {
+      return put(k, std::move(v), scale::encode(v).value());
+    }
+
+    std::shared_ptr<V> put(const K &k, V &&v, common::BufferView encoded) {
+      auto h = hash(encoded);
+      auto weak = hashes_.get(h);
+      std::shared_ptr<V> shared;
+      if (weak) {
+        shared = weak->get().lock();
+        // check collisions (size_t is weak hash)
+        if (*shared != v) {
+          shared.reset();
+        }
+      }
+      if (not shared) {
+        shared = std::make_shared<V>(std::move(v));
+        if (weak) {
+          weak->get() = shared;
+        } else {
+          hashes_.put(h, shared);
+        }
+      }
+      values_.put(k, std::shared_ptr<V>{shared});
+      return shared;
+    }
+
+    void erase(const K &k) {
+      values_.erase(k);
+    }
+
+    template <typename F>
+    void erase_if(const F &f) {
+      values_.erase_if(f);
+    }
+
+   private:
+    using Hash = size_t;
+    Hash hash(common::BufferView v) {
+      return boost::hash_range(v.begin(), v.end());
+    }
+
+    Lru<K, std::shared_ptr<V>> values_;
+    Lru<Hash, std::weak_ptr<V>> hashes_;
+  };
+}  // namespace kagome

--- a/core/utils/safe_object.hpp
+++ b/core/utils/safe_object.hpp
@@ -38,6 +38,8 @@
 // clang-format on
 template <typename T, typename M = std::shared_mutex>
 struct SafeObject {
+  using Type = T;
+
   template <typename... Args>
   SafeObject(Args &&...args) : t_(std::forward<Args>(args)...) {}
 
@@ -67,7 +69,7 @@ struct SafeObject {
 };
 
 template <typename T, typename M = std::shared_mutex>
-SafeObject(T&&) -> SafeObject<T, M>;
+SafeObject(T &&) -> SafeObject<T, M>;
 
 class WaitForSingleObject final {
   std::condition_variable wait_cv_;

--- a/test/core/network/synchronizer_test.cpp
+++ b/test/core/network/synchronizer_test.cpp
@@ -19,8 +19,8 @@
 #include "mock/core/crypto/hasher_mock.hpp"
 #include "mock/core/network/protocols/sync_protocol_mock.hpp"
 #include "mock/core/network/router_mock.hpp"
-#include "mock/core/runtime/core_mock.hpp"
 #include "mock/core/runtime/module_factory_mock.hpp"
+#include "mock/core/runtime/runtime_properties_cache_mock.hpp"
 #include "mock/core/storage/persistent_map_mock.hpp"
 #include "mock/core/storage/spaced_storage_mock.hpp"
 #include "mock/core/storage/trie/serialization/trie_serializer_mock.hpp"
@@ -96,7 +96,7 @@ class SynchronizerTest
                                                     scheduler,
                                                     hasher,
                                                     module_factory,
-                                                    core_api,
+                                                    runtime_properties_cache,
                                                     chain_sub_engine,
                                                     grandpa_environment);
   }
@@ -126,8 +126,9 @@ class SynchronizerTest
       std::make_shared<crypto::HasherMock>();
   std::shared_ptr<runtime::ModuleFactoryMock> module_factory =
       std::make_shared<runtime::ModuleFactoryMock>();
-  std::shared_ptr<runtime::CoreMock> core_api =
-      std::make_shared<runtime::CoreMock>();
+  std::shared_ptr<runtime::RuntimePropertiesCacheMock>
+      runtime_properties_cache =
+          std::make_shared<runtime::RuntimePropertiesCacheMock>();
   primitives::events::ChainSubscriptionEnginePtr chain_sub_engine =
       std::make_shared<primitives::events::ChainSubscriptionEngine>();
   std::shared_ptr<BufferStorageMock> buffer_storage =

--- a/test/core/runtime/binaryen/metadata_test.cpp
+++ b/test/core/runtime/binaryen/metadata_test.cpp
@@ -9,7 +9,7 @@
 
 #include "core/runtime/binaryen/binaryen_runtime_test.hpp"
 #include "host_api/impl/host_api_impl.hpp"
-#include "mock/core/blockchain/block_header_repository_mock.hpp"
+#include "mock/core/runtime/runtime_upgrade_tracker_mock.hpp"
 #include "runtime/binaryen/memory_impl.hpp"
 #include "runtime/runtime_api/impl/metadata.hpp"
 #include "testutil/outcome.hpp"
@@ -18,12 +18,12 @@
 using ::testing::_;
 using ::testing::Return;
 
-using kagome::blockchain::BlockHeaderRepositoryMock;
 using kagome::primitives::BlockHeader;
 using kagome::primitives::BlockId;
 using kagome::primitives::BlockInfo;
 using kagome::runtime::Metadata;
 using kagome::runtime::MetadataImpl;
+using kagome::runtime::RuntimeUpgradeTrackerMock;
 
 namespace fs = kagome::filesystem;
 
@@ -37,11 +37,14 @@ class MetadataTest : public BinaryenRuntimeTest {
     BinaryenRuntimeTest::SetUp();
     prepareEphemeralStorageExpects();
 
-    api_ = std::make_shared<MetadataImpl>(executor_);
+    api_ = std::make_shared<MetadataImpl>(
+        executor_, header_repo_, runtime_upgrade_tracker_);
   }
 
  protected:
   std::shared_ptr<Metadata> api_;
+  std::shared_ptr<RuntimeUpgradeTrackerMock> runtime_upgrade_tracker_ =
+      std::make_shared<RuntimeUpgradeTrackerMock>();
 };
 
 /**
@@ -50,7 +53,12 @@ class MetadataTest : public BinaryenRuntimeTest {
  * @then successful result is returned
  */
 TEST_F(MetadataTest, metadata) {
-  EXPECT_CALL(*header_repo_, getBlockHeader("block_hash"_hash256))
-      .WillRepeatedly(Return(BlockHeader{.number = 42}));
-  ASSERT_TRUE(api_->metadata("block_hash"_hash256));
+  BlockInfo info{42, "block_hash"_hash256};
+  EXPECT_CALL(*header_repo_, getBlockHeader(info.hash))
+      .WillRepeatedly(Return(BlockHeader{.number = info.number}));
+  EXPECT_CALL(*header_repo_, getNumberByHash(info.hash))
+      .WillOnce(Return(info.number));
+  EXPECT_CALL(*runtime_upgrade_tracker_, getLastCodeUpdateState(info))
+      .WillOnce(Return(info.hash));
+  ASSERT_TRUE(api_->metadata(info.hash));
 }

--- a/test/core/runtime/binaryen/parachain_test.cpp
+++ b/test/core/runtime/binaryen/parachain_test.cpp
@@ -14,6 +14,7 @@
 
 using kagome::common::Buffer;
 using kagome::host_api::HostApiImpl;
+using kagome::primitives::events::ChainSubscriptionEngine;
 using kagome::primitives::parachain::Chain;
 using kagome::primitives::parachain::DutyRoster;
 using kagome::primitives::parachain::Parachain;
@@ -33,7 +34,8 @@ class ParachainHostTest : public BinaryenRuntimeTest {
   void SetUp() override {
     BinaryenRuntimeTest::SetUp();
 
-    api_ = std::make_shared<ParachainHostImpl>(executor_);
+    api_ = std::make_shared<ParachainHostImpl>(
+        executor_, std::make_shared<ChainSubscriptionEngine>());
   }
 
   ParaId createParachainId() const {
@@ -43,16 +45,6 @@ class ParachainHostTest : public BinaryenRuntimeTest {
  protected:
   std::shared_ptr<ParachainHost> api_;
 };
-
-// TODO(yuraz): PRE-157 find out do we need to give block_id to api functions
-/**
- * @given initialized parachain host api
- * @when dutyRoster() is invoked
- * @then successful result is returned
- */
-TEST_F(ParachainHostTest, DISABLED_DutyRosterTest) {
-  ASSERT_TRUE(api_->duty_roster("block_hash"_hash256));
-}
 
 /**
  * @given initialized parachain host api

--- a/test/core/runtime/runtime_test_base.hpp
+++ b/test/core/runtime/runtime_test_base.hpp
@@ -38,12 +38,12 @@
 #include "primitives/block.hpp"
 #include "primitives/block_header.hpp"
 #include "primitives/block_id.hpp"
-#include "runtime/executor.hpp"
 #include "runtime/common/module_repository_impl.hpp"
 #include "runtime/common/runtime_instances_pool.hpp"
 #include "runtime/common/runtime_transaction_error.hpp"
 #include "runtime/common/runtime_upgrade_tracker_impl.hpp"
 #include "runtime/core_api_factory.hpp"
+#include "runtime/executor.hpp"
 #include "runtime/module.hpp"
 #include "runtime/runtime_context.hpp"
 #include "storage/in_memory/in_memory_storage.hpp"
@@ -177,8 +177,8 @@ class RuntimeTestBase : public ::testing::Test {
   }
 
   void prepareEphemeralStorageExpects() {
-    EXPECT_CALL(*trie_storage_, getEphemeralBatchAt(_))
-        .WillOnce(testing::Invoke([this](auto &root) {
+    ON_CALL(*trie_storage_, getEphemeralBatchAt(_))
+        .WillByDefault(testing::Invoke([this](auto &root) {
           auto batch = std::make_unique<TrieBatchMock>();
           prepareStorageBatchExpectations(*batch);
           return batch;

--- a/test/core/runtime/wavm/core_integration_test.cpp
+++ b/test/core/runtime/wavm/core_integration_test.cpp
@@ -42,7 +42,8 @@ class CoreTest : public WavmRuntimeTest {
   void SetUp() override {
     WavmRuntimeTest::SetUp();
 
-    core_ = std::make_shared<CoreImpl>(executor_, ctx_factory_, header_repo_);
+    core_ = std::make_shared<CoreImpl>(
+        executor_, ctx_factory_, header_repo_, nullptr);
   }
 
  protected:

--- a/test/mock/core/runtime/core_mock.hpp
+++ b/test/mock/core/runtime/core_mock.hpp
@@ -18,11 +18,6 @@ namespace kagome::runtime {
 
     MOCK_METHOD(outcome::result<primitives::Version>,
                 version,
-                (std::shared_ptr<ModuleInstance>),
-                (override));
-
-    MOCK_METHOD(outcome::result<primitives::Version>,
-                version,
                 (const primitives::BlockHash &block),
                 (override));
 

--- a/test/mock/core/runtime/parachain_host_mock.hpp
+++ b/test/mock/core/runtime/parachain_host_mock.hpp
@@ -13,11 +13,6 @@ namespace kagome::runtime {
 
   class ParachainHostMock : public ParachainHost {
    public:
-    MOCK_METHOD(outcome::result<DutyRoster>,
-                duty_roster,
-                (const primitives::BlockHash &),
-                (override));
-
     MOCK_METHOD(outcome::result<std::vector<ParachainId>>,
                 active_parachains,
                 (const primitives::BlockHash &),


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- deduplicate `callCoreVersion` (genesis and old state sync)
- update runtime caches to `Lru`

### Benefits

### Possible Drawbacks