### PR TITLE
[feat] add TTL for grandpa historical votes and update storage spaces

### DIFF
--- a/core/consensus/grandpa/impl/grandpa_impl.cpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.cpp
@@ -68,7 +68,7 @@ namespace kagome::consensus::grandpa {
   constexpr std::chrono::milliseconds kGossipDuration{1000};
 
   inline auto historicalVotesKey(AuthoritySetId set, RoundNumber round) {
-    auto key = storage::kGrandpaHistoricalVotesPrefix;
+    common::Buffer key;
     key.putUint64(set);
     key.putUint64(round);
     return key;
@@ -102,7 +102,7 @@ namespace kagome::consensus::grandpa {
         reputation_repository_(std::move(reputation_repository)),
         timeline_{timeline},
         chain_sub_{std::move(chain_sub_engine)},
-        db_{db.getSpace(storage::Space::kDefault)},
+        db_{db.getSpace(storage::Space::kGrandpaHistoricalVotes)},
         main_pool_handler_{main_thread_pool.handler(*app_state_manager)},
         grandpa_pool_handler_{poolHandlerReadyMake(
             this, app_state_manager, grandpa_thread_pool, logger_)},

--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -282,7 +282,8 @@ namespace {
     options.max_open_files = soft_limit.value() / 2;
 
     const std::unordered_map<std::string, int32_t> column_ttl = {
-        {"avaliability_storage", 25 * 60 * 60}};  // 25 hours
+        {"avaliability_storage", 25 * 60 * 60},  // 25 hours
+        {"grandpa_historical_votes", 2 * 60}};   // 2 minutes
     auto db_res =
         storage::RocksDb::create(app_config.databasePath(chain_spec->id()),
                                  options,

--- a/core/storage/rocksdb/rocksdb_spaces.cpp
+++ b/core/storage/rocksdb/rocksdb_spaces.cpp
@@ -22,7 +22,8 @@ namespace kagome::storage {
                                      "dispute_data",
                                      "beefy_justification",
                                      "avaliability_storage",
-                                     "audi_peers"};
+                                     "audi_peers",
+                                     "grandpa_historical_votes"};
   static_assert(kNames.size() == Space::kTotal - 1);
 
   std::string spaceName(Space space) {

--- a/core/storage/spaces.hpp
+++ b/core/storage/spaces.hpp
@@ -24,6 +24,7 @@ namespace kagome::storage {
     kBeefyJustification,
     kAvaliabilityStorage,
     kAudiPeers,
+    kGrandpaHistoricalVotes,
 
     kTotal
   };


### PR DESCRIPTION
[//]: # (
Copyright Quadrivium LLC
All Rights Reserved
SPDX-License-Identifier: Apache-2.0
)

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch. -->

### Referenced issues

Closes #2468 

### Description of the Change

We have noticed that historical votes contribute the most to the grow of the database.
The problem was that KAGOME didn't have pruning mechanism for historical votes.
To solve that problem this PR:
1. Creates a new RocksDB column for historical votes, instead of using default column
2. New column will have a TTL of 2 minutes, meaning all historical votes will be expired after two minutes.

Note, that in reality historical votes won't be cleared every two minutes, but rather their database entries will be marked as expired. The real removal of expired historical votes database entries will happen during database compaction, which happens automatically once in a while

### Possible Drawbacks

None

## Checklist Before Opening a PR

Before you open a Pull Request (PR), please make sure you've completed the following steps and confirm by answering 'Yes' to each item:

1. **Code is formatted**: Have you run your code through clang-format to ensure it adheres to the project's coding standards? **Yes**
2. **Code is documented**: Have you added comments and documentation to your code according to the guidelines in the project's [contributing guidelines](https://github.com/qdrvm/kagome/CONTRIBUTING.md)? **Yes**
3. **Self-review**: Have you reviewed your own code to ensure it is free of typos, syntax errors, logical errors, and unresolved TODOs or FIXME without linking to an issue? **Yes**
4. **Zombienet Tests**: Have you ensured that the zombienet tests are passing? Zombienet is a network simulation and testing tool used in this project. It's important to ensure that these tests pass to maintain the stability and reliability of the project. **Yes**

<!-- Please answer 'Yes' to each of these items in your PR description to confirm that you've completed them. This will help maintain the quality of the project and facilitate efficient collaboration. -->

