### PR TITLE
[fix] update max interval and enable audi timestamp

### DIFF
--- a/core/authority_discovery/publisher/address_publisher.cpp
+++ b/core/authority_discovery/publisher/address_publisher.cpp
@@ -27,10 +27,10 @@ std::vector<uint8_t> pbEncodeVec(const T &v) {
 
 namespace kagome::authority_discovery {
   constexpr std::chrono::seconds kIntervalInitial{2};
-  constexpr std::chrono::hours kIntervalMax{1};
+  constexpr std::chrono::minutes kIntervalMax{5};
 
   // TODO(kamilsa): #2351, remove this variable when resolved
-  constexpr bool kAudiDisableTimestamp = true;
+  constexpr bool kAudiDisableTimestamp = false;
 
   static const metrics::GaugeHelper metric_amount_addresses_last_published{
       "kagome_authority_discovery_amount_external_addresses_last_published",

--- a/core/authority_discovery/publisher/address_publisher.cpp
+++ b/core/authority_discovery/publisher/address_publisher.cpp
@@ -122,7 +122,7 @@ namespace kagome::authority_discovery {
         authorities,
         authority_discovery_api_->authorities(block_tree_->bestBlock().hash));
 
-    auto audi_key = keys_->getAudiKeyPair(authorities);
+    auto audi_key = keys_->getAudiKeyPair();
     if (not audi_key) {
       SL_WARN(log_, "No authority discovery key");
       return outcome::success();

--- a/core/authority_discovery/publisher/address_publisher.cpp
+++ b/core/authority_discovery/publisher/address_publisher.cpp
@@ -179,9 +179,19 @@ namespace kagome::authority_discovery {
     }
     metric_amount_addresses_last_published->set(addresses.size());
     ::authority_discovery_v3::AuthorityRecord record;
+    std::string peer_addresses;
     for (const auto &address : addresses) {
       PB_SPAN_ADD(record, addresses, address.getBytesAddress());
+      if (not peer_addresses.empty()) {
+        peer_addresses.append(", ");
+      }
+      peer_addresses.append(address.getStringAddress());
     }
+    auto log = log::createLogger("AddressPublisher", "authority_discovery");
+    SL_DEBUG(log,
+             "Publishing authority discovery record for {} with addresses: {}",
+             audi_key.public_key.toHex(),
+             peer_addresses);
     if (now) {
       Timestamp time{now->count()};
       OUTCOME_TRY(encoded_time, scale::encode(time));

--- a/core/crypto/key_store/session_keys.cpp
+++ b/core/crypto/key_store/session_keys.cpp
@@ -131,26 +131,36 @@ namespace kagome::crypto {
                                  std::equal_to{});
   }
 
-  std::shared_ptr<Sr25519Keypair> SessionKeysImpl::getAudiKeyPair(
+  std::vector<Sr25519Keypair> SessionKeysImpl::getAudiKeyPairs(
       const std::vector<primitives::AuthorityDiscoveryId> &authorities) {
-    if (auto res = find<Sr25519Provider>(audi_key_pair_,
-                                         KeyTypes::AUTHORITY_DISCOVERY,
-                                         store_->sr25519(),
-                                         authorities,
-                                         std::equal_to{})) {
-      return std::move(res->first);
+    if (not roles_.isAuthority()) {
+      return {};
     }
-    return nullptr;
-  }
 
-  SessionKeys::KeypairWithIndexOpt<EcdsaKeypair>
-  SessionKeysImpl::getBeefKeyPair(
-      const std::vector<EcdsaPublicKey> &authorities) {
-    return find<EcdsaProvider>(beef_key_pair_,
-                               KeyTypes::BEEFY,
-                               store_->ecdsa(),
-                               authorities,
-                               std::equal_to{});
+    std::vector<Sr25519Keypair> result;
+    auto keys_res =
+        store_->sr25519().getPublicKeys(KeyTypes::AUTHORITY_DISCOVERY);
+    if (not keys_res) {
+      return result;
+    }
+
+    auto &keys = keys_res.value();
+    for (auto &pubkey : keys) {
+      auto it = std::ranges::find_if(
+          authorities.begin(), authorities.end(), [&](const auto &authority) {
+            return pubkey == authority;
+          });
+
+      if (it != authorities.end()) {
+        auto keypair_opt = store_->sr25519().findKeypair(
+            KeyTypes::AUTHORITY_DISCOVERY, pubkey);
+        if (keypair_opt) {
+          result.push_back(std::move(keypair_opt.value()));
+        }
+      }
+    }
+
+    return result;
   }
 
   std::vector<Sr25519Keypair> SessionKeysImpl::getAudiKeyPairs() {
@@ -170,6 +180,16 @@ namespace kagome::crypto {
     }
 
     return keypairs;
+  }
+
+  SessionKeys::KeypairWithIndexOpt<EcdsaKeypair>
+  SessionKeysImpl::getBeefKeyPair(
+      const std::vector<EcdsaPublicKey> &authorities) {
+    return find<EcdsaProvider>(beef_key_pair_,
+                               KeyTypes::BEEFY,
+                               store_->ecdsa(),
+                               authorities,
+                               std::equal_to{});
   }
 
 }  // namespace kagome::crypto

--- a/core/crypto/key_store/session_keys.cpp
+++ b/core/crypto/key_store/session_keys.cpp
@@ -152,4 +152,21 @@ namespace kagome::crypto {
                                authorities,
                                std::equal_to{});
   }
+
+  std::optional<Sr25519Keypair> SessionKeysImpl::getAudiKeyPair() {
+    auto keys_res = store_->sr25519().getPublicKeys(KeyTypes::AUTHORITY_DISCOVERY);
+    if (not keys_res || keys_res.value().empty()) {
+      return std::nullopt;
+    }
+
+    // Get the first available AUTHORITY_DISCOVERY key
+    auto &pubkey = keys_res.value().front();
+    auto keypair_opt = store_->sr25519().findKeypair(KeyTypes::AUTHORITY_DISCOVERY, pubkey);
+
+    // Return the keypair if found, otherwise nullopt
+    if (keypair_opt) {
+      return keypair_opt.value();
+    }
+    return std::nullopt;
+  }
 }  // namespace kagome::crypto

--- a/core/crypto/key_store/session_keys.cpp
+++ b/core/crypto/key_store/session_keys.cpp
@@ -153,20 +153,23 @@ namespace kagome::crypto {
                                std::equal_to{});
   }
 
-  std::optional<Sr25519Keypair> SessionKeysImpl::getAudiKeyPair() {
-    auto keys_res = store_->sr25519().getPublicKeys(KeyTypes::AUTHORITY_DISCOVERY);
+  std::vector<Sr25519Keypair> SessionKeysImpl::getAudiKeyPairs() {
+    std::vector<Sr25519Keypair> keypairs;
+    auto keys_res =
+        store_->sr25519().getPublicKeys(KeyTypes::AUTHORITY_DISCOVERY);
     if (not keys_res || keys_res.value().empty()) {
-      return std::nullopt;
+      return keypairs;
     }
 
-    // Get the first available AUTHORITY_DISCOVERY key
-    auto &pubkey = keys_res.value().front();
-    auto keypair_opt = store_->sr25519().findKeypair(KeyTypes::AUTHORITY_DISCOVERY, pubkey);
-
-    // Return the keypair if found, otherwise nullopt
-    if (keypair_opt) {
-      return keypair_opt.value();
+    for (const auto &pubkey : keys_res.value()) {
+      auto keypair_opt =
+          store_->sr25519().findKeypair(KeyTypes::AUTHORITY_DISCOVERY, pubkey);
+      if (keypair_opt) {
+        keypairs.push_back(keypair_opt.value());
+      }
     }
-    return std::nullopt;
+
+    return keypairs;
   }
+
 }  // namespace kagome::crypto

--- a/core/crypto/key_store/session_keys.cpp
+++ b/core/crypto/key_store/session_keys.cpp
@@ -155,7 +155,7 @@ namespace kagome::crypto {
         auto keypair_opt = store_->sr25519().findKeypair(
             KeyTypes::AUTHORITY_DISCOVERY, pubkey);
         if (keypair_opt) {
-          result.push_back(std::move(keypair_opt.value()));
+          result.push_back(keypair_opt.value());
         }
       }
     }

--- a/core/crypto/key_store/session_keys.hpp
+++ b/core/crypto/key_store/session_keys.hpp
@@ -79,11 +79,9 @@ namespace kagome::crypto {
         const std::vector<primitives::AuthorityDiscoveryId> &authorities) = 0;
 
     /**
-     * @return current AUDI session key pair from storage without checking
-     * authority list
-     * @note if there are multiple keys in storage, it returns the first one
+     * @return all AUDI session key pairs from storage without checking
      */
-    virtual std::optional<Sr25519Keypair> getAudiKeyPair() = 0;
+    virtual std::vector<Sr25519Keypair> getAudiKeyPairs() = 0;
 
     /**
      * @return current BEEF session key pair
@@ -137,7 +135,7 @@ namespace kagome::crypto {
         const std::vector<primitives::AuthorityDiscoveryId> &authorities)
         override;
 
-    std::optional<Sr25519Keypair> getAudiKeyPair() override;
+    std::vector<Sr25519Keypair> getAudiKeyPairs() override;
 
     KeypairWithIndexOpt<EcdsaKeypair> getBeefKeyPair(
         const std::vector<EcdsaPublicKey> &authorities) override;

--- a/core/crypto/key_store/session_keys.hpp
+++ b/core/crypto/key_store/session_keys.hpp
@@ -79,6 +79,13 @@ namespace kagome::crypto {
         const std::vector<primitives::AuthorityDiscoveryId> &authorities) = 0;
 
     /**
+     * @return current AUDI session key pair from storage without checking
+     * authority list
+     * @note if there are multiple keys in storage, it returns the first one
+     */
+    virtual std::optional<Sr25519Keypair> getAudiKeyPair() = 0;
+
+    /**
      * @return current BEEF session key pair
      */
     virtual KeypairWithIndexOpt<EcdsaKeypair> getBeefKeyPair(
@@ -129,6 +136,8 @@ namespace kagome::crypto {
     std::shared_ptr<Sr25519Keypair> getAudiKeyPair(
         const std::vector<primitives::AuthorityDiscoveryId> &authorities)
         override;
+
+    std::optional<Sr25519Keypair> getAudiKeyPair() override;
 
     KeypairWithIndexOpt<EcdsaKeypair> getBeefKeyPair(
         const std::vector<EcdsaPublicKey> &authorities) override;

--- a/core/crypto/key_store/session_keys.hpp
+++ b/core/crypto/key_store/session_keys.hpp
@@ -73,9 +73,10 @@ namespace kagome::crypto {
         const std::vector<Sr25519PublicKey> &authorities) = 0;
 
     /**
-     * @return current AUDI session key pair
+     * @return all AUDI session key pairs from storage that exist in authorities
+     * list
      */
-    virtual std::shared_ptr<Sr25519Keypair> getAudiKeyPair(
+    virtual std::vector<Sr25519Keypair> getAudiKeyPairs(
         const std::vector<primitives::AuthorityDiscoveryId> &authorities) = 0;
 
     /**
@@ -131,7 +132,7 @@ namespace kagome::crypto {
     KeypairWithIndexOpt<Sr25519Keypair> getParaKeyPair(
         const std::vector<Sr25519PublicKey> &authorities) override;
 
-    std::shared_ptr<Sr25519Keypair> getAudiKeyPair(
+    std::vector<Sr25519Keypair> getAudiKeyPairs(
         const std::vector<primitives::AuthorityDiscoveryId> &authorities)
         override;
 

--- a/core/parachain/validator/signer.cpp
+++ b/core/parachain/validator/signer.cpp
@@ -77,11 +77,16 @@ namespace kagome::parachain {
       return std::nullopt;
     }
 
-    auto keys = session_keys_->getAudiKeyPair(session_info->discovery_keys);
-    if (keys != nullptr) {
+    auto keypairs =
+        session_keys_->getAudiKeyPairs(session_info->discovery_keys);
+    if (not keypairs.empty()) {
+      // Find the index of the first keypair that matches any discovery key.
+
       for (ValidatorIndex i = 0; i < session_info->discovery_keys.size(); ++i) {
-        if (keys->public_key == session_info->discovery_keys[i]) {
-          return i;
+        for (const auto &keypair : keypairs) {
+          if (keypair.public_key == session_info->discovery_keys[i]) {
+            return i;
+          }
         }
       }
     }

--- a/test/mock/core/crypto/session_keys_mock.hpp
+++ b/test/mock/core/crypto/session_keys_mock.hpp
@@ -43,10 +43,7 @@ namespace kagome::crypto {
                 (const std::vector<primitives::AuthorityDiscoveryId> &),
                 (override));
 
-    MOCK_METHOD(std::optional<Sr25519Keypair>,
-                getAudiKeyPair,
-                (),
-                (override));
+    MOCK_METHOD(std::vector<Sr25519Keypair>, getAudiKeyPairs, (), (override));
 
     MOCK_METHOD(KeypairWithIndexOpt<EcdsaKeypair>,
                 getBeefKeyPair,

--- a/test/mock/core/crypto/session_keys_mock.hpp
+++ b/test/mock/core/crypto/session_keys_mock.hpp
@@ -43,6 +43,11 @@ namespace kagome::crypto {
                 (const std::vector<primitives::AuthorityDiscoveryId> &),
                 (override));
 
+    MOCK_METHOD(std::optional<Sr25519Keypair>,
+                getAudiKeyPair,
+                (),
+                (override));
+
     MOCK_METHOD(KeypairWithIndexOpt<EcdsaKeypair>,
                 getBeefKeyPair,
                 (const std::vector<EcdsaPublicKey> &),

--- a/test/mock/core/crypto/session_keys_mock.hpp
+++ b/test/mock/core/crypto/session_keys_mock.hpp
@@ -38,8 +38,8 @@ namespace kagome::crypto {
                 (const std::vector<Sr25519PublicKey> &),
                 (override));
 
-    MOCK_METHOD(std::shared_ptr<Sr25519Keypair>,
-                getAudiKeyPair,
+    MOCK_METHOD(std::vector<Sr25519Keypair>,
+                getAudiKeyPairs,
                 (const std::vector<primitives::AuthorityDiscoveryId> &),
                 (override));
 


### PR DESCRIPTION
[//]: # (
Copyright Quadrivium LLC
All Rights Reserved
SPDX-License-Identifier: Apache-2.0
)

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch. -->

### Referenced issues

#2351

### Description of the Change

* Returns audi timestamp
* Decreases address publishing interval to 5 minutes
* Starts publishing addresses before we became an authority (same behaviour as in polkadot-sdk)

### Possible Drawbacks

Too frequent publishing interval comparing to polkadot sdk

## Checklist Before Opening a PR

Before you open a Pull Request (PR), please make sure you've completed the following steps and confirm by answering 'Yes' to each item:

1. **Code is formatted**: Have you run your code through clang-format to ensure it adheres to the project's coding standards? **Yes**
2. **Code is documented**: Have you added comments and documentation to your code according to the guidelines in the project's [contributing guidelines](https://github.com/qdrvm/kagome/CONTRIBUTING.md)? **Yes**
3. **Self-review**: Have you reviewed your own code to ensure it is free of typos, syntax errors, logical errors, and unresolved TODOs or FIXME without linking to an issue? **Yes**
4. **Zombienet Tests**: Have you ensured that the zombienet tests are passing? Zombienet is a network simulation and testing tool used in this project. It's important to ensure that these tests pass to maintain the stability and reliability of the project. **Yes**

<!-- Please answer 'Yes' to each of these items in your PR description to confirm that you've completed them. This will help maintain the quality of the project and facilitate efficient collaboration. -->

